### PR TITLE
Implement targeted individual vehicle command flow

### DIFF
--- a/software/edge/src/aeris_msgs/CMakeLists.txt
+++ b/software/edge/src/aeris_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ set(interface_files
   "srv/GasIsopleth.srv"
   "srv/SetCameraView.srv"
   "srv/MissionCommand.srv"
+  "srv/VehicleCommand.srv"
   "action/MapTile.action"
   "action/ThermalHotspot.action"
   "action/AcousticBearing.action"

--- a/software/edge/src/aeris_msgs/srv/VehicleCommand.srv
+++ b/software/edge/src/aeris_msgs/srv/VehicleCommand.srv
@@ -1,0 +1,6 @@
+string vehicle_id
+string command
+string mission_id
+---
+bool success
+string message

--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -3,11 +3,11 @@ import math
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Final
+from typing import Callable, Final
 
 import rclpy
 from aeris_msgs.msg import MissionProgress, MissionState, Telemetry
-from aeris_msgs.srv import MissionCommand
+from aeris_msgs.srv import MissionCommand, VehicleCommand
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 from std_msgs.msg import String
@@ -41,6 +41,7 @@ class MissionNode(Node):
     _AUTONOMOUS_STATES: Final[set[str]] = {"SEARCHING", "TRACKING"}
     _ABORTABLE_STATES: Final[set[str]] = {"SEARCHING", "TRACKING"}
     _SUPPORTED_PATTERNS: Final[set[str]] = {"lawnmower", "spiral"}
+    _SUPPORTED_VEHICLE_COMMANDS: Final[set[str]] = {"HOLD", "RESUME", "RECALL"}
 
     def __init__(self) -> None:
         super().__init__("aeris_mission_orchestrator")
@@ -164,6 +165,12 @@ class MissionNode(Node):
             MissionCommand,
             "abort_mission",
             self._handle_abort_mission,
+            callback_group=self._serialized_callback_group,
+        )
+        self._vehicle_command_service = self.create_service(
+            VehicleCommand,
+            "vehicle_command",
+            self._handle_vehicle_command,
             callback_group=self._serialized_callback_group,
         )
 
@@ -362,6 +369,49 @@ class MissionNode(Node):
                 )
 
         return success_count, total_count
+
+    def _resolve_scout_endpoint(self, vehicle_id: str) -> ScoutEndpoint | None:
+        normalized_vehicle_id = self._normalize_vehicle_id(vehicle_id)
+        for endpoint in self._scout_endpoints:
+            if endpoint.vehicle_id == normalized_vehicle_id:
+                return endpoint
+        return None
+
+    def _is_endpoint_online(self, endpoint: ScoutEndpoint) -> bool:
+        if self._scout_online_window_sec < 0:
+            return False
+        last_seen = self._scout_last_seen_monotonic.get(endpoint.vehicle_id)
+        if last_seen is None:
+            return False
+        return (time.monotonic() - last_seen) <= self._scout_online_window_sec
+
+    def _dispatch_vehicle_command(
+        self, endpoint: ScoutEndpoint, command: str
+    ) -> tuple[bool, str]:
+        dispatchers: dict[str, Callable[[], bool]] = {
+            "HOLD": self._mavlink_adapter.send_hold_position,
+            "RESUME": self._mavlink_adapter.send_resume_mission,
+            "RECALL": self._mavlink_adapter.send_return_to_launch,
+        }
+        dispatch = dispatchers.get(command)
+        if dispatch is None:
+            return False, f"unsupported command '{command}'"
+
+        try:
+            self._mavlink_adapter.set_endpoint(endpoint.host, endpoint.port)
+        except OSError as error:
+            return (
+                False,
+                f"vehicle_command dispatch failed for '{endpoint.vehicle_id}': {error}",
+            )
+
+        sent = dispatch()
+        if not sent:
+            return (
+                False,
+                f"vehicle_command '{command}' was not acknowledged by '{endpoint.vehicle_id}'",
+            )
+        return True, ""
 
     def _parse_mission_plan(
         self, zone_geometry: str
@@ -572,6 +622,60 @@ class MissionNode(Node):
         response.message = (
             f"Mission {self._mission_id} aborted; RTL dispatches "
             f"{successful_dispatches}/{total_dispatches}"
+        )
+        return response
+
+    def _handle_vehicle_command(
+        self, request: VehicleCommand.Request, response: VehicleCommand.Response
+    ) -> VehicleCommand.Response:
+        command = self._normalized_command(request.command)
+        if command not in self._SUPPORTED_VEHICLE_COMMANDS:
+            response.success = False
+            response.message = (
+                f"vehicle_command rejected due to unsupported command '{request.command}'"
+            )
+            return response
+
+        if self._state not in self._AUTONOMOUS_STATES:
+            response.success = False
+            response.message = f"vehicle_command '{command}' rejected while in {self._state}"
+            return response
+
+        if request.mission_id.strip() and request.mission_id.strip() != self._mission_id:
+            response.success = False
+            response.message = "vehicle_command rejected due to mission_id mismatch"
+            return response
+
+        normalized_vehicle_id = self._normalize_vehicle_id(request.vehicle_id)
+        if not normalized_vehicle_id:
+            response.success = False
+            response.message = "vehicle_command rejected due to missing vehicle_id"
+            return response
+
+        endpoint = self._resolve_scout_endpoint(normalized_vehicle_id)
+        if endpoint is None:
+            response.success = False
+            response.message = (
+                f"vehicle_command rejected due to unknown vehicle_id '{request.vehicle_id}'"
+            )
+            return response
+
+        if not self._is_endpoint_online(endpoint):
+            response.success = False
+            response.message = (
+                f"vehicle_command rejected due to offline vehicle_id '{request.vehicle_id}'"
+            )
+            return response
+
+        command_sent, command_error = self._dispatch_vehicle_command(endpoint, command)
+        if not command_sent:
+            response.success = False
+            response.message = command_error
+            return response
+
+        response.success = True
+        response.message = (
+            f"vehicle_command '{command}' accepted for target '{endpoint.vehicle_id}'"
         )
         return response
 

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -1,11 +1,12 @@
 import json
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 import rclpy
 from aeris_msgs.msg import MissionProgress, MissionState, Telemetry
-from aeris_msgs.srv import MissionCommand
+from aeris_msgs.srv import MissionCommand, VehicleCommand
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -56,6 +57,9 @@ class MissionObserver(Node):
         )
         self.start_client = self.create_client(MissionCommand, "start_mission")
         self.abort_client = self.create_client(MissionCommand, "abort_mission")
+        self.vehicle_command_client = self.create_client(
+            VehicleCommand, "vehicle_command"
+        )
 
     def _on_state(self, message: MissionState) -> None:
         with self._state_lock:
@@ -102,6 +106,7 @@ def mission_harness(ros_runtime: MultiThreadedExecutor):
 
     assert observer.start_client.wait_for_service(timeout_sec=2.0)
     assert observer.abort_client.wait_for_service(timeout_sec=2.0)
+    assert observer.vehicle_command_client.wait_for_service(timeout_sec=2.0)
 
     try:
         yield mission_node, observer
@@ -396,3 +401,199 @@ def test_start_mission_rejects_when_no_scout_is_online(mission_harness) -> None:
     assert response is not None
     assert not response.success
     assert "no scout endpoint reported telemetry recently" in response.message
+
+
+def test_vehicle_command_targets_only_requested_endpoint(
+    mission_harness, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    now = time.monotonic()
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "vehicle-command-mission"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {  # noqa: SLF001
+        "scout_1": now,
+        "scout_2": now,
+    }
+
+    endpoint_calls: list[tuple[str, int]] = []
+    hold_calls: list[int] = []
+
+    def _record_endpoint(host: str, port: int) -> None:
+        endpoint_calls.append((host, int(port)))
+
+    def _record_hold() -> bool:
+        hold_calls.append(1)
+        return True
+
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", _record_endpoint)  # noqa: SLF001
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", _record_hold)  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout2",
+        mission_id="vehicle-command-mission",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert result.success
+    assert hold_calls == [1]
+    assert endpoint_calls == [("127.0.0.1", 14541)]
+    assert mission_node._state == "SEARCHING"  # noqa: SLF001
+
+
+def test_vehicle_command_rejects_unknown_vehicle(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-unknown-vehicle"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="unknown7",
+        mission_id="reject-unknown-vehicle",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "unknown vehicle_id" in result.message
+
+
+def test_vehicle_command_rejects_offline_vehicle(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-offline-vehicle"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {  # noqa: SLF001
+        "scout_2": time.monotonic() - 10.0,
+    }
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout2",
+        mission_id="reject-offline-vehicle",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "offline vehicle_id" in result.message
+
+
+def test_vehicle_command_rejects_unsupported_command(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-command"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {"scout_1": time.monotonic()}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="LAND",
+        vehicle_id="scout1",
+        mission_id="reject-command",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "unsupported command" in result.message
+
+
+def test_vehicle_command_rejects_invalid_state_transition(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "IDLE"  # noqa: SLF001
+    mission_node._mission_id = "state-gate"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {"scout_1": time.monotonic()}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout1",
+        mission_id="state-gate",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "rejected while in IDLE" in result.message
+
+
+def test_vehicle_command_service_accepts_online_target(mission_harness, monkeypatch) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout2")
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "vehicle-service-accept"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    endpoint_calls: list[tuple[str, int]] = []
+    hold_calls: list[int] = []
+
+    def _record_endpoint(host: str, port: int) -> None:
+        endpoint_calls.append((host, int(port)))
+
+    def _record_hold() -> bool:
+        hold_calls.append(1)
+        return True
+
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", _record_endpoint)  # noqa: SLF001
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", _record_hold)  # noqa: SLF001
+
+    request = VehicleCommand.Request()
+    request.command = "HOLD"
+    request.vehicle_id = "scout2"
+    request.mission_id = "vehicle-service-accept"
+    result_future = observer.vehicle_command_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert response.success
+    assert "accepted" in response.message
+    assert endpoint_calls == [("127.0.0.1", 14541)]
+    assert hold_calls == [1]
+    assert mission_node._state == "SEARCHING"  # noqa: SLF001
+
+
+def test_vehicle_command_service_rejects_unknown_target(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "vehicle-service-reject"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    request = VehicleCommand.Request()
+    request.command = "HOLD"
+    request.vehicle_id = "unknown99"
+    request.mission_id = "vehicle-service-reject"
+    result_future = observer.vehicle_command_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert not response.success
+    assert "unknown vehicle_id" in response.message

--- a/software/viewer/src/components/fleet/VehicleCard.tsx
+++ b/software/viewer/src/components/fleet/VehicleCard.tsx
@@ -60,11 +60,19 @@ export function VehicleCard({
   onFocus,
 }: VehicleCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { selectVehicle, recallVehicle, holdVehicle, resumeVehicle, selectedVehicleId } = useFleetContext();
+  const {
+    selectVehicle,
+    recallVehicle,
+    holdVehicle,
+    resumeVehicle,
+    selectedVehicleId,
+    commandErrors,
+  } = useFleetContext();
   
   const isSelected = selectedVehicleId === vehicle.id;
   const statusConfig = getVehicleStatusConfig(vehicle.status);
   const typeColor = getVehicleTypeColor(vehicle.type);
+  const commandError = commandErrors[vehicle.id];
   
   const handleSelect = () => {
     selectVehicle(isSelected ? null : vehicle.id);
@@ -323,6 +331,12 @@ export function VehicleCard({
                 <Target className="w-4 h-4" />
                 Focus on Map
               </button>
+
+              {commandError && (
+                <p className="text-xs text-danger bg-danger/10 border border-danger/30 rounded-md px-2 py-1">
+                  {commandError}
+                </p>
+              )}
             </div>
           </motion.div>
         )}

--- a/software/viewer/src/context/FleetContext.tsx
+++ b/software/viewer/src/context/FleetContext.tsx
@@ -19,7 +19,18 @@ import type { VehicleInfo, VehicleCommand, VehicleCommandRequest } from '@/types
 import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { vehicleStateToInfo } from '@/types/vehicle';
 import { useROSConnection } from '@/hooks/useROSConnection';
+import {
+  buildVehicleCommandServiceRequest,
+  callVehicleCommandService,
+  formatVehicleCommandFailure,
+  getVehicleCommandValidationError,
+} from '@/lib/fleetCommandBehavior';
 import ROSLIB from 'roslib';
+
+type FleetCommandResult = {
+  success: boolean;
+  message: string;
+};
 
 // ============================================================================
 // Context Types
@@ -36,10 +47,14 @@ interface FleetContextValue {
   toggleVehicleSelection: (id: string) => void;
   
   // Commands
-  sendCommand: (vehicleId: string, command: VehicleCommand, params?: { latitude?: number; longitude?: number; altitude?: number }) => void;
-  recallVehicle: (vehicleId: string) => void;
-  holdVehicle: (vehicleId: string) => void;
-  resumeVehicle: (vehicleId: string) => void;
+  sendCommand: (
+    vehicleId: string,
+    command: VehicleCommand,
+    params?: { latitude?: number; longitude?: number; altitude?: number }
+  ) => Promise<FleetCommandResult>;
+  recallVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
+  holdVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
+  resumeVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
   recallAll: () => void;
   holdAll: () => void;
   resumeAll: () => void;
@@ -55,6 +70,7 @@ interface FleetContextValue {
   
   // Command history
   lastCommand?: VehicleCommandRequest;
+  commandErrors: Record<string, string>;
 }
 
 // ============================================================================
@@ -77,6 +93,7 @@ export function FleetProvider({ children }: FleetProviderProps) {
   
   const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(null);
   const [lastCommand, setLastCommand] = useState<VehicleCommandRequest>();
+  const [commandErrors, setCommandErrors] = useState<Record<string, string>>({});
   
   // Convert raw vehicle states to VehicleInfo
   const vehicles = useMemo(() => {
@@ -117,11 +134,28 @@ export function FleetProvider({ children }: FleetProviderProps) {
   // Commands
   // ============================================================================
   
-  const sendCommand = useCallback((
+  const publishLegacyCommand = useCallback((request: VehicleCommandRequest) => {
+    if (!ros || !isConnected) {
+      return;
+    }
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: '/fleet/command',
+      messageType: 'std_msgs/String',
+    });
+
+    const message = new ROSLIB.Message({
+      data: JSON.stringify(request),
+    });
+    topic.publish(message);
+  }, [ros, isConnected]);
+
+  const sendCommand = useCallback(async (
     vehicleId: string,
     command: VehicleCommand,
     params?: { latitude?: number; longitude?: number; altitude?: number }
-  ) => {
+  ): Promise<FleetCommandResult> => {
     const request: VehicleCommandRequest = {
       vehicleId,
       command,
@@ -130,45 +164,79 @@ export function FleetProvider({ children }: FleetProviderProps) {
     };
     
     setLastCommand(request);
-    
-    // Publish to ROS if connected
-    if (ros && isConnected) {
-      const topic = new ROSLIB.Topic({
-        ros: ros,
-        name: '/fleet/command',
-        messageType: 'std_msgs/String',
-      });
-      
-      const message = new ROSLIB.Message({
-        data: JSON.stringify(request),
-      });
-      
-      topic.publish(message);
+
+    const validationError = getVehicleCommandValidationError({
+      rosConnected: !!ros && isConnected,
+      vehicleId,
+    });
+    if (validationError) {
+      setCommandErrors(prev => ({ ...prev, [vehicleId]: validationError }));
+      return { success: false, message: validationError };
     }
-  }, [ros, isConnected]);
+
+    const serviceRequest = buildVehicleCommandServiceRequest({
+      vehicleId,
+      command,
+    });
+
+    try {
+      const response = await callVehicleCommandService({
+        ros,
+        request: serviceRequest,
+        createService: args => new ROSLIB.Service(args),
+        createServiceRequest: payload => new ROSLIB.ServiceRequest(payload as object),
+      });
+
+      if (!response.success) {
+        const failure = formatVehicleCommandFailure(command, vehicleId, response.message);
+        setCommandErrors(prev => ({ ...prev, [vehicleId]: failure }));
+        console.warn(`[FleetContext] ${failure}`);
+        return { success: false, message: failure };
+      }
+
+      setCommandErrors(prev => {
+        if (!(vehicleId in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[vehicleId];
+        return next;
+      });
+
+      // Keep backward compatibility with legacy listeners until they are removed.
+      publishLegacyCommand(request);
+      return response;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const failure = formatVehicleCommandFailure(command, vehicleId, errorMessage);
+      setCommandErrors(prev => ({ ...prev, [vehicleId]: failure }));
+      console.error('[FleetContext] Failed to send vehicle command:', error);
+      return { success: false, message: failure };
+    }
+  }, [isConnected, publishLegacyCommand, ros]);
   
   const recallVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'RECALL');
+    return sendCommand(vehicleId, 'RECALL');
   }, [sendCommand]);
   
   const holdVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'HOLD');
+    return sendCommand(vehicleId, 'HOLD');
   }, [sendCommand]);
   
   const resumeVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'RESUME');
+    return sendCommand(vehicleId, 'RESUME');
   }, [sendCommand]);
   
   const recallAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'RECALL'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'RECALL')));
   }, [vehicles, sendCommand]);
   
   const holdAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'HOLD'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'HOLD')));
   }, [vehicles, sendCommand]);
   
   const resumeAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'RESUME'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'RESUME')));
   }, [vehicles, sendCommand]);
   
   // ============================================================================
@@ -190,6 +258,7 @@ export function FleetProvider({ children }: FleetProviderProps) {
     resumeAll,
     fleetStats,
     lastCommand,
+    commandErrors,
   };
   
   return (

--- a/software/viewer/src/lib/fleetCommandBehavior.d.ts
+++ b/software/viewer/src/lib/fleetCommandBehavior.d.ts
@@ -1,0 +1,52 @@
+export const VEHICLE_COMMAND_SERVICE_TIMEOUT_MS: number;
+export const VEHICLE_COMMAND_SERVICE_TYPE: string;
+export const VEHICLE_COMMAND_SERVICE_NAME: string;
+
+export function buildVehicleCommandServiceRequest(args: {
+  vehicleId: string;
+  command: string;
+  missionId?: string;
+}): {
+  vehicle_id: string;
+  command: string;
+  mission_id: string;
+};
+
+export function normalizeVehicleCommandServiceResponse(response: unknown): {
+  success: boolean;
+  message: string;
+};
+
+export function getVehicleCommandValidationError(args: {
+  rosConnected: boolean;
+  vehicleId: string | undefined;
+}): string | null;
+
+export function formatVehicleCommandFailure(
+  command: string,
+  vehicleId: string,
+  message: string
+): string;
+
+export function callVehicleCommandService(args: {
+  ros: unknown;
+  serviceName?: string;
+  serviceType?: string;
+  request: unknown;
+  timeoutMs?: number;
+  createService: (args: {
+    ros: unknown;
+    name: string;
+    serviceType: string;
+  }) => {
+    callService: (
+      request: unknown,
+      onSuccess: (response: unknown) => void,
+      onError: (error: unknown) => void
+    ) => void;
+  };
+  createServiceRequest: (request: unknown) => unknown;
+}): Promise<{
+  success: boolean;
+  message: string;
+}>;

--- a/software/viewer/src/lib/fleetCommandBehavior.js
+++ b/software/viewer/src/lib/fleetCommandBehavior.js
@@ -1,0 +1,71 @@
+import { withServiceTimeout } from "./missionControlBehavior.js";
+
+export const VEHICLE_COMMAND_SERVICE_TIMEOUT_MS = 8000;
+export const VEHICLE_COMMAND_SERVICE_TYPE = "aeris_msgs/srv/VehicleCommand";
+export const VEHICLE_COMMAND_SERVICE_NAME = "vehicle_command";
+
+export function buildVehicleCommandServiceRequest({
+  vehicleId,
+  command,
+  missionId = "",
+}) {
+  return {
+    vehicle_id: vehicleId,
+    command,
+    mission_id: missionId,
+  };
+}
+
+export function normalizeVehicleCommandServiceResponse(response) {
+  return {
+    success: Boolean(response?.success),
+    message: typeof response?.message === "string" ? response.message : "",
+  };
+}
+
+export function getVehicleCommandValidationError({ rosConnected, vehicleId }) {
+  if (!rosConnected) {
+    return "ROS is disconnected. Reconnect before sending vehicle commands.";
+  }
+
+  if (!vehicleId || !vehicleId.trim()) {
+    return "Vehicle command failed: vehicle id is missing.";
+  }
+
+  return null;
+}
+
+export function formatVehicleCommandFailure(command, vehicleId, message) {
+  const details = message && message.trim()
+    ? message.trim()
+    : "No rejection reason was returned by the orchestrator.";
+  return `${command} rejected for ${vehicleId}: ${details}`;
+}
+
+export function callVehicleCommandService({
+  ros,
+  serviceName = VEHICLE_COMMAND_SERVICE_NAME,
+  serviceType = VEHICLE_COMMAND_SERVICE_TYPE,
+  request,
+  timeoutMs = VEHICLE_COMMAND_SERVICE_TIMEOUT_MS,
+  createService,
+  createServiceRequest,
+}) {
+  return withServiceTimeout(
+    (resolve, reject) => {
+      const service = createService({
+        ros,
+        name: serviceName,
+        serviceType,
+      });
+      const serviceRequest = createServiceRequest(request);
+      service.callService(
+        serviceRequest,
+        response => resolve(normalizeVehicleCommandServiceResponse(response)),
+        error => reject(new Error(String(error)))
+      );
+    },
+    timeoutMs,
+    serviceName
+  );
+}

--- a/software/viewer/src/lib/fleetCommandBehavior.test.mjs
+++ b/software/viewer/src/lib/fleetCommandBehavior.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildVehicleCommandServiceRequest,
+  callVehicleCommandService,
+  formatVehicleCommandFailure,
+  getVehicleCommandValidationError,
+} from "./fleetCommandBehavior.js";
+
+test("buildVehicleCommandServiceRequest includes vehicle_id and command", () => {
+  const request = buildVehicleCommandServiceRequest({
+    vehicleId: "scout2",
+    command: "HOLD",
+    missionId: "mission-42",
+  });
+
+  assert.deepEqual(request, {
+    vehicle_id: "scout2",
+    command: "HOLD",
+    mission_id: "mission-42",
+  });
+});
+
+test("callVehicleCommandService resolves rejected responses for UI handling", async () => {
+  const calls = [];
+
+  const result = await callVehicleCommandService({
+    ros: {},
+    request: {
+      vehicle_id: "unknown",
+      command: "HOLD",
+      mission_id: "mission-42",
+    },
+    createService: ({ name, serviceType }) => {
+      calls.push([name, serviceType]);
+      return {
+        callService(_request, onSuccess) {
+          onSuccess({ success: false, message: "unknown vehicle_id 'unknown'" });
+        },
+      };
+    },
+    createServiceRequest: request => request,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(result.success, false);
+  assert.match(result.message, /unknown vehicle_id/);
+});
+
+test("vehicle command validation blocks disconnected transport", () => {
+  const error = getVehicleCommandValidationError({
+    rosConnected: false,
+    vehicleId: "scout1",
+  });
+  assert.equal(
+    error,
+    "ROS is disconnected. Reconnect before sending vehicle commands."
+  );
+});
+
+test("formatVehicleCommandFailure returns a clear error string", () => {
+  assert.equal(
+    formatVehicleCommandFailure("HOLD", "scout1", "vehicle is offline"),
+    "HOLD rejected for scout1: vehicle is offline"
+  );
+});


### PR DESCRIPTION
## Summary
- add a dedicated ROS service contract for targeted vehicle commands
- add orchestrator `vehicle_command` handling with vehicle ID normalization, online checks, state gating, and endpoint-isolated dispatch
- extend the MAVLink adapter with ACK-aware HOLD/RESUME command dispatch and shared command-ack logic
- migrate Fleet UI command actions to service call/ack flow and surface per-vehicle command failures in the card UI
- add edge and viewer tests covering payload shape, command mapping, target isolation, and rejection handling

## Validation
- `node --test software/viewer/src/lib/missionControlBehavior.test.mjs software/viewer/src/lib/fleetCommandBehavior.test.mjs` (pass)
- `python3 -m pytest -q software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py software/edge/src/aeris_orchestrator/test/test_mission_node.py` in ROS Humble container after `colcon build --packages-select aeris_msgs aeris_orchestrator --symlink-install` (25 passed)
- `npm --prefix software/viewer run lint` (fails on pre-existing rule in `software/viewer/src/hooks/useMissionControl.ts:119`)

## Tracking
- Story 1.4: Individual Vehicle Commands
- Story status: review

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added vehicle command service enabling hold position, resume mission, and return-to-launch operations for fleet vehicles
  - Commands now return asynchronous results with success/failure status and error messages
  - Per-vehicle command error messages displayed in the UI for better feedback
  - Enhanced command handling with acknowledgment validation and retry logic for reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements a comprehensive individual vehicle command flow by introducing a new ROS service contract (`VehicleCommand.srv`) that enables targeted control of specific vehicles within a fleet. The implementation spans the entire stack: backend orchestrator, MAVLink adapter, and frontend UI.

**Key changes:**
- Added `VehicleCommand` ROS service with vehicle ID normalization, online status checks, state gating (only in SEARCHING/TRACKING), and mission ID validation
- Refactored MAVLink adapter to extract common ACK-aware command logic into `_send_command_with_ack`, enabling reuse for RTL, HOLD, and RESUME commands
- Extended frontend `FleetContext` to migrate from legacy topic-based commands to async service calls with per-vehicle error tracking and UI feedback
- Added comprehensive test coverage (25 passing Python tests, all JavaScript tests passing) covering payload validation, command mapping, target isolation, and rejection scenarios

**Architecture highlights:**
- Proper separation of concerns with dedicated service contract vs. mission-wide commands
- Endpoint isolation ensures commands only affect the targeted vehicle
- Backward compatibility maintained with legacy command topic publishing
- Error states surfaced in vehicle card UI for immediate user feedback

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations for production deployment
- The implementation demonstrates solid engineering practices with comprehensive test coverage, proper error handling, and clear separation of concerns. The refactoring of MAVLink adapter command logic reduces code duplication and improves maintainability. However, there are a few considerations: (1) the migration from topic-based to service-based commands introduces a new communication pattern that should be monitored in production, (2) the 8-second timeout for vehicle commands may need tuning based on real-world network conditions, and (3) the backward compatibility layer (publishLegacyCommand) should eventually be removed once all consumers migrate to the service pattern
- Pay attention to `FleetContext.tsx` for the async migration pattern and `mission_node.py` for the vehicle command validation logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py | Refactored RTL into generic _send_command_with_ack and added send_hold_position and send_resume_mission methods with ACK handling |
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Added vehicle_command service handler with vehicle ID normalization, online checks, state gating, and endpoint-specific command dispatch |
| software/viewer/src/context/FleetContext.tsx | Migrated command actions from legacy topic publishing to async service calls with error state management and backward compatibility |
| software/viewer/src/lib/fleetCommandBehavior.js | New module implementing vehicle command service request building, validation, error formatting, and service invocation with timeout |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Fleet UI
    participant FC as FleetContext
    participant FCB as fleetCommandBehavior
    participant ROS as ROS Bridge
    participant MN as mission_node
    participant MA as mavlink_adapter
    participant Vehicle as MAVLink Vehicle

    UI->>FC: recallVehicle(vehicleId)
    FC->>FCB: getVehicleCommandValidationError()
    FCB-->>FC: null (validation passed)
    FC->>FCB: buildVehicleCommandServiceRequest()
    FCB-->>FC: {vehicle_id, command, mission_id}
    FC->>FCB: callVehicleCommandService()
    FCB->>ROS: service.callService(request)
    ROS->>MN: VehicleCommand.Request
    MN->>MN: _normalize_vehicle_id()
    MN->>MN: _resolve_scout_endpoint()
    MN->>MN: _is_endpoint_online()
    MN->>MN: _dispatch_vehicle_command()
    MN->>MA: set_endpoint(host, port)
    MA-->>MN: endpoint selected
    MN->>MA: send_return_to_launch()
    MA->>MA: _send_command_with_ack()
    MA->>Vehicle: MAV_CMD_NAV_RETURN_TO_LAUNCH
    Vehicle-->>MA: COMMAND_ACK (ACCEPTED)
    Vehicle-->>MA: HEARTBEAT (RTL mode)
    MA-->>MN: true (command acknowledged)
    MN-->>ROS: {success: true, message}
    ROS-->>FCB: response
    FCB->>FCB: normalizeVehicleCommandServiceResponse()
    FCB-->>FC: {success: true, message}
    FC->>FC: clear commandErrors[vehicleId]
    FC->>FC: publishLegacyCommand() (backward compat)
    FC-->>UI: command success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->