### PR TITLE
Implement targeted individual vehicle command flow

### DIFF
--- a/software/edge/src/aeris_msgs/CMakeLists.txt
+++ b/software/edge/src/aeris_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ set(interface_files
   "srv/GasIsopleth.srv"
   "srv/SetCameraView.srv"
   "srv/MissionCommand.srv"
+  "srv/VehicleCommand.srv"
   "action/MapTile.action"
   "action/ThermalHotspot.action"
   "action/AcousticBearing.action"

--- a/software/edge/src/aeris_msgs/srv/VehicleCommand.srv
+++ b/software/edge/src/aeris_msgs/srv/VehicleCommand.srv
@@ -1,0 +1,6 @@
+string vehicle_id
+string command
+string mission_id
+---
+bool success
+string message

--- a/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
@@ -10,6 +10,7 @@ class _FakeMav:
         self.mission_count_calls: list[tuple] = []
         self.mission_item_int_calls: list[tuple] = []
         self.set_position_calls: list[tuple] = []
+        self.command_long_calls: list[tuple] = []
 
     def mission_count_send(self, *args) -> None:
         self.mission_count_calls.append(args)
@@ -20,15 +21,43 @@ class _FakeMav:
     def set_position_target_local_ned_send(self, *args) -> None:
         self.set_position_calls.append(args)
 
+    def command_long_send(self, *args) -> None:
+        self.command_long_calls.append(args)
+
 
 class _FakeConnection:
     def __init__(self, endpoint: str) -> None:
         self.endpoint = endpoint
         self.mav = _FakeMav()
         self.closed = False
+        self.messages_by_type: dict[str, list[object]] = {}
+        self.recv_match_calls: list[tuple[str, bool, float | None]] = []
 
     def close(self) -> None:
         self.closed = True
+
+    def recv_match(self, type: str, blocking: bool, timeout: float | None = None):
+        self.recv_match_calls.append((type, blocking, timeout))
+        queue = self.messages_by_type.get(type, [])
+        if queue:
+            return queue.pop(0)
+        return None
+
+
+class _FakeAck:
+    def __init__(self, command: int, result: int) -> None:
+        self.command = command
+        self.result = result
+
+
+class _FakeHeartbeat:
+    def __init__(self, custom_mode: int) -> None:
+        self.custom_mode = custom_mode
+
+
+def _px4_rtl_custom_mode() -> int:
+    # PX4 MAIN_MODE_AUTO=4, SUB_MODE_AUTO_RTL=5.
+    return (5 << 24) | (4 << 16)
 
 
 def test_adapter_sends_mission_item_int_and_local_ned_setpoints(monkeypatch) -> None:
@@ -73,4 +102,218 @@ def test_adapter_sends_mission_item_int_and_local_ned_setpoints(monkeypatch) -> 
     adapter.set_endpoint("127.0.0.1", 14541)
     assert len(connections) == 2
     assert connections[0].closed
+    adapter.close()
+
+
+def test_adapter_sends_explicit_rtl_command_to_current_endpoint(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).append(
+        _FakeAck(
+            mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+            mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
+    )
+    connections[0].messages_by_type.setdefault("HEARTBEAT", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode())
+    )
+    assert adapter.send_return_to_launch()
+
+    first_conn = connections[0]
+    assert len(first_conn.mav.command_long_calls) == 1
+    rtl_call = first_conn.mav.command_long_calls[0]
+    assert rtl_call[0] == 1  # target_system default
+    assert rtl_call[1] == 1  # target_component default
+    assert rtl_call[2] == mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH
+    assert rtl_call[3] == 0  # confirmation on first attempt
+
+    adapter.set_endpoint("127.0.0.1", 14541)
+    connections[1].messages_by_type.setdefault("COMMAND_ACK", []).append(
+        _FakeAck(
+            mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+            mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
+    )
+    connections[1].messages_by_type.setdefault("HEARTBEAT", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode())
+    )
+    assert adapter.send_return_to_launch()
+    assert len(connections) == 2
+    assert len(connections[1].mav.command_long_calls) == 1
+
+    adapter.close()
+
+
+def test_adapter_retries_rtl_when_ack_is_missing(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).extend(
+        [
+            None,
+            _FakeAck(
+                mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+                mavutil.mavlink.MAV_RESULT_ACCEPTED,
+            ),
+        ]
+    )
+    connections[0].messages_by_type.setdefault("HEARTBEAT", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode())
+    )
+
+    assert adapter.send_return_to_launch()
+    assert len(connections[0].mav.command_long_calls) == 2
+    first_attempt = connections[0].mav.command_long_calls[0]
+    second_attempt = connections[0].mav.command_long_calls[1]
+    assert first_attempt[3] == 0
+    assert second_attempt[3] == 1
+    adapter.close()
+
+
+def test_adapter_returns_false_when_heartbeat_never_confirms_rtl(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).extend(
+        [
+            _FakeAck(
+                mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+                mavutil.mavlink.MAV_RESULT_ACCEPTED,
+            ),
+            _FakeAck(
+                mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+                mavutil.mavlink.MAV_RESULT_ACCEPTED,
+            ),
+        ]
+    )
+    connections[0].messages_by_type.setdefault("HEARTBEAT", []).extend(
+        [
+            _FakeHeartbeat(0),
+            _FakeHeartbeat(0),
+        ]
+    )
+
+    assert not adapter.send_return_to_launch()
+    assert len(connections[0].mav.command_long_calls) == 2
+    adapter.close()
+
+
+def test_adapter_send_rtl_returns_false_on_oserror(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+
+    def _raise_oserror(*_args):
+        raise OSError("simulated failure")
+
+    connections[0].mav.command_long_send = _raise_oserror
+
+    assert not adapter.send_return_to_launch()
+    adapter.close()
+
+
+def test_adapter_sends_hold_and_resume_with_ack(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+    command_id = mavutil.mavlink.MAV_CMD_DO_PAUSE_CONTINUE
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).extend(
+        [
+            _FakeAck(command_id, mavutil.mavlink.MAV_RESULT_ACCEPTED),
+            _FakeAck(command_id, mavutil.mavlink.MAV_RESULT_ACCEPTED),
+        ]
+    )
+
+    assert adapter.send_hold_position()
+    assert adapter.send_resume_mission()
+
+    sent_calls = connections[0].mav.command_long_calls
+    assert len(sent_calls) == 2
+    assert sent_calls[0][2] == command_id
+    assert sent_calls[0][4] == 0.0
+    assert sent_calls[1][2] == command_id
+    assert sent_calls[1][4] == 1.0
+    adapter.close()
+
+
+def test_adapter_rejects_hold_when_command_ack_is_rejected(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14540, stream_hz=20.0)
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).append(
+        _FakeAck(
+            mavutil.mavlink.MAV_CMD_DO_PAUSE_CONTINUE,
+            mavutil.mavlink.MAV_RESULT_DENIED,
+        )
+    )
+
+    assert not adapter.send_hold_position()
+    assert len(connections[0].mav.command_long_calls) >= 1
     adapter.close()

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -1,11 +1,12 @@
 import json
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 import rclpy
 from aeris_msgs.msg import MissionProgress, MissionState, Telemetry
-from aeris_msgs.srv import MissionCommand
+from aeris_msgs.srv import MissionCommand, VehicleCommand
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -56,6 +57,9 @@ class MissionObserver(Node):
         )
         self.start_client = self.create_client(MissionCommand, "start_mission")
         self.abort_client = self.create_client(MissionCommand, "abort_mission")
+        self.vehicle_command_client = self.create_client(
+            VehicleCommand, "vehicle_command"
+        )
 
     def _on_state(self, message: MissionState) -> None:
         with self._state_lock:
@@ -64,6 +68,19 @@ class MissionObserver(Node):
     def _on_progress(self, message: MissionProgress) -> None:
         with self._progress_lock:
             self.progress_updates.append(message)
+
+
+def _publish_scout_telemetry(
+    observer: MissionObserver, mission_node: MissionNode, vehicle_id: str = "scout1"
+) -> None:
+    telemetry = Telemetry()
+    telemetry.vehicle_id = vehicle_id
+    telemetry.vehicle_type = "scout"
+    observer.telemetry_publisher.publish(telemetry)
+    normalized_id = mission_node._normalize_vehicle_id(vehicle_id)
+    assert _wait_until(
+        lambda: normalized_id in mission_node._scout_last_seen_monotonic
+    )
 
 
 @pytest.fixture
@@ -89,6 +106,7 @@ def mission_harness(ros_runtime: MultiThreadedExecutor):
 
     assert observer.start_client.wait_for_service(timeout_sec=2.0)
     assert observer.abort_client.wait_for_service(timeout_sec=2.0)
+    assert observer.vehicle_command_client.wait_for_service(timeout_sec=2.0)
 
     try:
         yield mission_node, observer
@@ -101,6 +119,7 @@ def mission_harness(ros_runtime: MultiThreadedExecutor):
 
 def test_start_mission_transitions_to_planning_then_searching(mission_harness) -> None:
     mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
 
     request = MissionCommand.Request()
     request.command = "START"
@@ -143,6 +162,7 @@ def test_start_mission_rejects_invalid_command(mission_harness) -> None:
 
 def test_abort_mission_transitions_to_aborted(mission_harness) -> None:
     mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
 
     start_request = MissionCommand.Request()
     start_request.command = "START"
@@ -169,7 +189,8 @@ def test_abort_mission_transitions_to_aborted(mission_harness) -> None:
 
 
 def test_abort_mission_rejects_invalid_command(mission_harness) -> None:
-    _, observer = mission_harness
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
 
     start_request = MissionCommand.Request()
     start_request.command = "START"
@@ -193,6 +214,35 @@ def test_abort_mission_rejects_invalid_command(mission_harness) -> None:
     assert response is not None
     assert not response.success
     assert "unsupported command" in response.message
+
+
+def test_abort_mission_rejects_mission_id_mismatch(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "mismatch-abort"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    abort_request = MissionCommand.Request()
+    abort_request.command = "ABORT"
+    abort_request.mission_id = "other-mission-id"
+    abort_request.zone_geometry = ""
+    abort_future = observer.abort_client.call_async(abort_request)
+
+    assert _wait_until(lambda: abort_future.done())
+    response = abort_future.result()
+    assert response is not None
+    assert not response.success
+    assert "mission_id mismatch" in response.message
+    assert "ABORTED" not in observer.states
 
 
 def test_start_mission_rejects_missing_zone_geometry(mission_harness) -> None:
@@ -270,14 +320,7 @@ def test_start_mission_rejects_non_finite_polygon_coordinates(mission_harness) -
 def test_start_mission_prefers_recently_seen_scout_endpoint(mission_harness) -> None:
     mission_node, observer = mission_harness
 
-    telemetry = Telemetry()
-    telemetry.vehicle_id = "scout2"
-    telemetry.vehicle_type = "scout"
-    observer.telemetry_publisher.publish(telemetry)
-
-    assert _wait_until(
-        lambda: "scout_2" in mission_node._scout_last_seen_monotonic  # noqa: SLF001
-    )
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout2")
 
     request = MissionCommand.Request()
     request.command = "START"
@@ -291,3 +334,266 @@ def test_start_mission_prefers_recently_seen_scout_endpoint(mission_harness) -> 
     assert response.success
     assert "scout 'scout_2'" in response.message
     assert mission_node._active_scout_vehicle_id == "scout_2"  # noqa: SLF001
+
+
+def test_abort_mission_dispatches_rtl_to_all_active_endpoints_best_effort(
+    mission_harness, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "fleet-abort"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout2")
+
+    endpoint_calls: list[tuple[str, int]] = []
+    rtl_attempts: list[int] = []
+
+    def _record_endpoint(host: str, port: int) -> None:
+        endpoint_calls.append((host, int(port)))
+
+    def _record_rtl_attempt() -> bool:
+        rtl_attempts.append(1)
+        if len(rtl_attempts) == 1:
+            raise OSError("simulated endpoint write failure")
+        return True
+
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", _record_endpoint)  # noqa: SLF001
+    monkeypatch.setattr(  # noqa: SLF001
+        mission_node._mavlink_adapter, "send_return_to_launch", _record_rtl_attempt
+    )
+
+    abort_request = MissionCommand.Request()
+    abort_request.command = "ABORT"
+    abort_request.mission_id = "fleet-abort"
+    abort_request.zone_geometry = ""
+    abort_future = observer.abort_client.call_async(abort_request)
+
+    assert _wait_until(lambda: abort_future.done())
+    response = abort_future.result()
+    assert response is not None
+    assert response.success
+    assert _wait_until(lambda: "ABORTED" in observer.states)
+    assert len(rtl_attempts) == 2
+    assert sorted(endpoint_calls) == [("127.0.0.1", 14540), ("127.0.0.1", 14541)]
+
+
+def test_start_mission_rejects_when_no_scout_is_online(mission_harness) -> None:
+    _, observer = mission_harness
+
+    request = MissionCommand.Request()
+    request.command = "START"
+    request.mission_id = "no-online-scout"
+    request.zone_geometry = VALID_ZONE_GEOMETRY
+    result_future = observer.start_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert not response.success
+    assert "no scout endpoint reported telemetry recently" in response.message
+
+
+def test_vehicle_command_targets_only_requested_endpoint(
+    mission_harness, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    now = time.monotonic()
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "vehicle-command-mission"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {  # noqa: SLF001
+        "scout_1": now,
+        "scout_2": now,
+    }
+
+    endpoint_calls: list[tuple[str, int]] = []
+    hold_calls: list[int] = []
+
+    def _record_endpoint(host: str, port: int) -> None:
+        endpoint_calls.append((host, int(port)))
+
+    def _record_hold() -> bool:
+        hold_calls.append(1)
+        return True
+
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", _record_endpoint)  # noqa: SLF001
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", _record_hold)  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout2",
+        mission_id="vehicle-command-mission",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert result.success
+    assert hold_calls == [1]
+    assert endpoint_calls == [("127.0.0.1", 14541)]
+    assert mission_node._state == "SEARCHING"  # noqa: SLF001
+
+
+def test_vehicle_command_rejects_unknown_vehicle(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-unknown-vehicle"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="unknown7",
+        mission_id="reject-unknown-vehicle",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "unknown vehicle_id" in result.message
+
+
+def test_vehicle_command_rejects_offline_vehicle(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-offline-vehicle"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {  # noqa: SLF001
+        "scout_2": time.monotonic() - 10.0,
+    }
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout2",
+        mission_id="reject-offline-vehicle",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "offline vehicle_id" in result.message
+
+
+def test_vehicle_command_rejects_unsupported_command(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "SEARCHING"  # noqa: SLF001
+    mission_node._mission_id = "reject-command"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {"scout_1": time.monotonic()}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="LAND",
+        vehicle_id="scout1",
+        mission_id="reject-command",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "unsupported command" in result.message
+
+
+def test_vehicle_command_rejects_invalid_state_transition(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    del observer
+
+    mission_node._state = "IDLE"  # noqa: SLF001
+    mission_node._mission_id = "state-gate"  # noqa: SLF001
+    mission_node._scout_last_seen_monotonic = {"scout_1": time.monotonic()}  # noqa: SLF001
+
+    request = SimpleNamespace(
+        command="HOLD",
+        vehicle_id="scout1",
+        mission_id="state-gate",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)  # noqa: SLF001
+
+    assert not result.success
+    assert "rejected while in IDLE" in result.message
+
+
+def test_vehicle_command_service_accepts_online_target(mission_harness, monkeypatch) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout2")
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "vehicle-service-accept"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    endpoint_calls: list[tuple[str, int]] = []
+    hold_calls: list[int] = []
+
+    def _record_endpoint(host: str, port: int) -> None:
+        endpoint_calls.append((host, int(port)))
+
+    def _record_hold() -> bool:
+        hold_calls.append(1)
+        return True
+
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", _record_endpoint)  # noqa: SLF001
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", _record_hold)  # noqa: SLF001
+
+    request = VehicleCommand.Request()
+    request.command = "HOLD"
+    request.vehicle_id = "scout2"
+    request.mission_id = "vehicle-service-accept"
+    result_future = observer.vehicle_command_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert response.success
+    assert "accepted" in response.message
+    assert endpoint_calls == [("127.0.0.1", 14541)]
+    assert hold_calls == [1]
+    assert mission_node._state == "SEARCHING"  # noqa: SLF001
+
+
+def test_vehicle_command_service_rejects_unknown_target(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "vehicle-service-reject"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    request = VehicleCommand.Request()
+    request.command = "HOLD"
+    request.vehicle_id = "unknown99"
+    request.mission_id = "vehicle-service-reject"
+    result_future = observer.vehicle_command_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert not response.success
+    assert "unknown vehicle_id" in response.message

--- a/software/viewer/src/components/fleet/VehicleCard.tsx
+++ b/software/viewer/src/components/fleet/VehicleCard.tsx
@@ -60,11 +60,19 @@ export function VehicleCard({
   onFocus,
 }: VehicleCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { selectVehicle, recallVehicle, holdVehicle, resumeVehicle, selectedVehicleId } = useFleetContext();
+  const {
+    selectVehicle,
+    recallVehicle,
+    holdVehicle,
+    resumeVehicle,
+    selectedVehicleId,
+    commandErrors,
+  } = useFleetContext();
   
   const isSelected = selectedVehicleId === vehicle.id;
   const statusConfig = getVehicleStatusConfig(vehicle.status);
   const typeColor = getVehicleTypeColor(vehicle.type);
+  const commandError = commandErrors[vehicle.id];
   
   const handleSelect = () => {
     selectVehicle(isSelected ? null : vehicle.id);
@@ -323,6 +331,12 @@ export function VehicleCard({
                 <Target className="w-4 h-4" />
                 Focus on Map
               </button>
+
+              {commandError && (
+                <p className="text-xs text-danger bg-danger/10 border border-danger/30 rounded-md px-2 py-1">
+                  {commandError}
+                </p>
+              )}
             </div>
           </motion.div>
         )}

--- a/software/viewer/src/context/FleetContext.tsx
+++ b/software/viewer/src/context/FleetContext.tsx
@@ -19,7 +19,18 @@ import type { VehicleInfo, VehicleCommand, VehicleCommandRequest } from '@/types
 import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { vehicleStateToInfo } from '@/types/vehicle';
 import { useROSConnection } from '@/hooks/useROSConnection';
+import {
+  buildVehicleCommandServiceRequest,
+  callVehicleCommandService,
+  formatVehicleCommandFailure,
+  getVehicleCommandValidationError,
+} from '@/lib/fleetCommandBehavior';
 import ROSLIB from 'roslib';
+
+type FleetCommandResult = {
+  success: boolean;
+  message: string;
+};
 
 // ============================================================================
 // Context Types
@@ -36,10 +47,14 @@ interface FleetContextValue {
   toggleVehicleSelection: (id: string) => void;
   
   // Commands
-  sendCommand: (vehicleId: string, command: VehicleCommand, params?: { latitude?: number; longitude?: number; altitude?: number }) => void;
-  recallVehicle: (vehicleId: string) => void;
-  holdVehicle: (vehicleId: string) => void;
-  resumeVehicle: (vehicleId: string) => void;
+  sendCommand: (
+    vehicleId: string,
+    command: VehicleCommand,
+    params?: { latitude?: number; longitude?: number; altitude?: number }
+  ) => Promise<FleetCommandResult>;
+  recallVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
+  holdVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
+  resumeVehicle: (vehicleId: string) => Promise<FleetCommandResult>;
   recallAll: () => void;
   holdAll: () => void;
   resumeAll: () => void;
@@ -55,6 +70,7 @@ interface FleetContextValue {
   
   // Command history
   lastCommand?: VehicleCommandRequest;
+  commandErrors: Record<string, string>;
 }
 
 // ============================================================================
@@ -77,6 +93,7 @@ export function FleetProvider({ children }: FleetProviderProps) {
   
   const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(null);
   const [lastCommand, setLastCommand] = useState<VehicleCommandRequest>();
+  const [commandErrors, setCommandErrors] = useState<Record<string, string>>({});
   
   // Convert raw vehicle states to VehicleInfo
   const vehicles = useMemo(() => {
@@ -117,11 +134,28 @@ export function FleetProvider({ children }: FleetProviderProps) {
   // Commands
   // ============================================================================
   
-  const sendCommand = useCallback((
+  const publishLegacyCommand = useCallback((request: VehicleCommandRequest) => {
+    if (!ros || !isConnected) {
+      return;
+    }
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: '/fleet/command',
+      messageType: 'std_msgs/String',
+    });
+
+    const message = new ROSLIB.Message({
+      data: JSON.stringify(request),
+    });
+    topic.publish(message);
+  }, [ros, isConnected]);
+
+  const sendCommand = useCallback(async (
     vehicleId: string,
     command: VehicleCommand,
     params?: { latitude?: number; longitude?: number; altitude?: number }
-  ) => {
+  ): Promise<FleetCommandResult> => {
     const request: VehicleCommandRequest = {
       vehicleId,
       command,
@@ -130,45 +164,79 @@ export function FleetProvider({ children }: FleetProviderProps) {
     };
     
     setLastCommand(request);
-    
-    // Publish to ROS if connected
-    if (ros && isConnected) {
-      const topic = new ROSLIB.Topic({
-        ros: ros,
-        name: '/fleet/command',
-        messageType: 'std_msgs/String',
-      });
-      
-      const message = new ROSLIB.Message({
-        data: JSON.stringify(request),
-      });
-      
-      topic.publish(message);
+
+    const validationError = getVehicleCommandValidationError({
+      rosConnected: !!ros && isConnected,
+      vehicleId,
+    });
+    if (validationError) {
+      setCommandErrors(prev => ({ ...prev, [vehicleId]: validationError }));
+      return { success: false, message: validationError };
     }
-  }, [ros, isConnected]);
+
+    const serviceRequest = buildVehicleCommandServiceRequest({
+      vehicleId,
+      command,
+    });
+
+    try {
+      const response = await callVehicleCommandService({
+        ros,
+        request: serviceRequest,
+        createService: args => new ROSLIB.Service(args),
+        createServiceRequest: payload => new ROSLIB.ServiceRequest(payload as object),
+      });
+
+      if (!response.success) {
+        const failure = formatVehicleCommandFailure(command, vehicleId, response.message);
+        setCommandErrors(prev => ({ ...prev, [vehicleId]: failure }));
+        console.warn(`[FleetContext] ${failure}`);
+        return { success: false, message: failure };
+      }
+
+      setCommandErrors(prev => {
+        if (!(vehicleId in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[vehicleId];
+        return next;
+      });
+
+      // Keep backward compatibility with legacy listeners until they are removed.
+      publishLegacyCommand(request);
+      return response;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const failure = formatVehicleCommandFailure(command, vehicleId, errorMessage);
+      setCommandErrors(prev => ({ ...prev, [vehicleId]: failure }));
+      console.error('[FleetContext] Failed to send vehicle command:', error);
+      return { success: false, message: failure };
+    }
+  }, [isConnected, publishLegacyCommand, ros]);
   
   const recallVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'RECALL');
+    return sendCommand(vehicleId, 'RECALL');
   }, [sendCommand]);
   
   const holdVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'HOLD');
+    return sendCommand(vehicleId, 'HOLD');
   }, [sendCommand]);
   
   const resumeVehicle = useCallback((vehicleId: string) => {
-    sendCommand(vehicleId, 'RESUME');
+    return sendCommand(vehicleId, 'RESUME');
   }, [sendCommand]);
   
   const recallAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'RECALL'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'RECALL')));
   }, [vehicles, sendCommand]);
   
   const holdAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'HOLD'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'HOLD')));
   }, [vehicles, sendCommand]);
   
   const resumeAll = useCallback(() => {
-    vehicles.forEach(v => sendCommand(v.id, 'RESUME'));
+    void Promise.all(vehicles.map(v => sendCommand(v.id, 'RESUME')));
   }, [vehicles, sendCommand]);
   
   // ============================================================================
@@ -190,6 +258,7 @@ export function FleetProvider({ children }: FleetProviderProps) {
     resumeAll,
     fleetStats,
     lastCommand,
+    commandErrors,
   };
   
   return (

--- a/software/viewer/src/lib/fleetCommandBehavior.d.ts
+++ b/software/viewer/src/lib/fleetCommandBehavior.d.ts
@@ -1,0 +1,52 @@
+export const VEHICLE_COMMAND_SERVICE_TIMEOUT_MS: number;
+export const VEHICLE_COMMAND_SERVICE_TYPE: string;
+export const VEHICLE_COMMAND_SERVICE_NAME: string;
+
+export function buildVehicleCommandServiceRequest(args: {
+  vehicleId: string;
+  command: string;
+  missionId?: string;
+}): {
+  vehicle_id: string;
+  command: string;
+  mission_id: string;
+};
+
+export function normalizeVehicleCommandServiceResponse(response: unknown): {
+  success: boolean;
+  message: string;
+};
+
+export function getVehicleCommandValidationError(args: {
+  rosConnected: boolean;
+  vehicleId: string | undefined;
+}): string | null;
+
+export function formatVehicleCommandFailure(
+  command: string,
+  vehicleId: string,
+  message: string
+): string;
+
+export function callVehicleCommandService(args: {
+  ros: unknown;
+  serviceName?: string;
+  serviceType?: string;
+  request: unknown;
+  timeoutMs?: number;
+  createService: (args: {
+    ros: unknown;
+    name: string;
+    serviceType: string;
+  }) => {
+    callService: (
+      request: unknown,
+      onSuccess: (response: unknown) => void,
+      onError: (error: unknown) => void
+    ) => void;
+  };
+  createServiceRequest: (request: unknown) => unknown;
+}): Promise<{
+  success: boolean;
+  message: string;
+}>;

--- a/software/viewer/src/lib/fleetCommandBehavior.js
+++ b/software/viewer/src/lib/fleetCommandBehavior.js
@@ -1,0 +1,92 @@
+export const VEHICLE_COMMAND_SERVICE_TIMEOUT_MS = 8000;
+export const VEHICLE_COMMAND_SERVICE_TYPE = "aeris_msgs/srv/VehicleCommand";
+export const VEHICLE_COMMAND_SERVICE_NAME = "vehicle_command";
+
+export function buildVehicleCommandServiceRequest({
+  vehicleId,
+  command,
+  missionId = "",
+}) {
+  return {
+    vehicle_id: vehicleId,
+    command,
+    mission_id: missionId,
+  };
+}
+
+export function normalizeVehicleCommandServiceResponse(response) {
+  return {
+    success: Boolean(response?.success),
+    message: typeof response?.message === "string" ? response.message : "",
+  };
+}
+
+export function getVehicleCommandValidationError({ rosConnected, vehicleId }) {
+  if (!rosConnected) {
+    return "ROS is disconnected. Reconnect before sending vehicle commands.";
+  }
+
+  if (!vehicleId || !vehicleId.trim()) {
+    return "Vehicle command failed: vehicle id is missing.";
+  }
+
+  return null;
+}
+
+export function formatVehicleCommandFailure(command, vehicleId, message) {
+  const details = message && message.trim()
+    ? message.trim()
+    : "No rejection reason was returned by the orchestrator.";
+  return `${command} rejected for ${vehicleId}: ${details}`;
+}
+
+export function callVehicleCommandService({
+  ros,
+  serviceName = VEHICLE_COMMAND_SERVICE_NAME,
+  serviceType = VEHICLE_COMMAND_SERVICE_TYPE,
+  request,
+  timeoutMs = VEHICLE_COMMAND_SERVICE_TIMEOUT_MS,
+  createService,
+  createServiceRequest,
+}) {
+  const withServiceTimeout = (invoke, timeoutMs, label = "service call") =>
+    new Promise((resolve, reject) => {
+      let settled = false;
+
+      const finish = (callback, value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutId);
+        callback(value);
+      };
+
+      const timeoutId = setTimeout(() => {
+        finish(reject, new Error(`${label} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      invoke(
+        value => finish(resolve, value),
+        error => finish(reject, error instanceof Error ? error : new Error(String(error)))
+      );
+    });
+
+  return withServiceTimeout(
+    (resolve, reject) => {
+      const service = createService({
+        ros,
+        name: serviceName,
+        serviceType,
+      });
+      const serviceRequest = createServiceRequest(request);
+      service.callService(
+        serviceRequest,
+        response => resolve(normalizeVehicleCommandServiceResponse(response)),
+        error => reject(new Error(String(error)))
+      );
+    },
+    timeoutMs,
+    serviceName
+  );
+}

--- a/software/viewer/src/lib/fleetCommandBehavior.test.mjs
+++ b/software/viewer/src/lib/fleetCommandBehavior.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildVehicleCommandServiceRequest,
+  callVehicleCommandService,
+  formatVehicleCommandFailure,
+  getVehicleCommandValidationError,
+} from "./fleetCommandBehavior.js";
+
+test("buildVehicleCommandServiceRequest includes vehicle_id and command", () => {
+  const request = buildVehicleCommandServiceRequest({
+    vehicleId: "scout2",
+    command: "HOLD",
+    missionId: "mission-42",
+  });
+
+  assert.deepEqual(request, {
+    vehicle_id: "scout2",
+    command: "HOLD",
+    mission_id: "mission-42",
+  });
+});
+
+test("callVehicleCommandService resolves rejected responses for UI handling", async () => {
+  const calls = [];
+
+  const result = await callVehicleCommandService({
+    ros: {},
+    request: {
+      vehicle_id: "unknown",
+      command: "HOLD",
+      mission_id: "mission-42",
+    },
+    createService: ({ name, serviceType }) => {
+      calls.push([name, serviceType]);
+      return {
+        callService(_request, onSuccess) {
+          onSuccess({ success: false, message: "unknown vehicle_id 'unknown'" });
+        },
+      };
+    },
+    createServiceRequest: request => request,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(result.success, false);
+  assert.match(result.message, /unknown vehicle_id/);
+});
+
+test("vehicle command validation blocks disconnected transport", () => {
+  const error = getVehicleCommandValidationError({
+    rosConnected: false,
+    vehicleId: "scout1",
+  });
+  assert.equal(
+    error,
+    "ROS is disconnected. Reconnect before sending vehicle commands."
+  );
+});
+
+test("formatVehicleCommandFailure returns a clear error string", () => {
+  assert.equal(
+    formatVehicleCommandFailure("HOLD", "scout1", "vehicle is offline"),
+    "HOLD rejected for scout1: vehicle is offline"
+  );
+});


### PR DESCRIPTION
## Summary
- add a dedicated ROS service contract for targeted vehicle commands
- add orchestrator `vehicle_command` handling with vehicle ID normalization, online checks, state gating, and endpoint-isolated dispatch
- extend the MAVLink adapter with ACK-aware HOLD/RESUME command dispatch and shared command-ack logic
- migrate Fleet UI command actions to service call/ack flow and surface per-vehicle command failures in the card UI
- add edge and viewer tests covering payload shape, command mapping, target isolation, and rejection handling

## Validation
- `python3 -m py_compile software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py` (pass)
- `node --test software/viewer/src/lib/fleetCommandBehavior.test.mjs` (pass)
- ROS container validation could not be re-run in this terminal because Docker daemon is currently unavailable (`/Users/saketh/.docker/run/docker.sock` missing)

## Tracking
- Story 1.4: Individual Vehicle Commands
- Story status: review

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced a vehicle command service with HOLD, RESUME, and RECALL operations for fleet vehicle control
- Added per-vehicle command error display in the UI, showing detailed feedback on failed operations
- Enhanced fleet command functions to return operation results with error messages
- Implemented command validation to ensure only supported commands are processed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements a comprehensive targeted vehicle command system that allows the Fleet UI to send HOLD, RESUME, and RECALL commands to individual vehicles during autonomous missions.

**Key changes:**
- Added `VehicleCommand.srv` ROS service contract with `vehicle_id`, `command`, and `mission_id` fields
- Implemented service handler in `mission_node.py` with validation for command type, mission state, vehicle online status, and mission ID matching
- Extended MAVLink adapter with ACK-aware command dispatch using retry logic and MAVLink `COMMAND_ACK` confirmation
- RTL commands now verify mode transition via `HEARTBEAT` messages (supports both PX4 and ArduPilot)
- Modified abort flow to fan-out RTL commands to all active scouts with best-effort delivery
- Migrated Fleet UI from topic-based to async service-based commands with per-vehicle error tracking
- Added comprehensive test coverage (243 lines for MAVLink adapter, 326 lines for mission node, 67 lines for viewer logic)

**Architecture improvements:**
- Commands are now request-response with explicit success/failure feedback rather than fire-and-forget
- Vehicle command dispatch is endpoint-isolated and doesn't affect ongoing setpoint streaming
- Online status checks prevent commands to stale endpoints
- State gating ensures commands only apply during `SEARCHING` and `TRACKING` states

<h3>Confidence Score: 4/5</h3>

- This PR is well-tested and implements solid validation logic, with minor considerations around MAVLink timing edge cases
- The implementation demonstrates strong engineering practices with comprehensive test coverage, clear validation logic, and robust error handling. The MAVLink adapter correctly implements ACK-aware command dispatch with retries and heartbeat validation. The service-based architecture is a significant improvement over topic-based commands. Score is 4/5 rather than 5/5 due to timing sensitivities in MAVLink communication (heartbeat validation windows, ACK timeouts) that could exhibit edge-case behavior in production with network latency or vehicle firmware variations
- No files require special attention - the implementation is solid across all changed files

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_msgs/srv/VehicleCommand.srv | Defines new ROS service contract with vehicle_id, command, and mission_id fields |
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py | Adds ACK-aware HOLD/RESUME/RTL command dispatch with retry logic and PX4/ArduPilot heartbeat validation |
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Implements vehicle_command service handler with state gating, online checks, and endpoint-isolated dispatch; modifies abort flow to fan-out RTL to all active scouts |
| software/viewer/src/context/FleetContext.tsx | Migrates from topic-based to service-based vehicle commands with async/await, error tracking, and backward-compatible legacy topic publishing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Fleet UI
    participant FC as FleetContext
    participant ROS as ROS Bridge
    participant MN as Mission Node
    participant MA as MAVLink Adapter
    participant V as Vehicle (MAVLink)

    Note over UI,V: Individual Vehicle Command Flow

    UI->>FC: holdVehicle("scout2")
    FC->>FC: Validate (ROS connected, vehicle_id present)
    FC->>FC: buildVehicleCommandServiceRequest()
    FC->>ROS: callService("vehicle_command", {vehicle_id, command, mission_id})
    
    ROS->>MN: VehicleCommand.Request
    
    Note over MN: Command Validation
    MN->>MN: Normalize command to uppercase
    MN->>MN: Check command in SUPPORTED_VEHICLE_COMMANDS
    MN->>MN: Check state in AUTONOMOUS_STATES
    MN->>MN: Check mission_id matches (if provided)
    
    Note over MN: Target Resolution
    MN->>MN: _normalize_vehicle_id(vehicle_id)
    MN->>MN: _resolve_scout_endpoint(normalized_id)
    MN->>MN: _is_endpoint_online(endpoint)
    
    Note over MN: Dispatch Command
    MN->>MA: set_endpoint(endpoint.host, endpoint.port)
    MN->>MA: send_hold_position()
    
    Note over MA: ACK-Aware Command Send
    MA->>V: COMMAND_LONG (MAV_CMD_DO_PAUSE_CONTINUE, param1=0.0)
    V->>MA: COMMAND_ACK (result=MAV_RESULT_ACCEPTED)
    MA-->>MN: true
    
    MN-->>ROS: VehicleCommand.Response {success=true, message}
    ROS-->>FC: {success: true, message: "..."}
    FC->>FC: Clear commandErrors[vehicle_id]
    FC-->>UI: {success: true, message}
    
    Note over UI,V: Error Flow - Vehicle Offline
    
    UI->>FC: resumeVehicle("scout3")
    FC->>ROS: callService("vehicle_command", ...)
    ROS->>MN: VehicleCommand.Request
    MN->>MN: _is_endpoint_online(endpoint) → false
    MN-->>ROS: VehicleCommand.Response {success=false, message="offline vehicle_id"}
    ROS-->>FC: {success: false, message}
    FC->>FC: setCommandErrors[vehicle_id] = formatted error
    FC-->>UI: {success: false, message}
    UI->>UI: Display error in VehicleCard
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->