### PR TITLE
Add adaptive bitrate video control in mesh agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # Log files
 *.log
+output/
 
 # Verification screenshots
 verification*.png

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/__init__.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/__init__.py
@@ -2,5 +2,6 @@
 
 This package provides ROS 2 nodes for simulating mesh network conditions,
 including impairment relay for lossy links and store-and-forward buffering
-for disconnected scenarios with durable replay metadata.
+for disconnected scenarios with durable replay metadata and adaptive
+video bitrate control.
 """

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py
@@ -47,6 +47,7 @@ class AbrPolicyConfig:
     min_dwell_sec: float = 2.0
     min_downgrade_interval_sec: float = 0.25
     severe_hold_sec: float = 2.0
+    reaction_window_sec: float = 1.0
     allow_video_suspend: bool = True
     severe_floor_profile: str = "V0"
     downgrade_step: int = 1
@@ -139,11 +140,19 @@ class AbrPolicy:
 
     def evaluate(self, sample: LinkHealthSample) -> AbrDecision | None:
         now = float(sample.timestamp_monotonic)
-        severe = self._is_severe(sample)
+        severe_threshold = self._is_severe(sample)
+        severe = severe_threshold
         degraded = severe or self._is_degraded(sample)
-        healthy_for_upgrade = self._is_upgrade_healthy(sample)
-
         self._track_impairment_window(now=now, degraded=degraded)
+        reaction_window_escalation = self._reaction_window_exceeded(
+            now=now,
+            degraded=degraded,
+            severe=severe_threshold,
+        )
+        if reaction_window_escalation:
+            severe = True
+            degraded = True
+        healthy_for_upgrade = self._is_upgrade_healthy(sample)
 
         if self._video_suspended:
             if severe:
@@ -167,11 +176,15 @@ class AbrPolicy:
                     sample=sample,
                     action="switch_profile",
                     to_profile=self._config.severe_floor_profile,
-                    reason="severe-impairment-force-v0",
+                    reason=(
+                        "reaction-window-force-v0"
+                        if reaction_window_escalation
+                        else "severe-impairment-force-v0"
+                    ),
                     degraded=degraded,
                     severe=severe,
                 )
-            if self._config.allow_video_suspend:
+            if self._config.allow_video_suspend and not reaction_window_escalation:
                 severe_elapsed = now - self._severe_started_monotonic
                 if severe_elapsed >= self._config.severe_hold_sec:
                     return self._transition(
@@ -245,6 +258,16 @@ class AbrPolicy:
             return
         self._impairment_started_monotonic = None
         self._impairment_reaction_recorded = True
+
+    def _reaction_window_exceeded(self, *, now: float, degraded: bool, severe: bool) -> bool:
+        if severe or not degraded:
+            return False
+        if self._impairment_started_monotonic is None:
+            return False
+        reaction_window_sec = max(0.0, float(self._config.reaction_window_sec))
+        if reaction_window_sec <= 0.0:
+            return False
+        return (now - self._impairment_started_monotonic) >= reaction_window_sec
 
     def _is_degraded(self, sample: LinkHealthSample) -> bool:
         cfg = self._config

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py
@@ -1,0 +1,351 @@
+"""Deterministic ABR policy primitives for mesh-agent video adaptation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import time
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class AbrTier:
+    """One ladder level that can be applied by the encoder pipeline."""
+
+    name: str
+    resolution: str
+    target_bitrate_kbps: int
+    max_bitrate_kbps: int
+    gop: int
+    fps: int
+
+
+@dataclass(frozen=True)
+class LinkHealthSample:
+    """Point-in-time network health sample consumed by the policy."""
+
+    timestamp_monotonic: float
+    pdr: float | None = None
+    rtt_ms: float | None = None
+    packet_loss: float | None = None
+    throughput_kbps: float | None = None
+    heartbeat_age_sec: float | None = None
+
+
+@dataclass
+class AbrPolicyConfig:
+    """Thresholds and guards for ABR decisions."""
+
+    pdr_degrade_threshold: float = 0.75
+    pdr_severe_threshold: float = 0.35
+    pdr_hysteresis: float = 0.08
+    rtt_degrade_threshold_ms: float = 250.0
+    rtt_severe_threshold_ms: float = 600.0
+    rtt_hysteresis_ms: float = 40.0
+    packet_loss_degrade_threshold: float = 0.10
+    packet_loss_severe_threshold: float = 0.35
+    heartbeat_severe_age_sec: float = 0.90
+    min_dwell_sec: float = 2.0
+    min_downgrade_interval_sec: float = 0.25
+    severe_hold_sec: float = 2.0
+    allow_video_suspend: bool = True
+    severe_floor_profile: str = "V0"
+    downgrade_step: int = 1
+    upgrade_step: int = 1
+
+
+@dataclass(frozen=True)
+class AbrDecision:
+    """A policy transition recommendation."""
+
+    timestamp_monotonic: float
+    action: str
+    from_profile: str
+    to_profile: str
+    reason: str
+    degraded: bool
+    severe: bool
+    decision_latency_ms: float
+    reaction_latency_ms: float | None
+    sample: LinkHealthSample
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        # Flatten nested sample for easier telemetry pipelines.
+        sample = payload.pop("sample")
+        payload["sample"] = sample
+        return payload
+
+
+@dataclass(frozen=True)
+class AbrPolicySnapshot:
+    """Current policy state + counters for observability."""
+
+    current_profile: str
+    video_suspended: bool
+    transition_count: int
+    downgrade_count: int
+    upgrade_count: int
+    severe_floor_entries: int
+    suspend_count: int
+
+
+class AbrPolicy:
+    """Deterministic ABR finite state machine."""
+
+    def __init__(
+        self,
+        *,
+        tiers: list[AbrTier],
+        config: AbrPolicyConfig,
+        now_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not tiers:
+            raise ValueError("ABR policy requires at least one ladder tier")
+        self._tiers = list(tiers)
+        self._tier_index_by_name = {tier.name: idx for idx, tier in enumerate(self._tiers)}
+        self._config = config
+        self._now_fn = now_fn
+        self._current_index = len(self._tiers) - 1
+        self._current_profile = self._tiers[self._current_index].name
+        self._video_suspended = False
+        now = float(self._now_fn())
+        self._last_transition_monotonic = now
+        self._severe_started_monotonic: float | None = None
+        self._impairment_started_monotonic: float | None = None
+        self._impairment_reaction_recorded = True
+        self._transition_count = 0
+        self._downgrade_count = 0
+        self._upgrade_count = 0
+        self._severe_floor_entries = 0
+        self._suspend_count = 0
+
+    @property
+    def config(self) -> AbrPolicyConfig:
+        return self._config
+
+    def reconfigure(self, config: AbrPolicyConfig) -> None:
+        self._config = config
+
+    def snapshot(self) -> AbrPolicySnapshot:
+        return AbrPolicySnapshot(
+            current_profile=self._current_profile,
+            video_suspended=self._video_suspended,
+            transition_count=self._transition_count,
+            downgrade_count=self._downgrade_count,
+            upgrade_count=self._upgrade_count,
+            severe_floor_entries=self._severe_floor_entries,
+            suspend_count=self._suspend_count,
+        )
+
+    def evaluate(self, sample: LinkHealthSample) -> AbrDecision | None:
+        now = float(sample.timestamp_monotonic)
+        severe = self._is_severe(sample)
+        degraded = severe or self._is_degraded(sample)
+        healthy_for_upgrade = self._is_upgrade_healthy(sample)
+
+        self._track_impairment_window(now=now, degraded=degraded)
+
+        if self._video_suspended:
+            if severe:
+                return None
+            return self._transition(
+                now=now,
+                sample=sample,
+                action="resume_video",
+                to_profile=self._config.severe_floor_profile,
+                reason="link-recovered-resume-v0",
+                degraded=degraded,
+                severe=severe,
+            )
+
+        if severe:
+            if self._severe_started_monotonic is None:
+                self._severe_started_monotonic = now
+            if self._current_profile != self._config.severe_floor_profile:
+                return self._transition(
+                    now=now,
+                    sample=sample,
+                    action="switch_profile",
+                    to_profile=self._config.severe_floor_profile,
+                    reason="severe-impairment-force-v0",
+                    degraded=degraded,
+                    severe=severe,
+                )
+            if self._config.allow_video_suspend:
+                severe_elapsed = now - self._severe_started_monotonic
+                if severe_elapsed >= self._config.severe_hold_sec:
+                    return self._transition(
+                        now=now,
+                        sample=sample,
+                        action="suspend_video",
+                        to_profile=self._config.severe_floor_profile,
+                        reason="severe-impairment-suspend-after-v0-hold",
+                        degraded=degraded,
+                        severe=severe,
+                    )
+            return None
+        self._severe_started_monotonic = None
+
+        if self._current_profile == self._config.severe_floor_profile and (
+            self._current_profile not in self._tier_index_by_name
+        ):
+            if healthy_for_upgrade and self._dwell_elapsed(now=now):
+                return self._transition(
+                    now=now,
+                    sample=sample,
+                    action="switch_profile",
+                    to_profile=self._tiers[0].name,
+                    reason="recovered-v0-to-ladder-floor",
+                    degraded=degraded,
+                    severe=severe,
+                )
+            return None
+
+        current_index = self._tier_index_by_name.get(self._current_profile, self._current_index)
+        self._current_index = current_index
+
+        if degraded:
+            if not self._downgrade_interval_elapsed(now=now):
+                return None
+            target_index = max(0, current_index - max(1, int(self._config.downgrade_step)))
+            if target_index != current_index:
+                return self._transition(
+                    now=now,
+                    sample=sample,
+                    action="switch_profile",
+                    to_profile=self._tiers[target_index].name,
+                    reason="link-degraded-step-down",
+                    degraded=degraded,
+                    severe=severe,
+                )
+            return None
+
+        if healthy_for_upgrade and self._dwell_elapsed(now=now):
+            target_index = min(
+                len(self._tiers) - 1, current_index + max(1, int(self._config.upgrade_step))
+            )
+            if target_index != current_index:
+                return self._transition(
+                    now=now,
+                    sample=sample,
+                    action="switch_profile",
+                    to_profile=self._tiers[target_index].name,
+                    reason="link-stable-step-up",
+                    degraded=degraded,
+                    severe=severe,
+                )
+
+        return None
+
+    def _track_impairment_window(self, *, now: float, degraded: bool) -> None:
+        if degraded:
+            if self._impairment_started_monotonic is None:
+                self._impairment_started_monotonic = now
+                self._impairment_reaction_recorded = False
+            return
+        self._impairment_started_monotonic = None
+        self._impairment_reaction_recorded = True
+
+    def _is_degraded(self, sample: LinkHealthSample) -> bool:
+        cfg = self._config
+        if sample.pdr is not None and sample.pdr < cfg.pdr_degrade_threshold:
+            return True
+        if sample.rtt_ms is not None and sample.rtt_ms > cfg.rtt_degrade_threshold_ms:
+            return True
+        if sample.packet_loss is not None and sample.packet_loss > cfg.packet_loss_degrade_threshold:
+            return True
+        return False
+
+    def _is_upgrade_healthy(self, sample: LinkHealthSample) -> bool:
+        cfg = self._config
+        if sample.pdr is not None and sample.pdr < (cfg.pdr_degrade_threshold + cfg.pdr_hysteresis):
+            return False
+        if sample.rtt_ms is not None and sample.rtt_ms > (
+            cfg.rtt_degrade_threshold_ms - cfg.rtt_hysteresis_ms
+        ):
+            return False
+        if (
+            sample.packet_loss is not None
+            and sample.packet_loss > max(cfg.packet_loss_degrade_threshold * 0.5, 0.0)
+        ):
+            return False
+        if sample.heartbeat_age_sec is not None and sample.heartbeat_age_sec > cfg.heartbeat_severe_age_sec:
+            return False
+        return True
+
+    def _is_severe(self, sample: LinkHealthSample) -> bool:
+        cfg = self._config
+        if sample.heartbeat_age_sec is not None and sample.heartbeat_age_sec >= cfg.heartbeat_severe_age_sec:
+            return True
+        if sample.pdr is not None and sample.pdr <= cfg.pdr_severe_threshold:
+            return True
+        if sample.rtt_ms is not None and sample.rtt_ms >= cfg.rtt_severe_threshold_ms:
+            return True
+        if sample.packet_loss is not None and sample.packet_loss >= cfg.packet_loss_severe_threshold:
+            return True
+        return False
+
+    def _dwell_elapsed(self, *, now: float) -> bool:
+        return (now - self._last_transition_monotonic) >= self._config.min_dwell_sec
+
+    def _downgrade_interval_elapsed(self, *, now: float) -> bool:
+        return (now - self._last_transition_monotonic) >= self._config.min_downgrade_interval_sec
+
+    def _transition(
+        self,
+        *,
+        now: float,
+        sample: LinkHealthSample,
+        action: str,
+        to_profile: str,
+        reason: str,
+        degraded: bool,
+        severe: bool,
+    ) -> AbrDecision:
+        from_profile = self._current_profile
+        if action == "suspend_video":
+            self._video_suspended = True
+            self._suspend_count += 1
+        elif action == "resume_video":
+            self._video_suspended = False
+            self._current_profile = to_profile
+            if to_profile in self._tier_index_by_name:
+                self._current_index = self._tier_index_by_name[to_profile]
+        else:
+            self._current_profile = to_profile
+            self._video_suspended = False
+            if to_profile in self._tier_index_by_name:
+                target_index = self._tier_index_by_name[to_profile]
+                if target_index < self._current_index:
+                    self._downgrade_count += 1
+                elif target_index > self._current_index:
+                    self._upgrade_count += 1
+                self._current_index = target_index
+            elif to_profile == self._config.severe_floor_profile:
+                self._severe_floor_entries += 1
+
+        self._transition_count += 1
+        self._last_transition_monotonic = now
+
+        reaction_latency_ms: float | None = None
+        if (
+            self._impairment_started_monotonic is not None
+            and not self._impairment_reaction_recorded
+            and action in {"switch_profile", "resume_video", "suspend_video"}
+        ):
+            reaction_latency_ms = max((now - self._impairment_started_monotonic) * 1000.0, 0.0)
+            self._impairment_reaction_recorded = True
+
+        decision_latency_ms = max((self._now_fn() - sample.timestamp_monotonic) * 1000.0, 0.0)
+        return AbrDecision(
+            timestamp_monotonic=now,
+            action=action,
+            from_profile=from_profile,
+            to_profile=to_profile,
+            reason=reason,
+            degraded=degraded,
+            severe=severe,
+            decision_latency_ms=decision_latency_ms,
+            reaction_latency_ms=reaction_latency_ms,
+            sample=sample,
+        )

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -21,8 +21,25 @@ from .message_envelope import (
     serialize_message_payload,
 )
 from .relay_routing import RelayEnvelope, RelayLatencyTracker, RelayRouteDecision, RelayRouteSelector
+from .abr_policy import AbrPolicyConfig, LinkHealthSample
 from .store_forward_core import ReplayMetadata, StoreForwardController
 from .store_forward_store import StoreForwardStore
+from .video_abr_controller import (
+    EncoderCommand,
+    EncoderTransport,
+    VideoAbrController,
+    VideoAbrControllerConfig,
+)
+
+
+class _RosEncoderTransport(EncoderTransport):
+    """ROS transport adapter for encoder control commands."""
+
+    def __init__(self, *, publisher: Any) -> None:
+        self._publisher = publisher
+
+    def send_command(self, command: EncoderCommand) -> None:
+        self._publisher.publish(String(data=command.to_json()))
 
 
 class StoreForwardTiles(Node):
@@ -58,6 +75,8 @@ class StoreForwardTiles(Node):
             self.declare_parameter("telemetry_output_topic", "telemetry_out").value
         )
         self._pdr_topic = str(self.declare_parameter("pdr_topic", "").value)
+        self._rtt_topic = str(self.declare_parameter("rtt_topic", "").value)
+        self._packet_loss_topic = str(self.declare_parameter("packet_loss_topic", "").value)
         self._vehicle_id = str(self.declare_parameter("vehicle_id", "").value)
         self._source_vehicle_id = str(
             self.declare_parameter("source_vehicle_id", self._vehicle_id).value
@@ -71,6 +90,10 @@ class StoreForwardTiles(Node):
             self.declare_parameter("relay_heartbeat_topic", "").value
         )
         self._relay_pdr_topic = str(self.declare_parameter("relay_pdr_topic", "").value)
+        self._relay_rtt_topic = str(self.declare_parameter("relay_rtt_topic", "").value)
+        self._relay_packet_loss_topic = str(
+            self.declare_parameter("relay_packet_loss_topic", "").value
+        )
         self._relay_heartbeat_timeout_sec = float(
             self.declare_parameter("relay_heartbeat_timeout_sec", 2.0).value
         )
@@ -127,6 +150,68 @@ class StoreForwardTiles(Node):
         self._link_up_override_enabled = bool(
             self.declare_parameter("link_up_override", False).value
         )
+        self._abr_enabled = bool(self.declare_parameter("abr_enabled", True).value)
+        self._abr_ladder_config = str(
+            self.declare_parameter("abr_ladder_config", "software/edge/config/srt/abr_ladder.yaml").value
+        )
+        self._abr_command_topic = str(
+            self.declare_parameter("abr_command_topic", "mesh/video/encoder_profile_cmd").value
+        )
+        self._abr_ack_topic = str(
+            self.declare_parameter("abr_ack_topic", "mesh/video/encoder_profile_ack").value
+        )
+        self._abr_decision_topic = str(
+            self.declare_parameter("abr_decision_topic", "mesh/abr_decisions").value
+        )
+        self._abr_eval_period_sec = float(self.declare_parameter("abr_eval_period_sec", 0.25).value)
+        self._abr_ack_timeout_sec = float(self.declare_parameter("abr_ack_timeout_sec", 0.5).value)
+        self._abr_ack_max_retries = int(self.declare_parameter("abr_ack_max_retries", 2).value)
+        self._abr_reaction_window_sec = float(
+            self.declare_parameter("abr_reaction_window_sec", 1.0).value
+        )
+        self._abr_min_dwell_sec = float(self.declare_parameter("abr_min_dwell_sec", 2.0).value)
+        self._abr_min_downgrade_interval_sec = float(
+            self.declare_parameter("abr_min_downgrade_interval_sec", 0.25).value
+        )
+        self._abr_severe_hold_sec = float(self.declare_parameter("abr_severe_hold_sec", 2.0).value)
+        self._abr_allow_video_suspend = bool(
+            self.declare_parameter("abr_allow_video_suspend", True).value
+        )
+        self._abr_pdr_degrade_threshold = float(
+            self.declare_parameter("abr_pdr_degrade_threshold", 0.75).value
+        )
+        self._abr_pdr_severe_threshold = float(
+            self.declare_parameter("abr_pdr_severe_threshold", 0.35).value
+        )
+        self._abr_pdr_hysteresis = float(self.declare_parameter("abr_pdr_hysteresis", 0.08).value)
+        self._abr_rtt_degrade_threshold_ms = float(
+            self.declare_parameter("abr_rtt_degrade_threshold_ms", 250.0).value
+        )
+        self._abr_rtt_severe_threshold_ms = float(
+            self.declare_parameter("abr_rtt_severe_threshold_ms", 600.0).value
+        )
+        self._abr_rtt_hysteresis_ms = float(
+            self.declare_parameter("abr_rtt_hysteresis_ms", 40.0).value
+        )
+        self._abr_packet_loss_degrade_threshold = float(
+            self.declare_parameter("abr_packet_loss_degrade_threshold", 0.10).value
+        )
+        self._abr_packet_loss_severe_threshold = float(
+            self.declare_parameter("abr_packet_loss_severe_threshold", 0.35).value
+        )
+        self._abr_heartbeat_severe_age_sec = float(
+            self.declare_parameter("abr_heartbeat_severe_age_sec", 0.90).value
+        )
+        self._abr_v0_profile_name = str(self.declare_parameter("abr_v0_profile_name", "V0").value)
+        self._abr_v0_resolution = str(self.declare_parameter("abr_v0_resolution", "320x180").value)
+        self._abr_v0_target_bitrate_kbps = int(
+            self.declare_parameter("abr_v0_target_bitrate_kbps", 220).value
+        )
+        self._abr_v0_max_bitrate_kbps = int(
+            self.declare_parameter("abr_v0_max_bitrate_kbps", 320).value
+        )
+        self._abr_v0_fps = int(self.declare_parameter("abr_v0_fps", 10).value)
+        self._abr_v0_gop = int(self.declare_parameter("abr_v0_gop", 30).value)
 
         self._store = StoreForwardStore(db_path=self._storage_path, max_bytes=self._max_bytes)
         self._controller = StoreForwardController(
@@ -149,6 +234,15 @@ class StoreForwardTiles(Node):
             enabled=self._link_up_override_enabled,
             link_up=self._link_up_override_value,
         )
+        self._latest_direct_pdr: float | None = None
+        self._latest_direct_rtt_ms: float | None = None
+        self._latest_direct_packet_loss: float | None = None
+        self._latest_relay_pdr: float | None = None
+        self._latest_relay_rtt_ms: float | None = None
+        self._latest_relay_packet_loss: float | None = None
+        self._last_direct_heartbeat_monotonic: float | None = None
+        self._last_relay_heartbeat_monotonic: float | None = None
+        self._abr_controller: VideoAbrController | None = None
 
         self._map_publisher = self.create_publisher(MapTile, self._map_output_topic, 10)
         self._detection_publisher = self.create_publisher(
@@ -173,6 +267,8 @@ class StoreForwardTiles(Node):
         self._replay_annotation_publisher = self.create_publisher(
             String, self._replay_annotation_topic, 10
         )
+        self._abr_command_publisher = self.create_publisher(String, self._abr_command_topic, 10)
+        self._abr_decision_publisher = self.create_publisher(String, self._abr_decision_topic, 10)
         self._route_specs: dict[str, tuple[type[Any], Any]] = {
             "map_tile": (MapTile, self._map_publisher),
             "relay_map_tile": (MapTile, self._map_relay_publisher),
@@ -196,6 +292,8 @@ class StoreForwardTiles(Node):
             self._heartbeat_relay_output_topic: (String, self._heartbeat_relay_publisher),
             self._telemetry_relay_output_topic: (Telemetry, self._telemetry_relay_publisher),
         }
+        if self._abr_enabled:
+            self._abr_controller = self._create_abr_controller()
 
         self._map_subscription = self.create_subscription(
             MapTile, self._map_input_topic, self._handle_map_tile, 10
@@ -220,6 +318,16 @@ class StoreForwardTiles(Node):
             self._pdr_subscription = self.create_subscription(
                 Float32, self._pdr_topic, self._handle_pdr, 10
             )
+        self._rtt_subscription = None
+        if self._rtt_topic:
+            self._rtt_subscription = self.create_subscription(
+                Float32, self._rtt_topic, self._handle_rtt, 10
+            )
+        self._packet_loss_subscription = None
+        if self._packet_loss_topic:
+            self._packet_loss_subscription = self.create_subscription(
+                Float32, self._packet_loss_topic, self._handle_packet_loss, 10
+            )
         self._relay_heartbeat_subscription = None
         if self._relay_heartbeat_topic:
             self._relay_heartbeat_subscription = self.create_subscription(
@@ -229,6 +337,21 @@ class StoreForwardTiles(Node):
         if self._relay_pdr_topic:
             self._relay_pdr_subscription = self.create_subscription(
                 Float32, self._relay_pdr_topic, self._handle_relay_pdr, 10
+            )
+        self._relay_rtt_subscription = None
+        if self._relay_rtt_topic:
+            self._relay_rtt_subscription = self.create_subscription(
+                Float32, self._relay_rtt_topic, self._handle_relay_rtt, 10
+            )
+        self._relay_packet_loss_subscription = None
+        if self._relay_packet_loss_topic:
+            self._relay_packet_loss_subscription = self.create_subscription(
+                Float32, self._relay_packet_loss_topic, self._handle_relay_packet_loss, 10
+            )
+        self._abr_ack_subscription = None
+        if self._abr_enabled and self._abr_ack_topic:
+            self._abr_ack_subscription = self.create_subscription(
+                String, self._abr_ack_topic, self._handle_abr_ack, 10
             )
 
         self._relay_map_subscription = None
@@ -262,6 +385,9 @@ class StoreForwardTiles(Node):
             )
 
         self._link_monitor_timer = self.create_timer(0.25, self._sync_connectivity)
+        self._abr_timer = None
+        if self._abr_enabled and self._abr_controller is not None:
+            self._abr_timer = self.create_timer(self._abr_eval_period_sec, self._evaluate_abr)
         self._metrics_timer = self.create_timer(5.0, self._log_metrics)
         self.add_on_set_parameters_callback(self._handle_param_update)
 
@@ -286,9 +412,18 @@ class StoreForwardTiles(Node):
             "relay_telemetry_input_topic",
             "relay_heartbeat_topic",
             "relay_pdr_topic",
+            "rtt_topic",
+            "packet_loss_topic",
+            "relay_rtt_topic",
+            "relay_packet_loss_topic",
             "replay_annotation_topic",
             "pdr_topic",
             "storage_path",
+            "abr_enabled",
+            "abr_ladder_config",
+            "abr_command_topic",
+            "abr_ack_topic",
+            "abr_decision_topic",
         }
 
         for param in params:
@@ -416,10 +551,346 @@ class StoreForwardTiles(Node):
                 )
                 continue
 
+            if param.name == "abr_eval_period_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_eval_period_sec = value
+                if self._abr_controller is not None:
+                    if self._abr_timer is not None:
+                        self._abr_timer.cancel()
+                    self._abr_timer = self.create_timer(
+                        self._abr_eval_period_sec, self._evaluate_abr
+                    )
+                continue
+
+            if param.name == "abr_ack_timeout_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_ack_timeout_sec = value
+                if self._abr_controller is not None:
+                    self._abr_controller.config.ack_timeout_sec = value
+                continue
+
+            if param.name == "abr_ack_max_retries":
+                value = int(param.value)
+                if value < 0:
+                    return SetParametersResult(successful=False)
+                self._abr_ack_max_retries = value
+                if self._abr_controller is not None:
+                    self._abr_controller.config.ack_max_retries = value
+                continue
+
+            if param.name == "abr_reaction_window_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_reaction_window_sec = value
+                if self._abr_controller is not None:
+                    self._abr_controller.config.reaction_window_sec = value
+                continue
+
+            if param.name == "abr_min_dwell_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_min_dwell_sec = value
+                if self._abr_controller is not None:
+                    policy = self._current_abr_policy_config()
+                    self._abr_controller.reconfigure_policy(policy)
+                continue
+
+            if param.name == "abr_min_downgrade_interval_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_min_downgrade_interval_sec = value
+                if self._abr_controller is not None:
+                    policy = self._current_abr_policy_config()
+                    self._abr_controller.reconfigure_policy(policy)
+                continue
+
+            if param.name == "abr_severe_hold_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_severe_hold_sec = value
+                if self._abr_controller is not None:
+                    policy = self._current_abr_policy_config()
+                    self._abr_controller.reconfigure_policy(policy)
+                continue
+
+            if param.name == "abr_allow_video_suspend":
+                self._abr_allow_video_suspend = bool(param.value)
+                if self._abr_controller is not None:
+                    policy = self._current_abr_policy_config()
+                    self._abr_controller.reconfigure_policy(policy)
+                continue
+
+            if param.name == "abr_pdr_degrade_threshold":
+                value = float(param.value)
+                if value < 0.0 or value > 1.0:
+                    return SetParametersResult(successful=False)
+                self._abr_pdr_degrade_threshold = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_pdr_severe_threshold":
+                value = float(param.value)
+                if value < 0.0 or value > 1.0:
+                    return SetParametersResult(successful=False)
+                self._abr_pdr_severe_threshold = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_pdr_hysteresis":
+                value = float(param.value)
+                if value < 0.0 or value > 1.0:
+                    return SetParametersResult(successful=False)
+                self._abr_pdr_hysteresis = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_rtt_degrade_threshold_ms":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_rtt_degrade_threshold_ms = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_rtt_severe_threshold_ms":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_rtt_severe_threshold_ms = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_rtt_hysteresis_ms":
+                value = float(param.value)
+                if value < 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_rtt_hysteresis_ms = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_packet_loss_degrade_threshold":
+                value = float(param.value)
+                if value < 0.0 or value > 1.0:
+                    return SetParametersResult(successful=False)
+                self._abr_packet_loss_degrade_threshold = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_packet_loss_severe_threshold":
+                value = float(param.value)
+                if value < 0.0 or value > 1.0:
+                    return SetParametersResult(successful=False)
+                self._abr_packet_loss_severe_threshold = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_heartbeat_severe_age_sec":
+                value = float(param.value)
+                if value <= 0.0:
+                    return SetParametersResult(successful=False)
+                self._abr_heartbeat_severe_age_sec = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
+                continue
+
+            if param.name == "abr_v0_profile_name":
+                value = str(param.value).strip()
+                if not value:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_profile_name = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
+            if param.name == "abr_v0_resolution":
+                value = str(param.value).strip()
+                if not value:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_resolution = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
+            if param.name == "abr_v0_target_bitrate_kbps":
+                value = int(param.value)
+                if value <= 0:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_target_bitrate_kbps = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
+            if param.name == "abr_v0_max_bitrate_kbps":
+                value = int(param.value)
+                if value <= 0:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_max_bitrate_kbps = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
+            if param.name == "abr_v0_fps":
+                value = int(param.value)
+                if value <= 0:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_fps = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
+            if param.name == "abr_v0_gop":
+                value = int(param.value)
+                if value <= 0:
+                    return SetParametersResult(successful=False)
+                self._abr_v0_gop = value
+                if self._abr_controller is not None:
+                    self._abr_controller.reconfigure_v0_profile(
+                        profile_name=self._abr_v0_profile_name,
+                        resolution=self._abr_v0_resolution,
+                        target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+                        max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+                        fps=self._abr_v0_fps,
+                        gop=self._abr_v0_gop,
+                    )
+                continue
+
             self.get_logger().warning(f"unsupported parameter '{param.name}'")
             return SetParametersResult(successful=False)
 
         return SetParametersResult(successful=True)
+
+    def _current_abr_policy_config(self) -> AbrPolicyConfig:
+        return AbrPolicyConfig(
+            pdr_degrade_threshold=self._abr_pdr_degrade_threshold,
+            pdr_severe_threshold=self._abr_pdr_severe_threshold,
+            pdr_hysteresis=self._abr_pdr_hysteresis,
+            rtt_degrade_threshold_ms=self._abr_rtt_degrade_threshold_ms,
+            rtt_severe_threshold_ms=self._abr_rtt_severe_threshold_ms,
+            rtt_hysteresis_ms=self._abr_rtt_hysteresis_ms,
+            packet_loss_degrade_threshold=self._abr_packet_loss_degrade_threshold,
+            packet_loss_severe_threshold=self._abr_packet_loss_severe_threshold,
+            heartbeat_severe_age_sec=self._abr_heartbeat_severe_age_sec,
+            min_dwell_sec=self._abr_min_dwell_sec,
+            min_downgrade_interval_sec=self._abr_min_downgrade_interval_sec,
+            severe_hold_sec=self._abr_severe_hold_sec,
+            allow_video_suspend=self._abr_allow_video_suspend,
+            severe_floor_profile=self._abr_v0_profile_name,
+        )
+
+    def _create_abr_controller(self) -> VideoAbrController:
+        config = VideoAbrControllerConfig(
+            ack_timeout_sec=self._abr_ack_timeout_sec,
+            ack_max_retries=self._abr_ack_max_retries,
+            reaction_window_sec=self._abr_reaction_window_sec,
+            v0_profile_name=self._abr_v0_profile_name,
+            v0_resolution=self._abr_v0_resolution,
+            v0_target_bitrate_kbps=self._abr_v0_target_bitrate_kbps,
+            v0_max_bitrate_kbps=self._abr_v0_max_bitrate_kbps,
+            v0_fps=self._abr_v0_fps,
+            v0_gop=self._abr_v0_gop,
+            policy=self._current_abr_policy_config(),
+        )
+        try:
+            controller = VideoAbrController(
+                ladder_path=self._abr_ladder_config,
+                config=config,
+                transport=_RosEncoderTransport(publisher=self._abr_command_publisher),
+            )
+        except Exception as exc:
+            raise RuntimeError(f"failed to initialize ABR ladder/controller: {exc}") from exc
+        return controller
+
+    def _active_link_health_sample(self) -> tuple[LinkHealthSample, RelayRouteDecision]:
+        decision = self._select_route_decision()
+        now = time.monotonic()
+        use_relay = decision.delivery_mode == "relay"
+        pdr = self._latest_relay_pdr if use_relay else self._latest_direct_pdr
+        rtt_ms = self._latest_relay_rtt_ms if use_relay else self._latest_direct_rtt_ms
+        packet_loss = (
+            self._latest_relay_packet_loss if use_relay else self._latest_direct_packet_loss
+        )
+        heartbeat_ts = (
+            self._last_relay_heartbeat_monotonic if use_relay else self._last_direct_heartbeat_monotonic
+        )
+        heartbeat_age_sec = None
+        if heartbeat_ts is not None:
+            heartbeat_age_sec = max(0.0, now - heartbeat_ts)
+        sample = LinkHealthSample(
+            timestamp_monotonic=now,
+            pdr=pdr,
+            rtt_ms=rtt_ms,
+            packet_loss=packet_loss,
+            throughput_kbps=None,
+            heartbeat_age_sec=heartbeat_age_sec,
+        )
+        return sample, decision
+
+    def _evaluate_abr(self) -> None:
+        if self._abr_controller is None:
+            return
+        sample, route = self._active_link_health_sample()
+        decision_payload = self._abr_controller.evaluate(sample)
+        self._abr_controller.tick()
+        if decision_payload is None:
+            return
+
+        decision_payload["active_route"] = route.delivery_mode
+        decision_payload["active_route_reason"] = route.reason
+        decision_payload["active_link_up"] = route.selected_link_up
+        self._abr_decision_publisher.publish(
+            String(data=json.dumps(decision_payload, separators=(",", ":")))
+        )
 
     def _handle_map_tile(self, msg: MapTile) -> None:
         self._handle_outbound(
@@ -449,10 +920,12 @@ class StoreForwardTiles(Node):
         )
 
     def _handle_connectivity_heartbeat(self, _msg: String) -> None:
+        self._last_direct_heartbeat_monotonic = time.monotonic()
         self._controller.connectivity.observe_heartbeat()
         self._route_selector.observe_direct_heartbeat()
 
     def _handle_relay_connectivity_heartbeat(self, _msg: String) -> None:
+        self._last_relay_heartbeat_monotonic = time.monotonic()
         self._route_selector.observe_relay_heartbeat()
 
     def _handle_telemetry(self, msg: Telemetry) -> None:
@@ -465,11 +938,38 @@ class StoreForwardTiles(Node):
         )
 
     def _handle_pdr(self, msg: Float32) -> None:
-        self._controller.connectivity.observe_pdr(float(msg.data))
-        self._route_selector.observe_direct_pdr(float(msg.data))
+        value = float(msg.data)
+        self._latest_direct_pdr = value
+        self._controller.connectivity.observe_pdr(value)
+        self._route_selector.observe_direct_pdr(value)
 
     def _handle_relay_pdr(self, msg: Float32) -> None:
-        self._route_selector.observe_relay_pdr(float(msg.data))
+        value = float(msg.data)
+        self._latest_relay_pdr = value
+        self._route_selector.observe_relay_pdr(value)
+
+    def _handle_rtt(self, msg: Float32) -> None:
+        self._latest_direct_rtt_ms = float(msg.data)
+
+    def _handle_relay_rtt(self, msg: Float32) -> None:
+        self._latest_relay_rtt_ms = float(msg.data)
+
+    def _handle_packet_loss(self, msg: Float32) -> None:
+        self._latest_direct_packet_loss = float(msg.data)
+
+    def _handle_relay_packet_loss(self, msg: Float32) -> None:
+        self._latest_relay_packet_loss = float(msg.data)
+
+    def _handle_abr_ack(self, msg: String) -> None:
+        if self._abr_controller is None:
+            return
+        try:
+            accepted = self._abr_controller.observe_encoder_ack(msg.data)
+        except ValueError:
+            self.get_logger().warning("invalid ABR ack payload; ignoring")
+            return
+        if not accepted:
+            self.get_logger().debug("received ABR ack for unknown/stale command")
 
     def _handle_map_tile_relay_ingress(self, msg: MapTile) -> None:
         self._handle_outbound(
@@ -838,6 +1338,21 @@ class StoreForwardTiles(Node):
         relay_snapshot = self._relay_latency.snapshot()
         current_route = self._select_route_decision()
         link_state = "up" if self._controller.connectivity.is_link_up() else "down"
+        abr_snapshot = self._abr_controller.snapshot() if self._abr_controller is not None else None
+        abr_summary = "abr=disabled"
+        if abr_snapshot is not None:
+            abr_summary = (
+                f"abr_profile={abr_snapshot.current_profile} "
+                f"abr_suspended={abr_snapshot.video_suspended} "
+                f"abr_transitions={abr_snapshot.transition_count} "
+                f"abr_down={abr_snapshot.downgrade_count} "
+                f"abr_up={abr_snapshot.upgrade_count} "
+                f"abr_v0={abr_snapshot.severe_floor_entries} "
+                f"abr_suspend={abr_snapshot.suspend_count} "
+                f"abr_cmd_failures={abr_snapshot.command_failures} "
+                f"abr_reaction_p50_ms={abr_snapshot.reaction_latency_p50_ms:.1f} "
+                f"abr_reaction_p95_ms={abr_snapshot.reaction_latency_p95_ms:.1f}"
+            )
         self.get_logger().info(
             "store-forward metrics "
             f"link={link_state} queued={metrics.queued_count} "
@@ -858,7 +1373,8 @@ class StoreForwardTiles(Node):
             f"relay_latency_p50={relay_snapshot.relay_latency_p50_sec:.3f}s "
             f"relay_latency_p95={relay_snapshot.relay_latency_p95_sec:.3f}s "
             f"replay_lag_p50={relay_snapshot.replay_lag_p50_sec:.3f}s "
-            f"replay_lag_p95={relay_snapshot.replay_lag_p95_sec:.3f}s"
+            f"replay_lag_p95={relay_snapshot.replay_lag_p95_sec:.3f}s "
+            f"{abr_summary}"
         )
 
     def destroy_node(self) -> bool:

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import time
 from typing import Any
 
@@ -152,7 +153,9 @@ class StoreForwardTiles(Node):
         )
         self._abr_enabled = bool(self.declare_parameter("abr_enabled", True).value)
         self._abr_ladder_config = str(
-            self.declare_parameter("abr_ladder_config", "software/edge/config/srt/abr_ladder.yaml").value
+            self.declare_parameter(
+                "abr_ladder_config", "software/edge/config/srt/abr_ladder.yaml"
+            ).value
         )
         self._abr_command_topic = str(
             self.declare_parameter("abr_command_topic", "mesh/video/encoder_profile_cmd").value
@@ -419,7 +422,6 @@ class StoreForwardTiles(Node):
             "replay_annotation_topic",
             "pdr_topic",
             "storage_path",
-            "abr_enabled",
             "abr_ladder_config",
             "abr_command_topic",
             "abr_ack_topic",
@@ -551,6 +553,21 @@ class StoreForwardTiles(Node):
                 )
                 continue
 
+            if param.name == "abr_enabled":
+                desired = bool(param.value)
+                if desired == self._abr_enabled:
+                    continue
+                if desired:
+                    try:
+                        self._enable_abr_runtime()
+                    except RuntimeError as exc:
+                        self.get_logger().error(str(exc))
+                        return SetParametersResult(successful=False)
+                else:
+                    self._disable_abr_runtime()
+                self._abr_enabled = desired
+                continue
+
             if param.name == "abr_eval_period_sec":
                 value = float(param.value)
                 if value <= 0.0:
@@ -570,7 +587,7 @@ class StoreForwardTiles(Node):
                     return SetParametersResult(successful=False)
                 self._abr_ack_timeout_sec = value
                 if self._abr_controller is not None:
-                    self._abr_controller.config.ack_timeout_sec = value
+                    self._abr_controller.update_ack_timeout(value)
                 continue
 
             if param.name == "abr_ack_max_retries":
@@ -589,6 +606,7 @@ class StoreForwardTiles(Node):
                 self._abr_reaction_window_sec = value
                 if self._abr_controller is not None:
                     self._abr_controller.config.reaction_window_sec = value
+                    self._abr_controller.reconfigure_policy(self._current_abr_policy_config())
                 continue
 
             if param.name == "abr_min_dwell_sec":
@@ -824,11 +842,56 @@ class StoreForwardTiles(Node):
             min_dwell_sec=self._abr_min_dwell_sec,
             min_downgrade_interval_sec=self._abr_min_downgrade_interval_sec,
             severe_hold_sec=self._abr_severe_hold_sec,
+            reaction_window_sec=self._abr_reaction_window_sec,
             allow_video_suspend=self._abr_allow_video_suspend,
             severe_floor_profile=self._abr_v0_profile_name,
         )
 
+    def _resolve_abr_ladder_path(self, configured_path: str) -> str:
+        configured = Path(configured_path).expanduser()
+        candidates: list[Path] = []
+        if configured.is_absolute():
+            candidates.append(configured)
+        else:
+            candidates.append(Path.cwd() / configured)
+            # Source-tree fallback for local development.
+            edge_root = Path(__file__).resolve().parents[3]
+            candidates.append(edge_root / "config" / "srt" / configured.name)
+
+        # Installed-package fallback for ROS deployments.
+        try:
+            from ament_index_python.packages import get_package_share_directory
+        except ImportError:
+            get_package_share_directory = None
+
+        if get_package_share_directory is not None:
+            try:
+                share_dir = Path(get_package_share_directory("aeris_mesh_agent"))
+                candidates.append(share_dir / "config" / "srt" / configured.name)
+            except Exception:
+                pass
+
+        seen: set[str] = set()
+        unique_candidates: list[Path] = []
+        for candidate in candidates:
+            normalized = str(candidate.resolve(strict=False))
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            unique_candidates.append(candidate)
+
+        for candidate in unique_candidates:
+            if candidate.is_file():
+                return str(candidate.resolve())
+
+        tried = ", ".join(str(path.resolve(strict=False)) for path in unique_candidates)
+        raise RuntimeError(
+            "ABR ladder config not found. Configure 'abr_ladder_config' with an absolute path. "
+            f"Tried: {tried}"
+        )
+
     def _create_abr_controller(self) -> VideoAbrController:
+        ladder_path = self._resolve_abr_ladder_path(self._abr_ladder_config)
         config = VideoAbrControllerConfig(
             ack_timeout_sec=self._abr_ack_timeout_sec,
             ack_max_retries=self._abr_ack_max_retries,
@@ -843,13 +906,33 @@ class StoreForwardTiles(Node):
         )
         try:
             controller = VideoAbrController(
-                ladder_path=self._abr_ladder_config,
+                ladder_path=ladder_path,
                 config=config,
                 transport=_RosEncoderTransport(publisher=self._abr_command_publisher),
             )
         except Exception as exc:
             raise RuntimeError(f"failed to initialize ABR ladder/controller: {exc}") from exc
         return controller
+
+    def _enable_abr_runtime(self) -> None:
+        if self._abr_controller is None:
+            self._abr_controller = self._create_abr_controller()
+        if self._abr_ack_subscription is None and self._abr_ack_topic:
+            self._abr_ack_subscription = self.create_subscription(
+                String, self._abr_ack_topic, self._handle_abr_ack, 10
+            )
+        if self._abr_timer is None:
+            self._abr_timer = self.create_timer(self._abr_eval_period_sec, self._evaluate_abr)
+
+    def _disable_abr_runtime(self) -> None:
+        if self._abr_timer is not None:
+            self._abr_timer.cancel()
+            self.destroy_timer(self._abr_timer)
+            self._abr_timer = None
+        if self._abr_ack_subscription is not None:
+            self.destroy_subscription(self._abr_ack_subscription)
+            self._abr_ack_subscription = None
+        self._abr_controller = None
 
     def _active_link_health_sample(self) -> tuple[LinkHealthSample, RelayRouteDecision]:
         decision = self._select_route_decision()
@@ -968,8 +1051,16 @@ class StoreForwardTiles(Node):
         except ValueError:
             self.get_logger().warning("invalid ABR ack payload; ignoring")
             return
-        if not accepted:
-            self.get_logger().debug("received ABR ack for unknown/stale command")
+        if accepted:
+            return
+        ack_command_id, ack_status, matched_pending = self._abr_controller.last_ack_details()
+        if matched_pending and ack_status and ack_status != "ok":
+            self.get_logger().warning(
+                "encoder rejected ABR command "
+                f"(command_id={ack_command_id}, status={ack_status}); retrying"
+            )
+            return
+        self.get_logger().debug("received ABR ack for unknown/stale command")
 
     def _handle_map_tile_relay_ingress(self, msg: MapTile) -> None:
         self._handle_outbound(

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -868,8 +868,11 @@ class StoreForwardTiles(Node):
             try:
                 share_dir = Path(get_package_share_directory("aeris_mesh_agent"))
                 candidates.append(share_dir / "config" / "srt" / configured.name)
-            except Exception:
-                pass
+            except Exception as exc:
+                self.get_logger().debug(
+                    "skipping aeris_mesh_agent share-dir ladder fallback: "
+                    f"{type(exc).__name__}: {exc}"
+                )
 
         seen: set[str] = set()
         unique_candidates: list[Path] = []

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
@@ -110,7 +110,13 @@ class EncoderAck:
         raw = json.loads(payload) if isinstance(payload, str) else payload
         if not isinstance(raw, dict):
             raise ValueError("encoder ack payload must be a JSON object")
-        command_id = int(raw.get("command_id"))
+        command_id_raw = raw.get("command_id")
+        if command_id_raw is None:
+            raise ValueError("encoder ack is missing command_id")
+        try:
+            command_id = int(command_id_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("encoder ack command_id is invalid") from exc
         profile_name = str(raw.get("profile_name", "")).strip()
         applied_at_ts = float(raw.get("applied_at_ts", time.time()))
         status = str(raw.get("status", "ok")).strip().lower() or "ok"
@@ -148,7 +154,7 @@ class EncoderTransport(Protocol):
     """Encoder command transport contract."""
 
     def send_command(self, command: EncoderCommand) -> None:
-        ...
+        pass
 
 
 @dataclass
@@ -178,6 +184,7 @@ class VideoAbrController:
         self._tier_by_name, tiers = self.load_ladder_tiers(ladder_path)
         if self._config.policy.severe_floor_profile != self._config.v0_profile_name:
             self._config.policy.severe_floor_profile = self._config.v0_profile_name
+        self._config.policy.reaction_window_sec = self._config.reaction_window_sec
 
         self._policy = AbrPolicy(tiers=tiers, config=self._config.policy, now_fn=self._now_mono_fn)
         self._pending_command: _PendingCommand | None = None
@@ -185,6 +192,9 @@ class VideoAbrController:
         self._command_failures = 0
         self._decision_latencies_ms: list[float] = []
         self._reaction_latencies_ms: list[float] = []
+        self._last_ack_command_id: int | None = None
+        self._last_ack_status: str | None = None
+        self._last_ack_matched_pending = False
 
     @property
     def config(self) -> VideoAbrControllerConfig:
@@ -255,8 +265,26 @@ class VideoAbrController:
     def reconfigure_policy(self, config: AbrPolicyConfig) -> None:
         if config.severe_floor_profile != self._config.v0_profile_name:
             config.severe_floor_profile = self._config.v0_profile_name
+        self._config.reaction_window_sec = float(config.reaction_window_sec)
         self._config.policy = config
         self._policy.reconfigure(config)
+
+    def update_ack_timeout(self, timeout_sec: float) -> None:
+        self._config.ack_timeout_sec = timeout_sec
+        if self._pending_command is None:
+            return
+        self._pending_command = _PendingCommand(
+            command=self._pending_command.command,
+            retries=self._pending_command.retries,
+            deadline_monotonic=self._next_ack_deadline(),
+        )
+
+    def last_ack_details(self) -> tuple[int | None, str | None, bool]:
+        return (
+            self._last_ack_command_id,
+            self._last_ack_status,
+            self._last_ack_matched_pending,
+        )
 
     def reconfigure_v0_profile(
         self,
@@ -289,12 +317,27 @@ class VideoAbrController:
 
     def observe_encoder_ack(self, payload: str | dict[str, object]) -> bool:
         ack = EncoderAck.from_payload(payload)
-        if self._pending_command is None:
+        self._last_ack_command_id = ack.command_id
+        self._last_ack_status = ack.status
+        pending = self._pending_command
+        if pending is None:
+            self._last_ack_matched_pending = False
             return False
-        if ack.command_id != self._pending_command.command.command_id:
+        if ack.command_id != pending.command.command_id:
+            self._last_ack_matched_pending = False
             return False
-        self._pending_command = None
-        return ack.status == "ok"
+        self._last_ack_matched_pending = True
+        if ack.status == "ok":
+            self._pending_command = None
+            return True
+        # Rejected acks are actionable failures: keep the command pending and
+        # trigger immediate retry processing on the next tick/evaluate cycle.
+        self._pending_command = _PendingCommand(
+            command=pending.command,
+            retries=pending.retries,
+            deadline_monotonic=self._now_mono_fn(),
+        )
+        return False
 
     def tick(self) -> None:
         self._process_pending_timeout()
@@ -392,7 +435,7 @@ class VideoAbrController:
         self._pending_command = _PendingCommand(
             command=command,
             retries=0,
-            deadline_monotonic=self._now_mono_fn() + max(0.05, self._config.ack_timeout_sec),
+            deadline_monotonic=self._next_ack_deadline(),
         )
 
     def _process_pending_timeout(self) -> None:
@@ -404,7 +447,28 @@ class VideoAbrController:
 
         if pending.retries >= max(0, int(self._config.ack_max_retries)):
             self._command_failures += 1
-            self._pending_command = None
+            # Do not abandon adaptation after retry exhaustion; keep retrying in
+            # bounded cycles so severe-floor commands eventually apply.
+            retried = EncoderCommand(
+                command_id=pending.command.command_id,
+                action=pending.command.action,
+                profile_name=pending.command.profile_name,
+                request_ts=pending.command.request_ts,
+                reason=pending.command.reason,
+                width=pending.command.width,
+                height=pending.command.height,
+                fps=pending.command.fps,
+                gop=pending.command.gop,
+                target_bitrate_kbps=pending.command.target_bitrate_kbps,
+                max_bitrate_kbps=pending.command.max_bitrate_kbps,
+                retry_count=pending.command.retry_count + 1,
+            )
+            self._transport.send_command(retried)
+            self._pending_command = _PendingCommand(
+                command=retried,
+                retries=0,
+                deadline_monotonic=self._next_ack_deadline(),
+            )
             return
 
         retried = EncoderCommand(
@@ -425,8 +489,11 @@ class VideoAbrController:
         self._pending_command = _PendingCommand(
             command=retried,
             retries=pending.retries + 1,
-            deadline_monotonic=self._now_mono_fn() + max(0.05, self._config.ack_timeout_sec),
+            deadline_monotonic=self._next_ack_deadline(),
         )
+
+    def _next_ack_deadline(self) -> float:
+        return self._now_mono_fn() + max(0.05, self._config.ack_timeout_sec)
 
     @staticmethod
     def _percentile(values: list[float], percentile: int) -> float:
@@ -437,5 +504,5 @@ class VideoAbrController:
         clipped = max(0.0, min(100.0, float(percentile))) / 100.0
         # Deterministic quantile estimate for short windows.
         sorted_values = sorted(float(v) for v in values)
-        index = int(round((len(sorted_values) - 1) * clipped))
+        index = round((len(sorted_values) - 1) * clipped)
         return float(sorted_values[index])

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
@@ -118,7 +118,14 @@ class EncoderAck:
         except (TypeError, ValueError) as exc:
             raise ValueError("encoder ack command_id is invalid") from exc
         profile_name = str(raw.get("profile_name", "")).strip()
-        applied_at_ts = float(raw.get("applied_at_ts", time.time()))
+        applied_raw = raw.get("applied_at_ts")
+        if applied_raw is None:
+            applied_at_ts = time.time()
+        else:
+            try:
+                applied_at_ts = float(applied_raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("encoder ack applied_at_ts is invalid") from exc
         status = str(raw.get("status", "ok")).strip().lower() or "ok"
         if not profile_name:
             raise ValueError("encoder ack is missing profile_name")

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
@@ -1,0 +1,441 @@
+"""Runtime ABR controller that parses ladder config and drives encoder commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import re
+import time
+from typing import Callable, Protocol
+
+import yaml
+
+from .abr_policy import (
+    AbrDecision,
+    AbrPolicy,
+    AbrPolicyConfig,
+    AbrTier,
+    LinkHealthSample,
+)
+
+_RESOLUTION_RE = re.compile(r"^\s*(\d+)x(\d+)\s*$")
+
+
+@dataclass(frozen=True)
+class EncoderProfile:
+    """Encoder profile payload resolved from ABR ladder tier."""
+
+    name: str
+    width: int
+    height: int
+    fps: int
+    gop: int
+    target_bitrate_kbps: int
+    max_bitrate_kbps: int
+
+    @property
+    def resolution(self) -> str:
+        return f"{self.width}x{self.height}"
+
+
+@dataclass
+class VideoAbrControllerConfig:
+    """Controller-level settings including retries + V0 profile behavior."""
+
+    ack_timeout_sec: float = 0.5
+    ack_max_retries: int = 2
+    reaction_window_sec: float = 1.0
+    v0_profile_name: str = "V0"
+    v0_resolution: str = "320x180"
+    v0_target_bitrate_kbps: int = 220
+    v0_max_bitrate_kbps: int = 320
+    v0_fps: int = 10
+    v0_gop: int = 30
+    policy: AbrPolicyConfig = field(default_factory=AbrPolicyConfig)
+
+
+@dataclass(frozen=True)
+class EncoderCommand:
+    """Command sent from ABR to encoder/video subsystem."""
+
+    command_id: int
+    action: str
+    profile_name: str
+    request_ts: float
+    reason: str
+    width: int | None = None
+    height: int | None = None
+    fps: int | None = None
+    gop: int | None = None
+    target_bitrate_kbps: int | None = None
+    max_bitrate_kbps: int | None = None
+    retry_count: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "command_id": self.command_id,
+            "action": self.action,
+            "profile_name": self.profile_name,
+            "request_ts": self.request_ts,
+            "reason": self.reason,
+            "resolution": (
+                None
+                if self.width is None or self.height is None
+                else f"{self.width}x{self.height}"
+            ),
+            "width": self.width,
+            "height": self.height,
+            "fps": self.fps,
+            "gop": self.gop,
+            "target_bitrate_kbps": self.target_bitrate_kbps,
+            "max_bitrate_kbps": self.max_bitrate_kbps,
+            "retry_count": self.retry_count,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class EncoderAck:
+    """Encoder profile application acknowledgement."""
+
+    command_id: int
+    profile_name: str
+    applied_at_ts: float
+    status: str = "ok"
+
+    @staticmethod
+    def from_payload(payload: str | dict[str, object]) -> "EncoderAck":
+        raw = json.loads(payload) if isinstance(payload, str) else payload
+        if not isinstance(raw, dict):
+            raise ValueError("encoder ack payload must be a JSON object")
+        command_id = int(raw.get("command_id"))
+        profile_name = str(raw.get("profile_name", "")).strip()
+        applied_at_ts = float(raw.get("applied_at_ts", time.time()))
+        status = str(raw.get("status", "ok")).strip().lower() or "ok"
+        if not profile_name:
+            raise ValueError("encoder ack is missing profile_name")
+        return EncoderAck(
+            command_id=command_id,
+            profile_name=profile_name,
+            applied_at_ts=applied_at_ts,
+            status=status,
+        )
+
+
+@dataclass(frozen=True)
+class VideoAbrSnapshot:
+    """Combined ABR policy/controller snapshot."""
+
+    current_profile: str
+    video_suspended: bool
+    pending_command_id: int | None
+    pending_retry_count: int
+    transition_count: int
+    downgrade_count: int
+    upgrade_count: int
+    severe_floor_entries: int
+    suspend_count: int
+    command_failures: int
+    decision_latency_p50_ms: float
+    decision_latency_p95_ms: float
+    reaction_latency_p50_ms: float
+    reaction_latency_p95_ms: float
+
+
+class EncoderTransport(Protocol):
+    """Encoder command transport contract."""
+
+    def send_command(self, command: EncoderCommand) -> None:
+        ...
+
+
+@dataclass
+class _PendingCommand:
+    command: EncoderCommand
+    retries: int
+    deadline_monotonic: float
+
+
+class VideoAbrController:
+    """Orchestrates ABR policy decisions and encoder command reliability."""
+
+    def __init__(
+        self,
+        *,
+        ladder_path: str,
+        config: VideoAbrControllerConfig,
+        transport: EncoderTransport,
+        now_mono_fn: Callable[[], float] = time.monotonic,
+        now_wall_fn: Callable[[], float] = time.time,
+    ) -> None:
+        self._config = config
+        self._now_mono_fn = now_mono_fn
+        self._now_wall_fn = now_wall_fn
+        self._transport = transport
+
+        self._tier_by_name, tiers = self.load_ladder_tiers(ladder_path)
+        if self._config.policy.severe_floor_profile != self._config.v0_profile_name:
+            self._config.policy.severe_floor_profile = self._config.v0_profile_name
+
+        self._policy = AbrPolicy(tiers=tiers, config=self._config.policy, now_fn=self._now_mono_fn)
+        self._pending_command: _PendingCommand | None = None
+        self._next_command_id = 1
+        self._command_failures = 0
+        self._decision_latencies_ms: list[float] = []
+        self._reaction_latencies_ms: list[float] = []
+
+    @property
+    def config(self) -> VideoAbrControllerConfig:
+        return self._config
+
+    @staticmethod
+    def load_ladder_tiers(path: str) -> tuple[dict[str, EncoderProfile], list[AbrTier]]:
+        with open(path, "r", encoding="utf-8") as fp:
+            raw = yaml.safe_load(fp)
+
+        if not isinstance(raw, dict):
+            raise ValueError("ABR ladder config must be a mapping")
+        ladder = raw.get("ladder")
+        if not isinstance(ladder, list) or not ladder:
+            raise ValueError("ABR ladder config requires a non-empty 'ladder' list")
+
+        tier_by_name: dict[str, EncoderProfile] = {}
+        abr_tiers: list[AbrTier] = []
+        previous_target = -1
+        for idx, item in enumerate(ladder):
+            if not isinstance(item, dict):
+                raise ValueError(f"invalid ladder tier at index {idx}: expected map")
+            name = str(item.get("name", "")).strip()
+            resolution = str(item.get("resolution", "")).strip()
+            match = _RESOLUTION_RE.match(resolution)
+            if not name or not match:
+                raise ValueError(f"invalid ladder tier '{name or idx}': missing name/resolution")
+            width = int(match.group(1))
+            height = int(match.group(2))
+            target = int(item.get("target_bitrate_kbps", 0))
+            max_bitrate = int(item.get("max_bitrate_kbps", 0))
+            gop = int(item.get("gop", 0))
+            fps = int(item.get("fps", 0))
+            if target <= 0 or max_bitrate <= 0 or gop <= 0 or fps <= 0:
+                raise ValueError(f"invalid ladder tier '{name}': non-positive numeric value")
+            if target > max_bitrate:
+                raise ValueError(f"invalid ladder tier '{name}': target bitrate > max bitrate")
+            if target <= previous_target:
+                raise ValueError(
+                    "ABR ladder target_bitrate_kbps values must be strictly increasing"
+                )
+            previous_target = target
+            if name in tier_by_name:
+                raise ValueError(f"duplicate ABR tier name: {name}")
+
+            profile = EncoderProfile(
+                name=name,
+                width=width,
+                height=height,
+                fps=fps,
+                gop=gop,
+                target_bitrate_kbps=target,
+                max_bitrate_kbps=max_bitrate,
+            )
+            tier_by_name[name] = profile
+            abr_tiers.append(
+                AbrTier(
+                    name=name,
+                    resolution=profile.resolution,
+                    target_bitrate_kbps=target,
+                    max_bitrate_kbps=max_bitrate,
+                    gop=gop,
+                    fps=fps,
+                )
+            )
+        return tier_by_name, abr_tiers
+
+    def reconfigure_policy(self, config: AbrPolicyConfig) -> None:
+        if config.severe_floor_profile != self._config.v0_profile_name:
+            config.severe_floor_profile = self._config.v0_profile_name
+        self._config.policy = config
+        self._policy.reconfigure(config)
+
+    def reconfigure_v0_profile(
+        self,
+        *,
+        profile_name: str,
+        resolution: str,
+        target_bitrate_kbps: int,
+        max_bitrate_kbps: int,
+        fps: int,
+        gop: int,
+    ) -> None:
+        match = _RESOLUTION_RE.match(str(resolution).strip())
+        if match is None:
+            raise ValueError("invalid V0 resolution; expected WIDTHxHEIGHT")
+        if target_bitrate_kbps <= 0 or max_bitrate_kbps <= 0:
+            raise ValueError("V0 bitrate values must be positive")
+        if target_bitrate_kbps > max_bitrate_kbps:
+            raise ValueError("V0 target bitrate must be <= max bitrate")
+        if fps <= 0 or gop <= 0:
+            raise ValueError("V0 fps/gop must be positive")
+
+        self._config.v0_profile_name = profile_name
+        self._config.v0_resolution = f"{int(match.group(1))}x{int(match.group(2))}"
+        self._config.v0_target_bitrate_kbps = int(target_bitrate_kbps)
+        self._config.v0_max_bitrate_kbps = int(max_bitrate_kbps)
+        self._config.v0_fps = int(fps)
+        self._config.v0_gop = int(gop)
+        self._config.policy.severe_floor_profile = profile_name
+        self._policy.reconfigure(self._config.policy)
+
+    def observe_encoder_ack(self, payload: str | dict[str, object]) -> bool:
+        ack = EncoderAck.from_payload(payload)
+        if self._pending_command is None:
+            return False
+        if ack.command_id != self._pending_command.command.command_id:
+            return False
+        self._pending_command = None
+        return ack.status == "ok"
+
+    def tick(self) -> None:
+        self._process_pending_timeout()
+
+    def evaluate(self, sample: LinkHealthSample) -> dict[str, object] | None:
+        self._process_pending_timeout()
+        decision = self._policy.evaluate(sample)
+        if decision is None:
+            return None
+
+        self._record_latencies(decision)
+        command = self._build_command(decision)
+        self._send_command(command)
+        payload = decision.to_dict()
+        payload["command"] = command.to_dict()
+        return payload
+
+    def snapshot(self) -> VideoAbrSnapshot:
+        policy_snapshot = self._policy.snapshot()
+        pending_id = None
+        pending_retry_count = 0
+        if self._pending_command is not None:
+            pending_id = self._pending_command.command.command_id
+            pending_retry_count = self._pending_command.retries
+
+        return VideoAbrSnapshot(
+            current_profile=policy_snapshot.current_profile,
+            video_suspended=policy_snapshot.video_suspended,
+            pending_command_id=pending_id,
+            pending_retry_count=pending_retry_count,
+            transition_count=policy_snapshot.transition_count,
+            downgrade_count=policy_snapshot.downgrade_count,
+            upgrade_count=policy_snapshot.upgrade_count,
+            severe_floor_entries=policy_snapshot.severe_floor_entries,
+            suspend_count=policy_snapshot.suspend_count,
+            command_failures=self._command_failures,
+            decision_latency_p50_ms=self._percentile(self._decision_latencies_ms, 50),
+            decision_latency_p95_ms=self._percentile(self._decision_latencies_ms, 95),
+            reaction_latency_p50_ms=self._percentile(self._reaction_latencies_ms, 50),
+            reaction_latency_p95_ms=self._percentile(self._reaction_latencies_ms, 95),
+        )
+
+    def _record_latencies(self, decision: AbrDecision) -> None:
+        if decision.decision_latency_ms >= 0.0:
+            self._decision_latencies_ms.append(decision.decision_latency_ms)
+            if len(self._decision_latencies_ms) > 512:
+                self._decision_latencies_ms = self._decision_latencies_ms[-512:]
+        if decision.reaction_latency_ms is not None and decision.reaction_latency_ms >= 0.0:
+            self._reaction_latencies_ms.append(decision.reaction_latency_ms)
+            if len(self._reaction_latencies_ms) > 512:
+                self._reaction_latencies_ms = self._reaction_latencies_ms[-512:]
+
+    def _build_command(self, decision: AbrDecision) -> EncoderCommand:
+        action = str(decision.action)
+        to_profile = str(decision.to_profile)
+        profile = self._resolve_profile(to_profile)
+
+        command = EncoderCommand(
+            command_id=self._next_command_id,
+            action=action,
+            profile_name=to_profile,
+            request_ts=self._now_wall_fn(),
+            reason=decision.reason,
+            width=profile.width if profile else None,
+            height=profile.height if profile else None,
+            fps=profile.fps if profile else None,
+            gop=profile.gop if profile else None,
+            target_bitrate_kbps=profile.target_bitrate_kbps if profile else None,
+            max_bitrate_kbps=profile.max_bitrate_kbps if profile else None,
+            retry_count=0,
+        )
+        self._next_command_id += 1
+        return command
+
+    def _resolve_profile(self, name: str) -> EncoderProfile | None:
+        if name in self._tier_by_name:
+            return self._tier_by_name[name]
+        if name == self._config.v0_profile_name:
+            match = _RESOLUTION_RE.match(self._config.v0_resolution)
+            if match is None:
+                raise ValueError("invalid v0_resolution in controller config")
+            return EncoderProfile(
+                name=name,
+                width=int(match.group(1)),
+                height=int(match.group(2)),
+                fps=int(self._config.v0_fps),
+                gop=int(self._config.v0_gop),
+                target_bitrate_kbps=int(self._config.v0_target_bitrate_kbps),
+                max_bitrate_kbps=int(self._config.v0_max_bitrate_kbps),
+            )
+        return None
+
+    def _send_command(self, command: EncoderCommand) -> None:
+        self._transport.send_command(command)
+        self._pending_command = _PendingCommand(
+            command=command,
+            retries=0,
+            deadline_monotonic=self._now_mono_fn() + max(0.05, self._config.ack_timeout_sec),
+        )
+
+    def _process_pending_timeout(self) -> None:
+        pending = self._pending_command
+        if pending is None:
+            return
+        if self._now_mono_fn() < pending.deadline_monotonic:
+            return
+
+        if pending.retries >= max(0, int(self._config.ack_max_retries)):
+            self._command_failures += 1
+            self._pending_command = None
+            return
+
+        retried = EncoderCommand(
+            command_id=pending.command.command_id,
+            action=pending.command.action,
+            profile_name=pending.command.profile_name,
+            request_ts=pending.command.request_ts,
+            reason=pending.command.reason,
+            width=pending.command.width,
+            height=pending.command.height,
+            fps=pending.command.fps,
+            gop=pending.command.gop,
+            target_bitrate_kbps=pending.command.target_bitrate_kbps,
+            max_bitrate_kbps=pending.command.max_bitrate_kbps,
+            retry_count=pending.retries + 1,
+        )
+        self._transport.send_command(retried)
+        self._pending_command = _PendingCommand(
+            command=retried,
+            retries=pending.retries + 1,
+            deadline_monotonic=self._now_mono_fn() + max(0.05, self._config.ack_timeout_sec),
+        )
+
+    @staticmethod
+    def _percentile(values: list[float], percentile: int) -> float:
+        if not values:
+            return 0.0
+        if len(values) == 1:
+            return float(values[0])
+        clipped = max(0.0, min(100.0, float(percentile))) / 100.0
+        # Deterministic quantile estimate for short windows.
+        sorted_values = sorted(float(v) for v in values)
+        index = int(round((len(sorted_values) - 1) * clipped))
+        return float(sorted_values[index])

--- a/software/edge/src/aeris_mesh_agent/package.xml
+++ b/software/edge/src/aeris_mesh_agent/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>aeris_msgs</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>pytest</test_depend>
 

--- a/software/edge/src/aeris_mesh_agent/package.xml
+++ b/software/edge/src/aeris_mesh_agent/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>python3-ament-index-python</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>aeris_msgs</exec_depend>
   <exec_depend>python3-yaml</exec_depend>

--- a/software/edge/src/aeris_mesh_agent/setup.py
+++ b/software/edge/src/aeris_mesh_agent/setup.py
@@ -15,11 +15,11 @@ setup(
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
         (f"share/{package_name}", ["package.xml"]),
     ],
-    install_requires=["setuptools"],
+    install_requires=["setuptools", "PyYAML"],
     zip_safe=True,
     maintainer="Aeris Developers",
     maintainer_email="dev@aeris.local",
-    description="Mesh impairment helpers and durable store-forward buffering for Aeris simulation.",
+    description="Mesh impairment helpers, durable store-forward buffering, and ABR control for Aeris simulation.",
     license="proprietary",
     tests_require=["pytest"],
     entry_points={

--- a/software/edge/src/aeris_mesh_agent/setup.py
+++ b/software/edge/src/aeris_mesh_agent/setup.py
@@ -14,6 +14,7 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
         (f"share/{package_name}", ["package.xml"]),
+        (f"share/{package_name}/config/srt", ["../../config/srt/abr_ladder.yaml"]),
     ],
     install_requires=["setuptools", "PyYAML"],
     zip_safe=True,

--- a/software/sim/tools/validate_multi_vehicle_dds.sh
+++ b/software/sim/tools/validate_multi_vehicle_dds.sh
@@ -37,8 +37,13 @@
 #   DETECTION_TOPIC                Default: /detections/fused
 #   REPLAY_ANNOTATION_TOPIC        Default: /mesh/replay_annotations
 #   ABR_DECISION_TOPIC             Default: /mesh/abr_decisions
+#   ABR_COMMAND_TOPIC              Default: /mesh/video/encoder_profile_cmd
+#   ABR_ACK_TOPIC                  Default: /mesh/video/encoder_profile_ack
 #   ABR_DECISION_SAMPLE_TIMEOUT_SEC Default: 12
 #   ABR_REACTION_P95_TARGET_MS     Default: 1000
+#   ABR_MODERATE_DROP_PROB         Default: 0.50
+#   ABR_MODERATE_DELAY_MS          Default: 150
+#   ABR_MODERATE_PHASE_SEC         Default: 3
 #   ABR_SEVERE_DROP_PROB           Default: 1.0
 #   ABR_SEVERE_PHASE_SEC           Default: 3
 #   ABR_REQUIRED                   Default: 1 (fail validation if ABR checks cannot be asserted)
@@ -85,8 +90,13 @@ TELEMETRY_TOPIC=${TELEMETRY_TOPIC:-/orchestrator/heartbeat}
 DETECTION_TOPIC=${DETECTION_TOPIC:-/detections/fused}
 REPLAY_ANNOTATION_TOPIC=${REPLAY_ANNOTATION_TOPIC:-/mesh/replay_annotations}
 ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC:-/mesh/abr_decisions}
+ABR_COMMAND_TOPIC=${ABR_COMMAND_TOPIC:-/mesh/video/encoder_profile_cmd}
+ABR_ACK_TOPIC=${ABR_ACK_TOPIC:-/mesh/video/encoder_profile_ack}
 ABR_DECISION_SAMPLE_TIMEOUT_SEC=${ABR_DECISION_SAMPLE_TIMEOUT_SEC:-12}
 ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS:-1000}
+ABR_MODERATE_DROP_PROB=${ABR_MODERATE_DROP_PROB:-0.50}
+ABR_MODERATE_DELAY_MS=${ABR_MODERATE_DELAY_MS:-150}
+ABR_MODERATE_PHASE_SEC=${ABR_MODERATE_PHASE_SEC:-3}
 ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB:-1.0}
 ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC:-3}
 ABR_REQUIRED=${ABR_REQUIRED:-1}
@@ -576,6 +586,71 @@ else:
 PY
 }
 
+assert_abr_moderate_behavior() {
+  local decision_file=$1
+  local require_samples=$2
+
+  python3 - "$decision_file" "$require_samples" <<'PY'
+import json
+import re
+import sys
+
+decision_file = sys.argv[1]
+require_samples = str(sys.argv[2]).strip().lower() in {"1", "true", "yes", "on"}
+
+decision_count = 0
+moderate_step_down_found = False
+forbidden_actions_found = []
+
+with open(decision_file, "r", encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        line = line.strip()
+        match = re.search(r"data:\s*'(.+)'", line)
+        if not match:
+            continue
+        raw = match.group(1).replace("\\'", "'")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        decision_count += 1
+        action = str(payload.get("action", "")).strip().lower()
+        reason = str(payload.get("reason", "")).strip().lower()
+        to_profile = str(payload.get("to_profile", "")).strip().upper()
+        if action == "switch_profile" and reason == "link-degraded-step-down" and to_profile != "V0":
+            moderate_step_down_found = True
+        if action == "suspend_video":
+            forbidden_actions_found.append("suspend_video")
+        if action == "switch_profile" and to_profile == "V0":
+            forbidden_actions_found.append("switch_to_v0")
+
+if decision_count == 0:
+    if require_samples:
+        print("ERROR: no ABR decision samples captured during moderate impairment phase")
+        sys.exit(1)
+    print("WARNING: no ABR decision samples during moderate impairment; skipping moderate assertions")
+    sys.exit(0)
+
+if not moderate_step_down_found:
+    if require_samples:
+        print("ERROR: moderate impairment phase did not produce non-V0 link-degraded-step-down decision")
+        sys.exit(1)
+    print("WARNING: moderate impairment phase lacked non-V0 step-down decision")
+    sys.exit(0)
+
+if forbidden_actions_found:
+    print(
+        "ERROR: moderate impairment phase triggered severe fallback actions: "
+        + ",".join(sorted(set(forbidden_actions_found)))
+    )
+    sys.exit(1)
+
+print("ABR moderate impairment behavior verified: non-V0 step-down observed without severe fallback")
+PY
+}
+
 is_truthy() {
   local value="${1:-}"
   case "${value,,}" in
@@ -662,7 +737,11 @@ run_validation_pass() {
   local replay_annotation_sample_file=""
   local relay_tile_latency_sample_file=""
   local abr_decision_hz_file=""
+  local abr_decision_moderate_hz_file=""
+  local abr_decision_moderate_sample_file=""
   local abr_decision_sample_file=""
+  local abr_command_sample_file=""
+  local abr_ack_sample_file=""
   local restored_mesh_hz_file=""
   local restored_telemetry_hz_file=""
   local restored_map_hz_file=""
@@ -736,6 +815,8 @@ run_validation_pass() {
     -p replay_annotation_topic:="${REPLAY_ANNOTATION_TOPIC#/}" \
     -p abr_enabled:=true \
     -p abr_decision_topic:="${ABR_DECISION_TOPIC#/}" \
+    -p abr_command_topic:="${ABR_COMMAND_TOPIC#/}" \
+    -p abr_ack_topic:="${ABR_ACK_TOPIC#/}" \
     -p abr_heartbeat_severe_age_sec:=0.8 \
     -p abr_severe_hold_sec:=1.5 \
     -p abr_allow_video_suspend:=true \
@@ -859,9 +940,38 @@ run_validation_pass() {
     echo "[validate_multi_vehicle_dds] WARNING: ABR decision topic not discovered during initial impairment window: ${ABR_DECISION_TOPIC}" >&2
   fi
 
+  echo "[validate_multi_vehicle_dds] Applying ABR moderate impairment checks (drop_prob=${ABR_MODERATE_DROP_PROB}, delay_ms=${ABR_MODERATE_DELAY_MS}, phase=${ABR_MODERATE_PHASE_SEC}s)"
+  ros2 param set /impairment_relay drop_prob "${ABR_MODERATE_DROP_PROB}" >"${pass_log_dir}/param_set_drop_prob_moderate.log"
+  ros2 param set /impairment_relay delay_ms "${ABR_MODERATE_DELAY_MS}" >"${pass_log_dir}/param_set_delay_ms_moderate.log"
+  sleep "${ABR_MODERATE_PHASE_SEC}"
+
+  if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_DECISION_TOPIC}"; then
+    abr_decision_moderate_hz_file=$(sample_topic_hz "${ABR_DECISION_TOPIC}" "${pass_log_dir}" "abr_decisions_moderate")
+    if ! assert_topic_rate_observed "${ABR_DECISION_TOPIC}" "moderate" "${abr_decision_moderate_hz_file}"; then
+      echo "[validate_multi_vehicle_dds] WARNING: no ABR decision rate observed during moderate impairment window: ${ABR_DECISION_TOPIC}" >&2
+    fi
+    abr_decision_moderate_sample_file="${pass_log_dir}/abr_decision_moderate_samples.log"
+    timeout "${ABR_DECISION_SAMPLE_TIMEOUT_SEC}"s ros2 topic echo --full-length "${ABR_DECISION_TOPIC}" >"${abr_decision_moderate_sample_file}" 2>&1 || true
+    if [[ -f "${abr_decision_moderate_sample_file}" ]] && grep -Eiq 'action|to_profile|reason' "${abr_decision_moderate_sample_file}"; then
+      assert_abr_moderate_behavior "${abr_decision_moderate_sample_file}" "${ABR_REQUIRED}"
+    else
+      if is_truthy "${ABR_REQUIRED}"; then
+        echo "[validate_multi_vehicle_dds] ERROR: ABR moderate samples missing required fields on ${ABR_DECISION_TOPIC}" >&2
+        return 1
+      fi
+      echo "[validate_multi_vehicle_dds] WARNING: ABR moderate samples missing expected fields on ${ABR_DECISION_TOPIC}; skipping strict moderate assertions." >&2
+    fi
+  else
+    if is_truthy "${ABR_REQUIRED}"; then
+      echo "[validate_multi_vehicle_dds] ERROR: ABR decision topic missing for moderate checks: ${ABR_DECISION_TOPIC}" >&2
+      return 1
+    fi
+    echo "[validate_multi_vehicle_dds] WARNING: ABR decision topic missing for moderate checks: ${ABR_DECISION_TOPIC}" >&2
+  fi
+
   echo "[validate_multi_vehicle_dds] Escalating impairment for ABR severe fallback checks (drop_prob=${ABR_SEVERE_DROP_PROB}, phase=${ABR_SEVERE_PHASE_SEC}s)"
   ros2 param set /impairment_relay drop_prob "${ABR_SEVERE_DROP_PROB}" >"${pass_log_dir}/param_set_drop_prob_severe.log"
-  sleep 1
+  ros2 param set /impairment_relay delay_ms "${ABR_MODERATE_DELAY_MS}" >"${pass_log_dir}/param_set_delay_ms_severe.log"
 
   if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_DECISION_TOPIC}"; then
     abr_decision_sample_file="${pass_log_dir}/abr_decision_samples.log"
@@ -881,6 +991,38 @@ run_validation_pass() {
       return 1
     fi
     echo "[validate_multi_vehicle_dds] WARNING: ABR decision topic not discovered (skipping ABR checks): ${ABR_DECISION_TOPIC}" >&2
+  fi
+
+  if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_COMMAND_TOPIC}"; then
+    abr_command_sample_file="${pass_log_dir}/abr_command_sample.log"
+    timeout "${PROBE_TIMEOUT_SEC}"s ros2 topic echo --full-length "${ABR_COMMAND_TOPIC}" --once >"${abr_command_sample_file}" 2>&1 || true
+    if [[ -s "${abr_command_sample_file}" ]]; then
+      echo "[validate_multi_vehicle_dds] ABR encoder command sample observed on ${ABR_COMMAND_TOPIC}"
+    else
+      if is_truthy "${ABR_REQUIRED}"; then
+        echo "[validate_multi_vehicle_dds] ERROR: ABR command topic had no samples during severe phase: ${ABR_COMMAND_TOPIC}" >&2
+        return 1
+      fi
+      echo "[validate_multi_vehicle_dds] WARNING: ABR command topic had no samples during severe phase: ${ABR_COMMAND_TOPIC}" >&2
+    fi
+  else
+    if is_truthy "${ABR_REQUIRED}"; then
+      echo "[validate_multi_vehicle_dds] ERROR: ABR command topic not discovered: ${ABR_COMMAND_TOPIC}" >&2
+      return 1
+    fi
+    echo "[validate_multi_vehicle_dds] WARNING: ABR command topic not discovered: ${ABR_COMMAND_TOPIC}" >&2
+  fi
+
+  if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_ACK_TOPIC}"; then
+    abr_ack_sample_file="${pass_log_dir}/abr_ack_sample.log"
+    timeout "${PROBE_TIMEOUT_SEC}"s ros2 topic echo --full-length "${ABR_ACK_TOPIC}" --once >"${abr_ack_sample_file}" 2>&1 || true
+    if [[ -s "${abr_ack_sample_file}" ]]; then
+      echo "[validate_multi_vehicle_dds] ABR encoder ack sample observed on ${ABR_ACK_TOPIC}"
+    else
+      echo "[validate_multi_vehicle_dds] WARNING: ABR ack topic discovered but no samples observed (encoder may be absent): ${ABR_ACK_TOPIC}" >&2
+    fi
+  else
+    echo "[validate_multi_vehicle_dds] WARNING: ABR ack topic not discovered: ${ABR_ACK_TOPIC}" >&2
   fi
   sleep "${ABR_SEVERE_PHASE_SEC}"
 
@@ -993,8 +1135,13 @@ echo "[validate_multi_vehicle_dds] RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_
 echo "[validate_multi_vehicle_dds] RELAY_TILE_LATENCY_P95_TARGET_SEC=${RELAY_TILE_LATENCY_P95_TARGET_SEC}"
 echo "[validate_multi_vehicle_dds] RELAY_TILE_LATENCY_REQUIRED=${RELAY_TILE_LATENCY_REQUIRED}"
 echo "[validate_multi_vehicle_dds] ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC}"
+echo "[validate_multi_vehicle_dds] ABR_COMMAND_TOPIC=${ABR_COMMAND_TOPIC}"
+echo "[validate_multi_vehicle_dds] ABR_ACK_TOPIC=${ABR_ACK_TOPIC}"
 echo "[validate_multi_vehicle_dds] ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS}"
 echo "[validate_multi_vehicle_dds] ABR_REQUIRED=${ABR_REQUIRED}"
+echo "[validate_multi_vehicle_dds] ABR_MODERATE_DROP_PROB=${ABR_MODERATE_DROP_PROB}"
+echo "[validate_multi_vehicle_dds] ABR_MODERATE_DELAY_MS=${ABR_MODERATE_DELAY_MS}"
+echo "[validate_multi_vehicle_dds] ABR_MODERATE_PHASE_SEC=${ABR_MODERATE_PHASE_SEC}"
 echo "[validate_multi_vehicle_dds] ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB}"
 echo "[validate_multi_vehicle_dds] ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC}"
 echo "[validate_multi_vehicle_dds] MAP_TILE_FALLBACK_ENABLE=${MAP_TILE_FALLBACK_ENABLE}"

--- a/software/sim/tools/validate_multi_vehicle_dds.sh
+++ b/software/sim/tools/validate_multi_vehicle_dds.sh
@@ -36,6 +36,12 @@
 #   TELEMETRY_TOPIC                Default: /orchestrator/heartbeat
 #   DETECTION_TOPIC                Default: /detections/fused
 #   REPLAY_ANNOTATION_TOPIC        Default: /mesh/replay_annotations
+#   ABR_DECISION_TOPIC             Default: /mesh/abr_decisions
+#   ABR_DECISION_SAMPLE_TIMEOUT_SEC Default: 12
+#   ABR_REACTION_P95_TARGET_MS     Default: 1000
+#   ABR_SEVERE_DROP_PROB           Default: 1.0
+#   ABR_SEVERE_PHASE_SEC           Default: 3
+#   ABR_REQUIRED                   Default: 1 (fail validation if ABR checks cannot be asserted)
 #   VIDEO_METADATA_TOPIC           Default: /scout1/stereo/left/image_raw
 #   REQUIRED_NAMESPACES            Comma-separated namespace checks (default: scout1,scout2)
 #   MULTI_DRONE_LAUNCH_PACKAGE     Default: aeris_sim
@@ -78,6 +84,12 @@ MAP_TILE_FALLBACK_RATE_HZ=${MAP_TILE_FALLBACK_RATE_HZ:-2}
 TELEMETRY_TOPIC=${TELEMETRY_TOPIC:-/orchestrator/heartbeat}
 DETECTION_TOPIC=${DETECTION_TOPIC:-/detections/fused}
 REPLAY_ANNOTATION_TOPIC=${REPLAY_ANNOTATION_TOPIC:-/mesh/replay_annotations}
+ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC:-/mesh/abr_decisions}
+ABR_DECISION_SAMPLE_TIMEOUT_SEC=${ABR_DECISION_SAMPLE_TIMEOUT_SEC:-12}
+ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS:-1000}
+ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB:-1.0}
+ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC:-3}
+ABR_REQUIRED=${ABR_REQUIRED:-1}
 VIDEO_METADATA_TOPIC=${VIDEO_METADATA_TOPIC:-/scout1/stereo/left/image_raw}
 REQUIRED_NAMESPACES=${REQUIRED_NAMESPACES:-scout1,scout2}
 MULTI_DRONE_LAUNCH_PACKAGE=${MULTI_DRONE_LAUNCH_PACKAGE:-aeris_sim}
@@ -477,6 +489,93 @@ print(f"Relay tile latency p95={p95:.3f}s within target {target:.3f}s")
 PY
 }
 
+assert_abr_decision_behavior() {
+  local decision_file=$1
+  local reaction_target_ms=$2
+  local require_samples=$3
+
+  python3 - "$decision_file" "$reaction_target_ms" "$require_samples" <<'PY'
+import json
+import re
+import sys
+
+decision_file = sys.argv[1]
+target_ms = float(sys.argv[2])
+require_samples = str(sys.argv[3]).strip().lower() in {"1", "true", "yes", "on"}
+
+reaction_latencies = []
+first_v0_ts = None
+first_suspend_ts = None
+decision_count = 0
+
+with open(decision_file, "r", encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        line = line.strip()
+        match = re.search(r"data:\s*'(.+)'", line)
+        if not match:
+            continue
+        raw = match.group(1).replace("\\'", "'")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        decision_count += 1
+        action = str(payload.get("action", "")).strip().lower()
+        to_profile = str(payload.get("to_profile", "")).strip()
+        timestamp = payload.get("timestamp_monotonic")
+        reaction_ms = payload.get("reaction_latency_ms")
+        if reaction_ms is not None:
+            try:
+                reaction_latencies.append(float(reaction_ms))
+            except (TypeError, ValueError):
+                pass
+        if action == "switch_profile" and to_profile.upper() == "V0" and first_v0_ts is None:
+            try:
+                first_v0_ts = float(timestamp)
+            except (TypeError, ValueError):
+                first_v0_ts = None
+        if action == "suspend_video" and first_suspend_ts is None:
+            try:
+                first_suspend_ts = float(timestamp)
+            except (TypeError, ValueError):
+                first_suspend_ts = None
+
+if decision_count == 0:
+    if require_samples:
+        print("ERROR: no ABR decision samples captured")
+        sys.exit(1)
+    print("WARNING: no ABR decision samples; skipping ABR assertions")
+    sys.exit(0)
+
+if not reaction_latencies:
+    if require_samples:
+        print("ERROR: ABR decisions captured but reaction_latency_ms samples missing")
+        sys.exit(1)
+    print("WARNING: ABR reaction latency samples missing; skipping p95 check")
+else:
+    reaction_latencies.sort()
+    p95_index = max(0, min(len(reaction_latencies) - 1, round((len(reaction_latencies) - 1) * 0.95)))
+    p95 = reaction_latencies[p95_index]
+    if p95 > target_ms:
+        print(f"ERROR: ABR reaction latency p95 {p95:.1f}ms exceeded target {target_ms:.1f}ms")
+        sys.exit(1)
+    print(f"ABR reaction latency p95={p95:.1f}ms within target {target_ms:.1f}ms")
+
+if first_suspend_ts is not None:
+    if first_v0_ts is None:
+        print("ERROR: suspend_video observed before V0 transition")
+        sys.exit(1)
+    if first_v0_ts > first_suspend_ts:
+        print("ERROR: V0 transition timestamp occurs after suspend_video")
+        sys.exit(1)
+    print("ABR severe fallback ordering verified: V0 transition before suspend_video")
+else:
+    print("ABR severe fallback ordering check: suspend_video not observed (acceptable if policy stayed at V0)")
+PY
+}
+
 is_truthy() {
   local value="${1:-}"
   case "${value,,}" in
@@ -562,6 +661,8 @@ run_validation_pass() {
   local replay_annotation_restored_hz_file=""
   local replay_annotation_sample_file=""
   local relay_tile_latency_sample_file=""
+  local abr_decision_hz_file=""
+  local abr_decision_sample_file=""
   local restored_mesh_hz_file=""
   local restored_telemetry_hz_file=""
   local restored_map_hz_file=""
@@ -633,6 +734,11 @@ run_validation_pass() {
     -p relay_activation_policy:=force-relay \
     -p relay_heartbeat_topic:="${TELEMETRY_TOPIC#/}" \
     -p replay_annotation_topic:="${REPLAY_ANNOTATION_TOPIC#/}" \
+    -p abr_enabled:=true \
+    -p abr_decision_topic:="${ABR_DECISION_TOPIC#/}" \
+    -p abr_heartbeat_severe_age_sec:=0.8 \
+    -p abr_severe_hold_sec:=1.5 \
+    -p abr_allow_video_suspend:=true \
     -p storage_path:="${pass_log_dir}/store-forward.db" \
     -p publish_live_annotations:=true >"${store_forward_log}" 2>&1 &
   STORE_FORWARD_PID=$!
@@ -744,6 +850,40 @@ run_validation_pass() {
     echo "[validate_multi_vehicle_dds] WARNING: replay annotation topic not discovered (skipping impaired replay metadata checks): ${REPLAY_ANNOTATION_TOPIC}" >&2
   fi
 
+  if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_DECISION_TOPIC}"; then
+    abr_decision_hz_file=$(sample_topic_hz "${ABR_DECISION_TOPIC}" "${pass_log_dir}" "abr_decisions_impaired")
+    if ! assert_topic_rate_observed "${ABR_DECISION_TOPIC}" "impaired" "${abr_decision_hz_file}"; then
+      echo "[validate_multi_vehicle_dds] WARNING: no ABR decision rate observed during initial impairment window: ${ABR_DECISION_TOPIC}" >&2
+    fi
+  else
+    echo "[validate_multi_vehicle_dds] WARNING: ABR decision topic not discovered during initial impairment window: ${ABR_DECISION_TOPIC}" >&2
+  fi
+
+  echo "[validate_multi_vehicle_dds] Escalating impairment for ABR severe fallback checks (drop_prob=${ABR_SEVERE_DROP_PROB}, phase=${ABR_SEVERE_PHASE_SEC}s)"
+  ros2 param set /impairment_relay drop_prob "${ABR_SEVERE_DROP_PROB}" >"${pass_log_dir}/param_set_drop_prob_severe.log"
+  sleep 1
+
+  if ros2 topic list 2>/dev/null | grep -Fxq "${ABR_DECISION_TOPIC}"; then
+    abr_decision_sample_file="${pass_log_dir}/abr_decision_samples.log"
+    timeout "${ABR_DECISION_SAMPLE_TIMEOUT_SEC}"s ros2 topic echo --full-length "${ABR_DECISION_TOPIC}" >"${abr_decision_sample_file}" 2>&1 || true
+    if [[ -f "${abr_decision_sample_file}" ]] && grep -Eiq 'action|to_profile|reaction_latency_ms' "${abr_decision_sample_file}"; then
+      assert_abr_decision_behavior "${abr_decision_sample_file}" "${ABR_REACTION_P95_TARGET_MS}" "${ABR_REQUIRED}"
+    else
+      if is_truthy "${ABR_REQUIRED}"; then
+        echo "[validate_multi_vehicle_dds] ERROR: ABR decision samples missing required fields on ${ABR_DECISION_TOPIC}" >&2
+        return 1
+      fi
+      echo "[validate_multi_vehicle_dds] WARNING: ABR decision samples missing expected fields on ${ABR_DECISION_TOPIC}; skipping strict ABR assertions." >&2
+    fi
+  else
+    if is_truthy "${ABR_REQUIRED}"; then
+      echo "[validate_multi_vehicle_dds] ERROR: ABR decision topic not discovered and ABR validation is required: ${ABR_DECISION_TOPIC}" >&2
+      return 1
+    fi
+    echo "[validate_multi_vehicle_dds] WARNING: ABR decision topic not discovered (skipping ABR checks): ${ABR_DECISION_TOPIC}" >&2
+  fi
+  sleep "${ABR_SEVERE_PHASE_SEC}"
+
   echo "[validate_multi_vehicle_dds] Disabling impairment"
   ros2 param set /impairment_relay drop_prob 0.0 >"${pass_log_dir}/param_set_drop_prob_off.log"
   ros2 param set /impairment_relay delay_ms 0 >"${pass_log_dir}/param_set_delay_ms_off.log"
@@ -852,6 +992,11 @@ echo "[validate_multi_vehicle_dds] RMW_VALIDATION_SET=${RMW_VALIDATION_SET}"
 echo "[validate_multi_vehicle_dds] RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
 echo "[validate_multi_vehicle_dds] RELAY_TILE_LATENCY_P95_TARGET_SEC=${RELAY_TILE_LATENCY_P95_TARGET_SEC}"
 echo "[validate_multi_vehicle_dds] RELAY_TILE_LATENCY_REQUIRED=${RELAY_TILE_LATENCY_REQUIRED}"
+echo "[validate_multi_vehicle_dds] ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC}"
+echo "[validate_multi_vehicle_dds] ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS}"
+echo "[validate_multi_vehicle_dds] ABR_REQUIRED=${ABR_REQUIRED}"
+echo "[validate_multi_vehicle_dds] ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB}"
+echo "[validate_multi_vehicle_dds] ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC}"
 echo "[validate_multi_vehicle_dds] MAP_TILE_FALLBACK_ENABLE=${MAP_TILE_FALLBACK_ENABLE}"
 echo "[validate_multi_vehicle_dds] MAP_TILE_FALLBACK_RATE_HZ=${MAP_TILE_FALLBACK_RATE_HZ}"
 echo "[validate_multi_vehicle_dds] MULTI_DRONE_LAUNCH_PACKAGE=${MULTI_DRONE_LAUNCH_PACKAGE}"

--- a/test/test_dds_multi_vehicle_comm.py
+++ b/test/test_dds_multi_vehicle_comm.py
@@ -146,6 +146,12 @@ def test_validation_recipe_contains_nominal_and_impaired_checks() -> None:
     assert "wait_for_topic \"${MAP_TILE_TOPIC}\"" in text
     assert "wait_for_topic \"${VIDEO_METADATA_TOPIC}\"" in text
     assert "REPLAY_ANNOTATION_TOPIC=${REPLAY_ANNOTATION_TOPIC:-/mesh/replay_annotations}" in text
+    assert "ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC:-/mesh/abr_decisions}" in text
+    assert "ABR_DECISION_SAMPLE_TIMEOUT_SEC=${ABR_DECISION_SAMPLE_TIMEOUT_SEC:-12}" in text
+    assert "ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS:-1000}" in text
+    assert "ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB:-1.0}" in text
+    assert "ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC:-3}" in text
+    assert "ABR_REQUIRED=${ABR_REQUIRED:-1}" in text
     assert "RELAY_TILE_LATENCY_P95_TARGET_SEC=${RELAY_TILE_LATENCY_P95_TARGET_SEC:-2.0}" in text
     assert "RELAY_TILE_SAMPLE_TIMEOUT_SEC=${RELAY_TILE_SAMPLE_TIMEOUT_SEC:-20}" in text
     assert "RELAY_TILE_LATENCY_REQUIRED=${RELAY_TILE_LATENCY_REQUIRED:-1}" in text
@@ -171,6 +177,7 @@ def test_validation_recipe_contains_nominal_and_impaired_checks() -> None:
     assert "ros2 run aeris_mesh_agent impairment_relay" in text
     assert "ros2 param set /impairment_relay drop_prob" in text
     assert "ros2 param set /impairment_relay delay_ms" in text
+    assert "ros2 param set /impairment_relay drop_prob \"${ABR_SEVERE_DROP_PROB}\"" in text
 
     assert "sample_topic_hz \"/mesh/heartbeat_imp\" \"${pass_log_dir}\" \"impaired\"" in text
     assert "sample_topic_hz \"/mesh/heartbeat_imp\" \"${pass_log_dir}\" \"restored\"" in text
@@ -180,8 +187,11 @@ def test_validation_recipe_contains_nominal_and_impaired_checks() -> None:
     assert "\"detection_restored\"" in text
     assert "replay_annotation_impaired" in text
     assert "replay_annotation_restored" in text
+    assert "abr_decisions_impaired" in text
+    assert "Escalating impairment for ABR severe fallback checks" in text
     assert "Replay annotation metadata observed on ${REPLAY_ANNOTATION_TOPIC}" in text
     assert "assert_relay_tile_latency_p95" in text
+    assert "assert_abr_decision_behavior" in text
     assert "local require_samples=$3" in text
     assert "python3 - \"$annotation_file\" \"$target_p95\" \"$require_samples\" <<'PY'" in text
     assert 'require_samples = str(sys.argv[3]).strip().lower() in {"1", "true", "yes", "on"}' in text

--- a/test/test_dds_multi_vehicle_comm.py
+++ b/test/test_dds_multi_vehicle_comm.py
@@ -147,8 +147,13 @@ def test_validation_recipe_contains_nominal_and_impaired_checks() -> None:
     assert "wait_for_topic \"${VIDEO_METADATA_TOPIC}\"" in text
     assert "REPLAY_ANNOTATION_TOPIC=${REPLAY_ANNOTATION_TOPIC:-/mesh/replay_annotations}" in text
     assert "ABR_DECISION_TOPIC=${ABR_DECISION_TOPIC:-/mesh/abr_decisions}" in text
+    assert "ABR_COMMAND_TOPIC=${ABR_COMMAND_TOPIC:-/mesh/video/encoder_profile_cmd}" in text
+    assert "ABR_ACK_TOPIC=${ABR_ACK_TOPIC:-/mesh/video/encoder_profile_ack}" in text
     assert "ABR_DECISION_SAMPLE_TIMEOUT_SEC=${ABR_DECISION_SAMPLE_TIMEOUT_SEC:-12}" in text
     assert "ABR_REACTION_P95_TARGET_MS=${ABR_REACTION_P95_TARGET_MS:-1000}" in text
+    assert "ABR_MODERATE_DROP_PROB=${ABR_MODERATE_DROP_PROB:-0.50}" in text
+    assert "ABR_MODERATE_DELAY_MS=${ABR_MODERATE_DELAY_MS:-150}" in text
+    assert "ABR_MODERATE_PHASE_SEC=${ABR_MODERATE_PHASE_SEC:-3}" in text
     assert "ABR_SEVERE_DROP_PROB=${ABR_SEVERE_DROP_PROB:-1.0}" in text
     assert "ABR_SEVERE_PHASE_SEC=${ABR_SEVERE_PHASE_SEC:-3}" in text
     assert "ABR_REQUIRED=${ABR_REQUIRED:-1}" in text
@@ -192,12 +197,19 @@ def test_validation_recipe_contains_nominal_and_impaired_checks() -> None:
     assert "Replay annotation metadata observed on ${REPLAY_ANNOTATION_TOPIC}" in text
     assert "assert_relay_tile_latency_p95" in text
     assert "assert_abr_decision_behavior" in text
+    assert "assert_abr_moderate_behavior" in text
+    assert "Applying ABR moderate impairment checks" in text
     assert "local require_samples=$3" in text
     assert "python3 - \"$annotation_file\" \"$target_p95\" \"$require_samples\" <<'PY'" in text
     assert 'require_samples = str(sys.argv[3]).strip().lower() in {"1", "true", "yes", "on"}' in text
     assert "relay_tile_latency_sample_file" in text
     assert "relay_envelope|route_key|published_at_ts|replayed_at_ts" in text
     assert "\"${RELAY_TILE_LATENCY_REQUIRED}\"" in text
+    assert "abr_decision_moderate_samples.log" in text
+    assert "abr_command_sample.log" in text
+    assert "abr_ack_sample.log" in text
+    assert "ABR encoder command sample observed on ${ABR_COMMAND_TOPIC}" in text
+    assert "ABR ack topic discovered but no samples observed (encoder may be absent): ${ABR_ACK_TOPIC}" in text
     assert "preflight_runtime_checks" in text
     assert "ensure_local_ros_package_visible" in text
     assert "ensure_local_ros_package_visible aeris_msgs || true" in text

--- a/test/test_video_abr_policy.py
+++ b/test/test_video_abr_policy.py
@@ -1,0 +1,281 @@
+"""ABR policy/controller tests for adaptive mesh video streaming behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MESH_AGENT_SRC = REPO_ROOT / "software" / "edge" / "src" / "aeris_mesh_agent"
+if str(MESH_AGENT_SRC) not in sys.path:
+    sys.path.insert(0, str(MESH_AGENT_SRC))
+
+from aeris_mesh_agent.abr_policy import AbrPolicy, AbrPolicyConfig, AbrTier, LinkHealthSample
+from aeris_mesh_agent.video_abr_controller import (
+    EncoderCommand,
+    EncoderTransport,
+    VideoAbrController,
+    VideoAbrControllerConfig,
+)
+
+
+class _CaptureTransport(EncoderTransport):
+    def __init__(self) -> None:
+        self.sent: list[EncoderCommand] = []
+
+    def send_command(self, command: EncoderCommand) -> None:
+        self.sent.append(command)
+
+
+def _ladder_tiers() -> list[AbrTier]:
+    return [
+        AbrTier(
+            name="base_360p",
+            resolution="640x360",
+            target_bitrate_kbps=900,
+            max_bitrate_kbps=1200,
+            gop=60,
+            fps=30,
+        ),
+        AbrTier(
+            name="perf_540p",
+            resolution="960x540",
+            target_bitrate_kbps=1800,
+            max_bitrate_kbps=2400,
+            gop=60,
+            fps=30,
+        ),
+        AbrTier(
+            name="detail_720p",
+            resolution="1280x720",
+            target_bitrate_kbps=3200,
+            max_bitrate_kbps=4200,
+            gop=60,
+            fps=30,
+        ),
+    ]
+
+
+def _write_ladder(path: Path) -> Path:
+    ladder_path = path / "abr_ladder.yaml"
+    ladder_path.write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "ladder:",
+                "  - name: base_360p",
+                "    resolution: 640x360",
+                "    target_bitrate_kbps: 900",
+                "    max_bitrate_kbps: 1200",
+                "    gop: 60",
+                "    fps: 30",
+                "  - name: perf_540p",
+                "    resolution: 960x540",
+                "    target_bitrate_kbps: 1800",
+                "    max_bitrate_kbps: 2400",
+                "    gop: 60",
+                "    fps: 30",
+                "  - name: detail_720p",
+                "    resolution: 1280x720",
+                "    target_bitrate_kbps: 3200",
+                "    max_bitrate_kbps: 4200",
+                "    gop: 60",
+                "    fps: 30",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return ladder_path
+
+
+def test_policy_threshold_crossing_hysteresis_and_dwell() -> None:
+    now = {"value": 100.2}
+    policy = AbrPolicy(
+        tiers=_ladder_tiers(),
+        config=AbrPolicyConfig(
+            pdr_degrade_threshold=0.80,
+            pdr_severe_threshold=0.35,
+            pdr_hysteresis=0.10,
+            min_dwell_sec=2.0,
+            min_downgrade_interval_sec=0.10,
+            severe_hold_sec=2.0,
+        ),
+        now_fn=lambda: now["value"],
+    )
+    now["value"] = 100.4
+
+    # First impairment triggers one-step downgrade.
+    first = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=100.4, pdr=0.70, rtt_ms=200.0, heartbeat_age_sec=0.1)
+    )
+    assert first is not None
+    assert first.action == "switch_profile"
+    assert first.from_profile == "detail_720p"
+    assert first.to_profile == "perf_540p"
+
+    # Dwell prevents immediate rebound.
+    now["value"] = 100.6
+    rebound_too_early = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=100.6, pdr=0.96, rtt_ms=120.0, heartbeat_age_sec=0.1)
+    )
+    assert rebound_too_early is None
+
+    # After dwell window, healthy link steps up.
+    now["value"] = 103.0
+    recovered = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=103.0, pdr=0.97, rtt_ms=110.0, heartbeat_age_sec=0.1)
+    )
+    assert recovered is not None
+    assert recovered.action == "switch_profile"
+    assert recovered.from_profile == "perf_540p"
+    assert recovered.to_profile == "detail_720p"
+
+
+def test_policy_enforces_v0_before_optional_suspend() -> None:
+    now = {"value": 10.0}
+    policy = AbrPolicy(
+        tiers=_ladder_tiers(),
+        config=AbrPolicyConfig(
+            heartbeat_severe_age_sec=0.8,
+            severe_hold_sec=1.5,
+            allow_video_suspend=True,
+            severe_floor_profile="V0",
+        ),
+        now_fn=lambda: now["value"],
+    )
+
+    first = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=10.0, heartbeat_age_sec=1.1, pdr=0.95)
+    )
+    assert first is not None
+    assert first.action == "switch_profile"
+    assert first.to_profile == "V0"
+
+    now["value"] = 11.0
+    hold = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=11.0, heartbeat_age_sec=1.2, pdr=0.95)
+    )
+    assert hold is None
+
+    now["value"] = 11.7
+    suspended = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=11.7, heartbeat_age_sec=1.3, pdr=0.95)
+    )
+    assert suspended is not None
+    assert suspended.action == "suspend_video"
+    assert suspended.from_profile == "V0"
+
+
+def test_controller_retries_timed_out_encoder_commands(tmp_path: Path) -> None:
+    ladder_path = _write_ladder(tmp_path)
+    now = {"mono": 50.0, "wall": 1000.0}
+    transport = _CaptureTransport()
+    controller = VideoAbrController(
+        ladder_path=str(ladder_path),
+        config=VideoAbrControllerConfig(
+            ack_timeout_sec=0.5,
+            ack_max_retries=2,
+            policy=AbrPolicyConfig(
+                heartbeat_severe_age_sec=0.7,
+                severe_hold_sec=3.0,
+                allow_video_suspend=False,
+            ),
+        ),
+        transport=transport,
+        now_mono_fn=lambda: now["mono"],
+        now_wall_fn=lambda: now["wall"],
+    )
+
+    decision = controller.evaluate(
+        LinkHealthSample(timestamp_monotonic=50.0, heartbeat_age_sec=1.0, pdr=0.95)
+    )
+    assert decision is not None
+    assert len(transport.sent) == 1
+    assert transport.sent[0].profile_name == "V0"
+    assert transport.sent[0].retry_count == 0
+
+    now["mono"] = 50.6
+    controller.tick()
+    assert len(transport.sent) == 2
+    assert transport.sent[1].command_id == transport.sent[0].command_id
+    assert transport.sent[1].retry_count == 1
+
+    now["mono"] = 51.2
+    controller.tick()
+    assert len(transport.sent) == 3
+    assert transport.sent[2].retry_count == 2
+
+    now["mono"] = 51.8
+    controller.tick()
+    assert len(transport.sent) == 3
+    assert controller.snapshot().command_failures == 1
+
+
+def test_controller_ack_prevents_retries(tmp_path: Path) -> None:
+    ladder_path = _write_ladder(tmp_path)
+    now = {"mono": 10.0, "wall": 20.0}
+    transport = _CaptureTransport()
+    controller = VideoAbrController(
+        ladder_path=str(ladder_path),
+        config=VideoAbrControllerConfig(
+            ack_timeout_sec=0.3,
+            ack_max_retries=2,
+            policy=AbrPolicyConfig(heartbeat_severe_age_sec=0.7),
+        ),
+        transport=transport,
+        now_mono_fn=lambda: now["mono"],
+        now_wall_fn=lambda: now["wall"],
+    )
+
+    decision = controller.evaluate(
+        LinkHealthSample(timestamp_monotonic=10.0, heartbeat_age_sec=0.9, pdr=0.95)
+    )
+    assert decision is not None
+    assert len(transport.sent) == 1
+    command_id = transport.sent[0].command_id
+    assert controller.observe_encoder_ack(
+        {
+            "command_id": command_id,
+            "profile_name": transport.sent[0].profile_name,
+            "applied_at_ts": 20.1,
+            "status": "ok",
+        }
+    )
+
+    now["mono"] = 10.6
+    controller.tick()
+    assert len(transport.sent) == 1
+    assert controller.snapshot().pending_command_id is None
+
+
+def test_ladder_parser_fails_on_unsorted_target_bitrate(tmp_path: Path) -> None:
+    ladder_path = tmp_path / "abr_bad.yaml"
+    ladder_path.write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "ladder:",
+                "  - name: high",
+                "    resolution: 1280x720",
+                "    target_bitrate_kbps: 2200",
+                "    max_bitrate_kbps: 2600",
+                "    gop: 60",
+                "    fps: 30",
+                "  - name: low",
+                "    resolution: 640x360",
+                "    target_bitrate_kbps: 900",
+                "    max_bitrate_kbps: 1200",
+                "    gop: 60",
+                "    fps: 30",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        VideoAbrController.load_ladder_tiers(str(ladder_path))
+    except ValueError as exc:
+        assert "strictly increasing" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for unsorted ladder bitrate values")

--- a/test/test_video_abr_policy.py
+++ b/test/test_video_abr_policy.py
@@ -8,6 +8,7 @@ import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MESH_AGENT_SRC = REPO_ROOT / "software" / "edge" / "src" / "aeris_mesh_agent"
+STORE_FORWARD_FILE = MESH_AGENT_SRC / "aeris_mesh_agent" / "store_forward_tiles.py"
 if str(MESH_AGENT_SRC) not in sys.path:
     sys.path.insert(0, str(MESH_AGENT_SRC))
 
@@ -167,6 +168,36 @@ def test_policy_enforces_v0_before_optional_suspend() -> None:
     assert suspended.from_profile == "V0"
 
 
+def test_policy_forces_v0_when_reaction_window_exceeded() -> None:
+    now = {"value": 5.0}
+    policy = AbrPolicy(
+        tiers=_ladder_tiers(),
+        config=AbrPolicyConfig(
+            pdr_degrade_threshold=0.80,
+            pdr_severe_threshold=0.20,
+            min_downgrade_interval_sec=10.0,
+            reaction_window_sec=0.5,
+            severe_floor_profile="V0",
+            allow_video_suspend=False,
+        ),
+        now_fn=lambda: now["value"],
+    )
+
+    first = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=5.0, pdr=0.70, rtt_ms=220.0, heartbeat_age_sec=0.1)
+    )
+    assert first is None
+
+    now["value"] = 5.7
+    forced = policy.evaluate(
+        LinkHealthSample(timestamp_monotonic=5.7, pdr=0.70, rtt_ms=220.0, heartbeat_age_sec=0.1)
+    )
+    assert forced is not None
+    assert forced.action == "switch_profile"
+    assert forced.to_profile == "V0"
+    assert forced.reason == "reaction-window-force-v0"
+
+
 def test_controller_retries_timed_out_encoder_commands(tmp_path: Path) -> None:
     ladder_path = _write_ladder(tmp_path)
     now = {"mono": 50.0, "wall": 1000.0}
@@ -208,8 +239,10 @@ def test_controller_retries_timed_out_encoder_commands(tmp_path: Path) -> None:
 
     now["mono"] = 51.8
     controller.tick()
-    assert len(transport.sent) == 3
+    assert len(transport.sent) == 4
+    assert transport.sent[3].retry_count == 3
     assert controller.snapshot().command_failures == 1
+    assert controller.snapshot().pending_command_id == transport.sent[0].command_id
 
 
 def test_controller_ack_prevents_retries(tmp_path: Path) -> None:
@@ -247,6 +280,112 @@ def test_controller_ack_prevents_retries(tmp_path: Path) -> None:
     controller.tick()
     assert len(transport.sent) == 1
     assert controller.snapshot().pending_command_id is None
+
+
+def test_controller_rejects_ack_without_command_id(tmp_path: Path) -> None:
+    ladder_path = _write_ladder(tmp_path)
+    now = {"mono": 5.0, "wall": 6.0}
+    transport = _CaptureTransport()
+    controller = VideoAbrController(
+        ladder_path=str(ladder_path),
+        config=VideoAbrControllerConfig(policy=AbrPolicyConfig(heartbeat_severe_age_sec=0.7)),
+        transport=transport,
+        now_mono_fn=lambda: now["mono"],
+        now_wall_fn=lambda: now["wall"],
+    )
+    decision = controller.evaluate(
+        LinkHealthSample(timestamp_monotonic=5.0, heartbeat_age_sec=0.9, pdr=0.95)
+    )
+    assert decision is not None
+
+    try:
+        controller.observe_encoder_ack(
+            {
+                "profile_name": transport.sent[0].profile_name,
+                "applied_at_ts": 6.1,
+                "status": "ok",
+            }
+        )
+    except ValueError as exc:
+        assert "command_id" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for ack payload missing command_id")
+
+
+def test_controller_retries_when_encoder_ack_rejects(tmp_path: Path) -> None:
+    ladder_path = _write_ladder(tmp_path)
+    now = {"mono": 20.0, "wall": 30.0}
+    transport = _CaptureTransport()
+    controller = VideoAbrController(
+        ladder_path=str(ladder_path),
+        config=VideoAbrControllerConfig(
+            ack_timeout_sec=0.5,
+            ack_max_retries=1,
+            policy=AbrPolicyConfig(heartbeat_severe_age_sec=0.7),
+        ),
+        transport=transport,
+        now_mono_fn=lambda: now["mono"],
+        now_wall_fn=lambda: now["wall"],
+    )
+
+    decision = controller.evaluate(
+        LinkHealthSample(timestamp_monotonic=20.0, heartbeat_age_sec=0.9, pdr=0.95)
+    )
+    assert decision is not None
+    assert len(transport.sent) == 1
+    command_id = transport.sent[0].command_id
+
+    accepted = controller.observe_encoder_ack(
+        {
+            "command_id": command_id,
+            "profile_name": transport.sent[0].profile_name,
+            "applied_at_ts": 30.1,
+            "status": "error",
+        }
+    )
+    assert not accepted
+
+    controller.tick()
+    assert len(transport.sent) == 2
+    assert transport.sent[1].command_id == command_id
+
+
+def test_controller_reconfigures_pending_ack_deadline(tmp_path: Path) -> None:
+    ladder_path = _write_ladder(tmp_path)
+    now = {"mono": 100.0, "wall": 200.0}
+    transport = _CaptureTransport()
+    controller = VideoAbrController(
+        ladder_path=str(ladder_path),
+        config=VideoAbrControllerConfig(
+            ack_timeout_sec=2.0,
+            ack_max_retries=1,
+            policy=AbrPolicyConfig(heartbeat_severe_age_sec=0.7),
+        ),
+        transport=transport,
+        now_mono_fn=lambda: now["mono"],
+        now_wall_fn=lambda: now["wall"],
+    )
+
+    decision = controller.evaluate(
+        LinkHealthSample(timestamp_monotonic=100.0, heartbeat_age_sec=0.9, pdr=0.95)
+    )
+    assert decision is not None
+    assert len(transport.sent) == 1
+
+    controller.update_ack_timeout(0.2)
+    now["mono"] = 100.3
+    controller.tick()
+    assert len(transport.sent) == 2
+
+
+def test_store_forward_wires_abr_metrics_decisions_commands_and_acks() -> None:
+    text = STORE_FORWARD_FILE.read_text(encoding="utf-8")
+    assert "def _active_link_health_sample(self)" in text
+    assert "self._abr_controller.evaluate(sample)" in text
+    assert "self._abr_decision_publisher.publish(" in text
+    assert "self._abr_ack_subscription = self.create_subscription(" in text
+    assert "encoder rejected ABR command" in text
+    assert "self._abr_controller.update_ack_timeout(value)" in text
 
 
 def test_ladder_parser_fails_on_unsorted_target_bitrate(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add deterministic ABR state-machine logic for active-link adaptation with hysteresis, dwell windows, and severe-loss V0 handling
- add a runtime ABR controller that validates the SRT ladder, emits encoder profile commands, and handles ack timeout/retry behavior
- wire ABR metrics + decisions into the mesh agent node and extend DDS validation checks for reaction-time and V0-before-suspend assertions
- add ABR unit tests and update validation-script static tests

## Validation
- pytest -q test/test_video_abr_policy.py test/test_store_forward_buffer.py test/test_dds_multi_vehicle_comm.py
- python3 -m py_compile software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
- bash -n software/sim/tools/validate_multi_vehicle_dds.sh

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive video bitrate (ABR) control with automatic profile selection, V0 fallback, and suspend/resume for severe impairments.
  * Runtime ABR commands, acknowledgements, and decision publishing with enriched telemetry (ABR snapshots, latency percentiles).

* **Packaging**
  * Package description, installer, and shipped config updated to include ABR components.

* **Tests**
  * New comprehensive tests and validation tooling for ABR behavior, retries, and decision timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements adaptive bitrate (ABR) control for video streaming in mesh networks. The implementation adds a deterministic state machine (`AbrPolicy`) that manages video quality transitions based on link health metrics (PDR, RTT, packet loss, heartbeat age), and a runtime controller (`VideoAbrController`) that parses SRT ladder configurations, emits encoder profile commands, and handles acknowledgment timeouts with retries.

## Key Changes
- **ABR Policy State Machine**: implements hysteresis and dwell windows to prevent oscillations, enforces V0 floor profile before optional video suspension during severe impairment, tracks reaction latency for observability
- **Video ABR Controller**: loads and validates ladder tiers from YAML config, builds encoder commands with resolution/bitrate/fps/gop parameters, implements ack timeout with configurable max retries
- **Mesh Agent Integration**: wires ABR into `StoreForwardTiles` node with ROS parameter configuration, monitors direct and relay link health metrics, publishes ABR decision telemetry
- **Validation**: adds unit tests for policy transitions and controller retry behavior, extends DDS validation script with ABR reaction latency p95 checks and V0-before-suspend ordering assertions

## Issues Found
- Missing `command_id` validation in `EncoderAck.from_payload` will raise unhelpful `TypeError` instead of descriptive `ValueError`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor error handling improvement recommended
- Score reflects well-structured implementation with comprehensive tests and validation. One logical error found in `EncoderAck.from_payload` where missing `command_id` raises unhelpful `TypeError` instead of descriptive error. Core ABR state machine logic is sound with proper hysteresis/dwell handling. Integration with mesh agent is clean. Test coverage includes policy transitions, V0 fallback enforcement, and retry behavior. Validation script properly asserts ABR reaction latency and ordering constraints.
- Pay close attention to `video_abr_controller.py:113` for the error handling fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/abr_policy.py | new ABR state machine with hysteresis, dwell windows, and V0 fallback logic |
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py | ABR controller with ladder parsing, encoder commands, and ack/retry handling |
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py | integrates ABR controller with mesh agent, adds link health monitoring and encoder transport |
| test/test_video_abr_policy.py | unit tests for ABR policy state transitions, V0 fallback, and encoder command retries |
| software/sim/tools/validate_multi_vehicle_dds.sh | adds ABR validation checks for reaction latency and V0-before-suspend ordering |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MA as MeshAgent
    participant ABR as AbrController
    participant Policy as AbrPolicy
    participant Encoder as VideoEncoder
    
    Note over MA: Link health monitoring
    MA->>MA: Sample PDR/RTT/packet loss
    MA->>ABR: evaluate(LinkHealthSample)
    ABR->>Policy: evaluate(sample)
    
    alt Severe impairment detected
        Policy-->>ABR: AbrDecision(to_profile=V0)
        ABR->>Encoder: EncoderCommand(V0 profile)
        Note over ABR: Start ack timeout timer
        alt Ack received
            Encoder-->>ABR: EncoderAck(command_id, status=ok)
            Note over ABR: Clear pending command
        else Timeout
            loop Retry up to max_retries
                ABR->>Encoder: Retry EncoderCommand
            end
        end
    else Degraded link
        Policy-->>ABR: AbrDecision(downgrade one step)
        ABR->>Encoder: EncoderCommand(lower tier)
    else Healthy link after dwell
        Policy-->>ABR: AbrDecision(upgrade one step)
        ABR->>Encoder: EncoderCommand(higher tier)
    else Still severe after hold period
        Policy-->>ABR: AbrDecision(action=suspend_video)
        ABR->>Encoder: EncoderCommand(suspend)
    end
    
    ABR->>MA: Decision payload + command
    MA->>MA: Publish ABR decision telemetry
```

<sub>Last reviewed commit: aa667f3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->