### PR TITLE
Bound untrusted zone geometry to prevent mission waypoint DoS

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/search_patterns.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/search_patterns.py
@@ -16,6 +16,9 @@ from .vehicle_ids import normalize_vehicle_id
 Waypoint = dict[str, float]
 
 _EPSILON = 1e-6
+_MAX_POLYGON_POINTS = 512
+_MAX_COORDINATE_ABS_M = 1_000_000.0
+_MAX_LAWNMOWER_ROWS = 10_000
 
 
 def validate_polygon(polygon: Iterable[dict[str, float]]) -> tuple[bool, str]:
@@ -35,6 +38,18 @@ def validate_polygon(polygon: Iterable[dict[str, float]]) -> tuple[bool, str]:
     normalized = _normalize_polygon(polygon)
     if len(normalized) < 3:
         return False, "polygon must contain at least 3 points"
+    if len(normalized) > _MAX_POLYGON_POINTS:
+        return (
+            False,
+            f"polygon contains too many points (max {_MAX_POLYGON_POINTS})",
+        )
+
+    min_x, max_x, min_z, max_z = _bounding_box(normalized)
+    if max(abs(min_x), abs(max_x), abs(min_z), abs(max_z)) > _MAX_COORDINATE_ABS_M:
+        return (
+            False,
+            "polygon coordinates exceed supported magnitude",
+        )
 
     area = _polygon_area(normalized)
     if area <= _EPSILON:
@@ -201,6 +216,8 @@ def generate_lawnmower_waypoints(
     row_index = 0
     waypoints: list[Waypoint] = []
     row_limit = math.ceil((max_z - min_z) / track_spacing_m) + 2
+    if row_limit > _MAX_LAWNMOWER_ROWS:
+        return []
 
     for _ in range(max(row_limit, 1)):
         intersections = _line_intersections_with_polygon(

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -464,6 +464,35 @@ def test_start_mission_rejects_non_finite_polygon_coordinates(mission_harness) -
     assert "invalid zone polygon" in response.message
 
 
+def test_start_mission_rejects_extreme_polygon_coordinates(mission_harness) -> None:
+    _, observer = mission_harness
+
+    request = MissionCommand.Request()
+    request.command = "START"
+    request.mission_id = "extreme-coordinates"
+    request.zone_geometry = json.dumps(
+        {
+            "pattern": "lawnmower",
+            "zone": {
+                "id": "zone-extreme-coordinates",
+                "polygon": [
+                    {"x": 0.0, "z": 0.0},
+                    {"x": 1_500_000.0, "z": 0.0},
+                    {"x": 1_500_000.0, "z": 10.0},
+                    {"x": 0.0, "z": 10.0},
+                ],
+            },
+        }
+    )
+    result_future = observer.start_client.call_async(request)
+
+    assert _wait_until(lambda: result_future.done())
+    response = result_future.result()
+    assert response is not None
+    assert not response.success
+    assert "invalid zone polygon" in response.message
+
+
 def test_start_mission_prefers_recently_seen_scout_endpoint(mission_harness) -> None:
     mission_node, observer = mission_harness
 

--- a/software/edge/src/aeris_orchestrator/test/test_search_patterns.py
+++ b/software/edge/src/aeris_orchestrator/test/test_search_patterns.py
@@ -57,11 +57,46 @@ def test_validate_polygon_rejects_non_finite_points() -> None:
     assert "at least 3 points" in reason
 
 
+def test_validate_polygon_rejects_too_many_points() -> None:
+    polygon = [{"x": float(index), "z": float(index % 3)} for index in range(513)]
+    valid, reason = validate_polygon(polygon)
+
+    assert not valid
+    assert "too many points" in reason
+
+
+def test_validate_polygon_rejects_extreme_coordinate_magnitude() -> None:
+    valid, reason = validate_polygon(
+        [
+            {"x": 0.0, "z": 0.0},
+            {"x": 1_500_000.0, "z": 0.0},
+            {"x": 1_500_000.0, "z": 10.0},
+            {"x": 0.0, "z": 10.0},
+        ]
+    )
+
+    assert not valid
+    assert "exceed supported magnitude" in reason
+
+
 def test_lawnmower_waypoints_stay_inside_polygon() -> None:
     polygon = _rectangle_polygon()
     waypoints = generate_waypoints("lawnmower", polygon, lawnmower_track_spacing_m=2.5)
     assert len(waypoints) > 2
     assert all(point_in_polygon(point, polygon) for point in waypoints)
+
+
+def test_lawnmower_waypoint_generation_limits_excessive_rows() -> None:
+    polygon = [
+        {"x": 0.0, "z": 0.0},
+        {"x": 5.0, "z": 0.0},
+        {"x": 5.0, "z": 60_000.0},
+        {"x": 0.0, "z": 60_000.0},
+    ]
+
+    waypoints = generate_waypoints("lawnmower", polygon, lawnmower_track_spacing_m=5.0)
+
+    assert waypoints == []
 
 
 def test_spiral_waypoints_stay_inside_polygon() -> None:


### PR DESCRIPTION
### Motivation
- The lawnmower waypoint generator iterated proportional to the polygon Z-span and accepted arbitrary polygon geometry, allowing an unauthenticated ROS client to submit huge or very dense polygons and cause massive CPU work or hangs. 
- The goal is to ensure untrusted `zone_geometry` is safely bounded before expensive waypoint generation while preserving existing planner behavior for normal inputs.

### Description
- Add explicit limits and guards in `aeris_orchestrator/search_patterns.py`: introduce `_MAX_POLYGON_POINTS`, `_MAX_COORDINATE_ABS_M`, and `_MAX_LAWNMOWER_ROWS` to bound input complexity and coordinate magnitude. 
- Extend `validate_polygon` to reject polygons with too many points or coordinates outside the allowed magnitude range, returning a clear error message. 
- Add a fail-fast cap in `generate_lawnmower_waypoints` to return early (empty waypoint list) when the computed row count exceeds `_MAX_LAWNMOWER_ROWS`. 
- Add unit tests exercising the new checks and behavior in `test/test_search_patterns.py` and a mission-level test in `test/test_mission_node.py` to verify a `START` request with extreme polygon coordinates is rejected.

### Testing
- Ran `PYTHONPATH=software/edge/src/aeris_orchestrator pytest -q software/edge/src/aeris_orchestrator/test/test_search_patterns.py` and observed all tests pass (`13 passed`).
- Ran the mission-node focused test with `PYTHONPATH=software/edge/src/aeris_orchestrator pytest -q software/edge/src/aeris_orchestrator/test/test_mission_node.py -k extreme_polygon_coordinates` in this environment and the module-level integration harness was skipped, so the targeted assertion was not executed here (`1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae27140f908322a5a07403addd782f)