### PR TITLE
Add automatic AI review triggers for pull requests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+    base_branches:
+      - ".*"

--- a/.github/workflows/ai-reviewers.yml
+++ b/.github/workflows/ai-reviewers.yml
@@ -1,0 +1,61 @@
+name: AI Reviewers
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  request-ai-review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger AI review bots
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = `<!-- ai-review-request:${context.payload.pull_request.head.sha} -->`;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              }
+            );
+
+            const alreadyPosted = comments.some(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                typeof comment.body === "string" &&
+                comment.body.includes(marker)
+            );
+
+            if (alreadyPosted) {
+              core.info("AI review request comment already exists for this commit.");
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: [
+                marker,
+                "@codex review",
+                "",
+                "Automatic AI review request for this PR."
+              ].join("\n"),
+            });

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,5 @@
+{
+  "strictness": 2,
+  "triggerOnUpdates": true,
+  "statusCheck": true
+}


### PR DESCRIPTION
Adds repo-side reviewer automation so pull requests consistently get AI review coverage.

- enable automatic CodeRabbit reviews for all PR target branches and incremental updates
- enable Greptile review updates and status checks
- trigger `@codex review` automatically when a PR opens or becomes ready for review

This keeps the automation separate from feature work and avoids relying on manual reviewer tags.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up three AI review tools — CodeRabbit, Greptile, and `@codex` — to run automatically on every pull request without requiring manual reviewer tags. The GitHub Actions workflow posts a deduplicated trigger comment; CodeRabbit and Greptile are configured via their own config files.

- `.github/workflows/ai-reviewers.yml` uses `pull_request_target` with `issues: write` / `pull-requests: write` permissions. The current script is safe, but the event trigger runs with base-repo write access even for fork PRs, which is a known escalation foothold if the workflow is extended later. It also does not list the `synchronize` event, so pushes to an already-open PR will not fire the `@codex review` comment despite the per-commit SHA deduplication implying that intent.
- `.coderabbit.yaml` enables auto-review and incremental review across all branches via the `\".*\"` regex; `auto_pause_after_reviewed_commits: 0` disables the pause behaviour.
- `.greptile/config.json` enables update-triggered reviews and a PR status check at strictness level 2.

<h3>Confidence Score: 3/5</h3>

The workflow needs two fixes before it is safe to merge: the pull_request_target trigger exposes write permissions to fork PRs, and the missing synchronize event means commits pushed to open PRs are silently ignored.

The workflow introduces pull_request_target with write permissions, which runs with base-repo access even from fork PRs — safe today but a latent foothold. The workflow also silently skips pushes to already-open PRs because synchronize is not listed as a trigger type, despite the per-SHA deduplication logic implying per-commit intent.

.github/workflows/ai-reviewers.yml needs the closest review — the trigger event and missing synchronize type are the two issues to resolve before merging.

<details open><summary><h3>Security Review</h3></summary>

- **Privileged event trigger from untrusted forks** (`.github/workflows/ai-reviewers.yml`): The workflow uses `pull_request_target`, which executes in the base repository's context — with repo secrets and write permissions — even when triggered by a fork PR. The current script does not execute any fork-supplied code, so there is no immediate exploit, but the pattern creates a foothold: any future change that checks out the PR head (`actions/checkout` with the fork ref) under this trigger would grant untrusted code full write access to the repository.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ai-reviewers.yml | New workflow using `pull_request_target` with write permissions — risky pattern for fork PRs; also missing `synchronize` trigger so new commits won't re-fire the review comment. |
| .coderabbit.yaml | Enables CodeRabbit auto-review on all branches (`".*"`); `auto_pause_after_reviewed_commits: 0` disables the pause feature, which is likely intentional. |
| .greptile/config.json | Straightforward Greptile config enabling update triggers and status checks at strictness level 2. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant GHActions as GitHub Actions
    participant Codex as @codex bot
    participant CR as CodeRabbit
    participant Greptile as Greptile

    Dev->>GH: Open / reopen PR or mark ready for review
    GH->>GHActions: pull_request_target event
    GHActions->>GH: List existing PR comments (paginated)
    alt Comment with matching SHA marker already exists
        GHActions->>GHActions: Skip (idempotency guard)
    else No existing marker
        GHActions->>GH: "Post comment with marker + "@codex review""
        GH->>Codex: Mention notification
        Codex->>GH: AI review posted
    end
    GH->>CR: PR event (auto_review enabled in .coderabbit.yaml)
    CR->>GH: CodeRabbit review posted
    GH->>Greptile: PR event (triggerOnUpdates in .greptile/config.json)
    Greptile->>GH: Greptile review + status check posted
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/ai-reviewers.yml:4-8
**`pull_request_target` with write permissions is a supply-chain risk**

`pull_request_target` runs in the context of the *base* repository — with access to repo secrets and with the `issues: write` / `pull-requests: write` grants — even when triggered by a pull request from a fork. The current script happens to be safe because it never checks out or executes fork code, but the combination of this event trigger and write permissions is a well-documented footgun: a future workflow edit that adds even an `actions/checkout` step with `ref: ${{ github.event.pull_request.head.sha }}` would immediately create a pwn-request-style RCE vector. The safer alternative is `pull_request` (which GitHub automatically withholds secrets and restricts permissions for fork PRs) or, if write access from forks is genuinely required, gating execution on `github.event.pull_request.head.repo.full_name == github.repository`.

### Issue 2 of 2
.github/workflows/ai-reviewers.yml:4-8
**`synchronize` event missing — new commits won't trigger a review**

The deduplication marker embeds `head.sha`, which means each commit gets a unique marker and a new `@codex review` comment is expected per push. But `synchronize` (the event that fires when commits are pushed to the PR branch) is not listed under `types`, so the workflow will only run on `opened`, `reopened`, and `ready_for_review`. Pushes to an already-open PR won't fire this workflow, leaving subsequent commits without an automated `@codex review` trigger.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add automatic AI PR review triggers"](https://github.com/aeris-drones/aeris/commit/aed04d54c4606bd9953ef971069ac9a456f7b733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32422749)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->