### PR TITLE
Show degraded vehicle state in tactical display

### DIFF
--- a/docker/rosbridge/README.md
+++ b/docker/rosbridge/README.md
@@ -2,6 +2,8 @@
 
 This folder builds a small self-contained rosbridge image that also includes the project's custom ROS 2 message types (`aeris_msgs`) so the viewer can subscribe/publish via WebSocket without runtime `apt-get`/`colcon` steps.
 
+Rebuild this image whenever `software/edge/src/aeris_msgs/msg/*.msg` changes, including `MapTile.msg` provenance fields used by the viewer.
+
 ## Run
 
 From repo root:
@@ -22,4 +24,3 @@ docker port aeris-rosbridge
 ```bash
 docker compose -f docker-compose.rosbridge.yml down
 ```
-

--- a/software/edge/src/aeris_map/README.md
+++ b/software/edge/src/aeris_map/README.md
@@ -44,6 +44,7 @@ Select the source via launch parameters without modifying core code.
    - `hash_sha256`: Content hash for cache validation
    - `byte_size`: Payload size for bandwidth estimation
    - `layer_ids`: Composition hints for multi-layer rendering
+   - `source_vehicle_id`: Vehicle provenance for GCS last-known/stale-region styling
 
 2. **Byte Request**: Consumer calls `GetMapTileBytes` service with `tile_id`
 
@@ -58,6 +59,8 @@ Select the source via launch parameters without modifying core code.
 
 - **Topic**: `/map/tiles` (`aeris_msgs/MapTile`)
 - **Service**: `/map/get_tile_bytes` (`aeris_msgs/GetMapTileBytes`)
+
+Changing `aeris_msgs/MapTile` requires rebuilding the rosbridge image so the GCS receives the updated message schema over WebSocket.
 
 ## MBTiles 1.3 Storage
 

--- a/software/edge/src/aeris_map/config/map_tile_stream.yaml
+++ b/software/edge/src/aeris_map/config/map_tile_stream.yaml
@@ -89,3 +89,7 @@ map_tile_publisher:
     # Layer identifiers enable multi-layer composition in ground station UI.
     # Format: [source_type, fetch_endpoint, mime_type]
     layer_ids: ["occupancy", "fetch-service:/map/get_tile_bytes", "mime:image/png"]
+
+    # Vehicle provenance for last-known tile ownership in the viewer.
+    # Multi-vehicle launches should override this per vehicle instance.
+    source_vehicle_id: ""

--- a/software/edge/src/aeris_map/include/aeris_map/tile_contract.hpp
+++ b/software/edge/src/aeris_map/include/aeris_map/tile_contract.hpp
@@ -64,12 +64,14 @@ std::string sha256_hex(const std::vector<uint8_t> & bytes);
  * @param layer_ids Vector of layer identifiers for UI composition
  * @param hash_sha256 SHA-256 hex digest of tile payload
  * @param byte_size Size of tile payload in bytes
+ * @param source_vehicle_id Vehicle that produced this tile, if known
  * @return Populated MapTile message ready for publication
  */
 aeris_msgs::msg::MapTile build_descriptor(
   const std::string & tile_id,
   const std::vector<std::string> & layer_ids,
   const std::string & hash_sha256,
-  uint32_t byte_size);
+  uint32_t byte_size,
+  const std::string & source_vehicle_id = "");
 
 }  // namespace aeris_map::tile_contract

--- a/software/edge/src/aeris_map/launch/rtabmap_vio_sim.launch.py
+++ b/software/edge/src/aeris_map/launch/rtabmap_vio_sim.launch.py
@@ -51,6 +51,7 @@ def generate_launch_description() -> LaunchDescription:
     mbtiles_path = LaunchConfiguration('mbtiles_path')
     map_source = LaunchConfiguration('map_source')
     slam_mode = LaunchConfiguration('slam_mode')
+    source_vehicle_id = LaunchConfiguration('source_vehicle_id')
     rtabmap_database_path = LaunchConfiguration('rtabmap_database_path')
     openvins_log_directory = LaunchConfiguration('openvins_log_directory')
 
@@ -126,6 +127,7 @@ def generate_launch_description() -> LaunchDescription:
                 'mbtiles_path': mbtiles_path,
                 'map_source': map_source,
                 'slam_mode': slam_mode,
+                'source_vehicle_id': source_vehicle_id,
             },
         ],
     )
@@ -186,6 +188,10 @@ def generate_launch_description() -> LaunchDescription:
         DeclareLaunchArgument('mbtiles_path', default_value=mbtiles_default),
         DeclareLaunchArgument('map_source', default_value='occupancy'),
         DeclareLaunchArgument('slam_mode', default_value='vio'),
+        DeclareLaunchArgument(
+            'source_vehicle_id',
+            default_value=LaunchConfiguration('scout_model_name'),
+        ),
         DeclareLaunchArgument('map_frame', default_value='map'),
         DeclareLaunchArgument('odom_frame', default_value='odom'),
         DeclareLaunchArgument('base_frame', default_value='base_link'),

--- a/software/edge/src/aeris_map/src/map_tile_publisher.cpp
+++ b/software/edge/src/aeris_map/src/map_tile_publisher.cpp
@@ -395,6 +395,7 @@ public:
     layer_ids_ = this->declare_parameter<std::vector<std::string>>(
       "layer_ids",
       default_layer_ids);
+    source_vehicle_id_ = this->declare_parameter<std::string>("source_vehicle_id", "");
 
     initialize_mbtiles();
 
@@ -895,7 +896,8 @@ private:
       tile_id,
       layer_ids_,
       hash,
-      static_cast<uint32_t>(bytes.size()));
+      static_cast<uint32_t>(bytes.size()),
+      source_vehicle_id_);
 
     TilePayload payload;
     payload.data = bytes;
@@ -1073,6 +1075,7 @@ private:
   std::string mbtiles_path_;
   std::string map_source_;
   std::vector<std::string> layer_ids_;
+  std::string source_vehicle_id_;
   aeris_map::slam_backend::BackendActivation slam_backend_;
 
   sqlite3 * db_{nullptr};

--- a/software/edge/src/aeris_map/src/tile_contract.cpp
+++ b/software/edge/src/aeris_map/src/tile_contract.cpp
@@ -81,7 +81,8 @@ aeris_msgs::msg::MapTile build_descriptor(
   const std::string & tile_id,
   const std::vector<std::string> & layer_ids,
   const std::string & hash_sha256,
-  uint32_t byte_size)
+  uint32_t byte_size,
+  const std::string & source_vehicle_id)
 {
   aeris_msgs::msg::MapTile descriptor;
   descriptor.tile_id = tile_id;
@@ -89,6 +90,7 @@ aeris_msgs::msg::MapTile build_descriptor(
   descriptor.layer_ids = layer_ids;
   descriptor.hash_sha256 = hash_sha256;
   descriptor.byte_size = byte_size;
+  descriptor.source_vehicle_id = source_vehicle_id;
   return descriptor;
 }
 

--- a/software/edge/src/aeris_map/test/test_tile_contract.cpp
+++ b/software/edge/src/aeris_map/test/test_tile_contract.cpp
@@ -69,7 +69,8 @@ TEST(TileContract, PopulatesMapTileSchema)
     "10/123/456",
     std::vector<std::string>{"occupancy", "fetch-service:/map/get_tile_bytes"},
     "deadbeef",
-    1024);
+    1024,
+    "scout-1");
 
   EXPECT_EQ(descriptor.tile_id, "10/123/456");
   EXPECT_EQ(descriptor.format, "mbtiles-1.3");
@@ -77,4 +78,5 @@ TEST(TileContract, PopulatesMapTileSchema)
   EXPECT_EQ(descriptor.layer_ids[0], "occupancy");
   EXPECT_EQ(descriptor.hash_sha256, "deadbeef");
   EXPECT_EQ(descriptor.byte_size, 1024U);
+  EXPECT_EQ(descriptor.source_vehicle_id, "scout-1");
 }

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -1121,6 +1121,15 @@ class StoreForwardTiles(Node):
         relay_hop: int = 0,
     ) -> None:
         decision = route_decision or self._select_route_decision()
+        source_vehicle_id = self._source_vehicle_id_from_message(
+            message,
+            input_topic=input_topic,
+            is_relay_ingress=route_key.startswith("relay_"),
+        )
+        if message_kind == "map_tile" and source_vehicle_id and not getattr(
+            message, "source_vehicle_id", ""
+        ):
+            message.source_vehicle_id = source_vehicle_id
         target_topic, target_route_key = self._resolve_route_target(
             delivery_mode=decision.delivery_mode,
             output_topic=output_topic,
@@ -1135,11 +1144,6 @@ class StoreForwardTiles(Node):
             payload_hash=payload_hash,
         )
         event_ts = extract_event_timestamp(message)
-        source_vehicle_id = self._source_vehicle_id_from_message(
-            message,
-            input_topic=input_topic,
-            is_relay_ingress=route_key.startswith("relay_"),
-        )
         if route_key.startswith("relay_") and not source_vehicle_id:
             self.get_logger().warning(
                 "relay ingress message missing source vehicle metadata "

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -1121,11 +1121,15 @@ class StoreForwardTiles(Node):
         relay_hop: int = 0,
     ) -> None:
         decision = route_decision or self._select_route_decision()
-        source_vehicle_id = self._source_vehicle_id_from_message(
-            message,
-            input_topic=input_topic,
-            is_relay_ingress=route_key.startswith("relay_"),
-        )
+        source_vehicle_id = ""
+        if message_kind == "map_tile":
+            source_vehicle_id = str(getattr(message, "source_vehicle_id", "") or "")
+        if not source_vehicle_id:
+            source_vehicle_id = self._source_vehicle_id_from_message(
+                message,
+                input_topic=input_topic,
+                is_relay_ingress=route_key.startswith("relay_"),
+            )
         if message_kind == "map_tile" and source_vehicle_id and not getattr(
             message, "source_vehicle_id", ""
         ):

--- a/software/edge/src/aeris_msgs/msg/MapTile.msg
+++ b/software/edge/src/aeris_msgs/msg/MapTile.msg
@@ -6,3 +6,4 @@ string format        # Image encoding (e.g., "png", "webp") for client-side deco
 string[] layer_ids   # Active map layers this tile contributes to (elevation, imagery, etc.)
 string hash_sha256   # Content hash for cache validation and deduplication
 uint32 byte_size     # Uncompressed size in bytes for storage planning
+string source_vehicle_id # Vehicle that produced the tile for stale-region ownership

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -530,7 +530,11 @@ function V2PageContent() {
           const vehicle = fleetVehicles.find(v => v.id === pipVehicleId);
           if (!vehicle) return null;
 
-          const isLive = vehicle.status === 'active' || vehicle.status === 'warning';
+          const isLive =
+            (vehicle.status === 'active' || vehicle.status === 'warning' || vehicle.status === 'returning') &&
+            vehicle.deliveryMode !== 'replayed' &&
+            vehicle.isRetroactive !== true &&
+            vehicle.isLastKnown !== true;
 
           return (
             <PiPVideoFeed

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -27,6 +27,8 @@ import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useFusedDetections } from '@/hooks/useFusedDetections';
 import { applyDetectionStatusOverrides, computeDetectionCounts } from '@/lib/detectionViewState';
 import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
+import { applyVehicleMissionMeta } from '@/lib/fleetVehicleProjection';
+import { normalizeMissionMetaForVehicle } from '@/lib/degradedVehicleState';
 
 /**
  * Mock detections for UI demonstration when ROS telemetry is unavailable.
@@ -124,6 +126,7 @@ function V2PageContent() {
     abortMission,
     rosConnected,
     vehicleSlamModes,
+    vehicleMissionMeta,
   } = useMissionControl();
   const {
     vehicles: telemetryVehicles,
@@ -161,25 +164,34 @@ function V2PageContent() {
    * the Aeris GCS for consistent spatial reasoning.
    */
   const fleetVehicles = useMemo<VehicleInfo[]>(() => {
-    return telemetryVehicles.map((vehicle) => ({
-      status: vehicle.deliveryMode === 'replayed' || vehicle.isRetroactive
-        ? 'warning'
-        : 'active',
-      id: vehicle.id,
-      name: vehicle.id.replace(/[_-]/g, ' ').toUpperCase(),
-      battery: typeof vehicle.batteryPercent === 'number'
-        ? Math.round(vehicle.batteryPercent)
-        : null,
-      altitude: Math.round(vehicle.position.y),
-      linkQuality: typeof vehicle.linkQualityPercent === 'number'
-        ? Math.round(vehicle.linkQualityPercent)
-        : undefined,
-      coverage: typeof vehicle.coveragePercent === 'number'
-        ? Math.round(vehicle.coveragePercent)
-        : undefined,
-      slamMode: vehicleSlamModes[normalizeVehicleId(vehicle.id)],
-    }));
-  }, [telemetryVehicles, vehicleSlamModes]);
+    return telemetryVehicles.map((vehicle) => {
+      const missionMeta = normalizeMissionMetaForVehicle(vehicle.id, vehicleMissionMeta);
+      return applyVehicleMissionMeta(
+        {
+          status: (vehicle.deliveryMode === 'replayed' || vehicle.isRetroactive
+            ? 'warning'
+            : 'active') as VehicleInfo['status'],
+          id: vehicle.id,
+          name: vehicle.id.replace(/[_-]/g, ' ').toUpperCase(),
+          battery: typeof vehicle.batteryPercent === 'number'
+            ? Math.round(vehicle.batteryPercent)
+            : null,
+          altitude: Math.round(vehicle.position.y),
+          linkQuality: typeof vehicle.linkQualityPercent === 'number'
+            ? Math.round(vehicle.linkQualityPercent)
+            : undefined,
+          coverage: typeof vehicle.coveragePercent === 'number'
+            ? Math.round(vehicle.coveragePercent)
+            : undefined,
+          slamMode: vehicleSlamModes[normalizeVehicleId(vehicle.id)],
+          lastUpdate: vehicle.lastUpdate,
+          deliveryMode: vehicle.deliveryMode,
+          isRetroactive: vehicle.isRetroactive,
+        },
+        missionMeta
+      );
+    });
+  }, [telemetryVehicles, vehicleMissionMeta, vehicleSlamModes]);
 
   /**
    * Map of vehicle IDs to their ground-plane (X, Z) positions for camera teleport.
@@ -420,6 +432,7 @@ function V2PageContent() {
       map={
         <MapScene3D
           vehicles={telemetryVehicles}
+          vehicleMissionMeta={vehicleMissionMeta}
           returnTrajectories={returnTrajectories}
           ref={mapRef}
           detections={detections}

--- a/software/viewer/src/components/cards/FleetCard.tsx
+++ b/software/viewer/src/components/cards/FleetCard.tsx
@@ -12,8 +12,9 @@ import { cn } from '@/lib/utils';
  * - error: Critical issue requiring immediate attention
  * - returning: Vehicle is executing return-to-launch sequence
  * - idle: Vehicle is on ground and ready
+ * - offline: Last-known state; telemetry is stale or mission progress says offline
  */
-export type VehicleStatus = 'active' | 'warning' | 'error' | 'returning' | 'idle';
+export type VehicleStatus = 'active' | 'warning' | 'error' | 'returning' | 'idle' | 'offline';
 
 export interface VehicleInfo {
   id: string;
@@ -49,6 +50,7 @@ const statusColors: Record<VehicleStatus, string> = {
   error: 'bg-[var(--danger)]',
   returning: 'bg-[var(--info)]',
   idle: 'bg-white/30',
+  offline: 'bg-zinc-500',
 };
 
 /**

--- a/software/viewer/src/components/map/DroneMarker3D.tsx
+++ b/software/viewer/src/components/map/DroneMarker3D.tsx
@@ -16,7 +16,7 @@ export interface DroneMarker3DProps {
   /** Display name for the vehicle - shown in the marker UI */
   vehicleName: string;
   /** Operational status - drives color coding and visual indicators */
-  status: 'active' | 'warning' | 'error' | 'returning';
+  status: 'active' | 'warning' | 'error' | 'returning' | 'offline';
   /** Whether this drone is currently selected - enables selection effects */
   isSelected: boolean;
   /** Whether to show the flight trail - controlled by layer visibility */
@@ -29,6 +29,8 @@ export interface DroneMarker3DProps {
   deliveryMode?: 'live' | 'replayed';
   /** Whether this marker represents replayed telemetry */
   isRetroactive?: boolean;
+  /** Age in milliseconds since the last live telemetry contact */
+  lastContactAgeMs?: number | null;
 }
 
 /** Status color mapping for visual feedback across the GCS */
@@ -37,7 +39,17 @@ const STATUS_COLORS = {
   warning: '#f59e0b',
   error: '#ef4444',
   returning: '#3b82f6',
+  offline: '#a1a1aa',
 };
+
+function formatMarkerAge(ageMs?: number | null): string {
+  if (!Number.isFinite(ageMs ?? Number.NaN)) {
+    return '--';
+  }
+  const seconds = Math.floor((ageMs ?? 0) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
+}
 
 /**
  * 3D visual representation of a drone in the Three.js scene.
@@ -74,12 +86,14 @@ export function DroneMarker3D({
   onClick,
   deliveryMode,
   isRetroactive,
+  lastContactAgeMs,
 }: DroneMarker3DProps) {
   const groupRef = useRef<THREE.Group>(null);
   const ringRef = useRef<THREE.Mesh>(null);
   const pulseRef = useRef<THREE.Mesh>(null);
   const statusColor = STATUS_COLORS[status];
   const showReplayBadge = deliveryMode === 'replayed' || isRetroactive === true;
+  const isOffline = status === 'offline';
 
   /**
    * Per-frame animation loop for selection effects.
@@ -147,9 +161,9 @@ export function DroneMarker3D({
         <mesh castShadow>
           <boxGeometry args={[8, 3, 8]} />
           <meshStandardMaterial
-            color={isSelected ? '#ffffff' : '#2a2a3a'}
+            color={isOffline ? '#34343a' : isSelected ? '#ffffff' : '#2a2a3a'}
             emissive={statusColor}
-            emissiveIntensity={isSelected ? 0.3 : 0.1}
+            emissiveIntensity={isOffline ? 0.03 : isSelected ? 0.3 : 0.1}
           />
         </mesh>
 
@@ -206,6 +220,11 @@ export function DroneMarker3D({
           {showReplayBadge && (
             <span className="ml-2 rounded border border-cyan-300/60 bg-cyan-400/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-cyan-200">
               Replayed
+            </span>
+          )}
+          {isOffline && (
+            <span className="ml-2 rounded border border-zinc-300/50 bg-zinc-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-100">
+              Last Known {formatMarkerAge(lastContactAgeMs)}
             </span>
           )}
         </div>

--- a/software/viewer/src/components/map/DroneMarker3D.tsx
+++ b/software/viewer/src/components/map/DroneMarker3D.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
+import { formatLastContactAge as formatMarkerAge } from '@/lib/degradedVehicleState';
 
 /** Props for the DroneMarker3D component - uses Three.js coordinate system where y is up */
 export interface DroneMarker3DProps {
@@ -41,15 +42,6 @@ const STATUS_COLORS = {
   returning: '#3b82f6',
   offline: '#a1a1aa',
 };
-
-function formatMarkerAge(ageMs?: number | null): string {
-  if (!Number.isFinite(ageMs ?? Number.NaN)) {
-    return '--';
-  }
-  const seconds = Math.floor((ageMs ?? 0) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
-}
 
 /**
  * 3D visual representation of a drone in the Three.js scene.

--- a/software/viewer/src/components/map/DroneMarker3DSurface.test.mjs
+++ b/software/viewer/src/components/map/DroneMarker3DSurface.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const FILE_PATH = path.join(process.cwd(), "src", "components", "map", "DroneMarker3D.tsx");
+
+test("DroneMarker3D reuses the shared last-contact formatter", () => {
+  const source = fs.readFileSync(FILE_PATH, "utf8");
+
+  assert.match(
+    source,
+    /import\s*\{\s*formatLastContactAge as formatMarkerAge\s*\}\s*from\s*['"]@\/lib\/degradedVehicleState['"]/,
+    "DroneMarker3D should import the shared last-contact formatter"
+  );
+  assert.doesNotMatch(
+    source,
+    /function formatMarkerAge\(/,
+    "DroneMarker3D should not keep a local duplicate of the age formatter"
+  );
+});

--- a/software/viewer/src/components/map/MapScene3D.tsx
+++ b/software/viewer/src/components/map/MapScene3D.tsx
@@ -15,6 +15,12 @@ import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useLayerVisibility } from '@/context/LayerVisibilityContext';
 import type { TileData } from '@/lib/map/MapTileManager';
 import type { VehicleState } from '@/lib/vehicle/VehicleManager';
+import {
+  deriveVehicleDegradedState,
+  normalizeMissionMetaForVehicle,
+  type MissionMetaMaps,
+} from '@/lib/degradedVehicleState';
+import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
 
 /**
  * Imperative handle interface exposed by MapScene3D.
@@ -35,6 +41,8 @@ export interface MapScene3DHandle {
 interface MapScene3DProps {
   /** Optional vehicle telemetry snapshot from the parent */
   vehicles?: VehicleState[];
+  /** Optional mission metadata used to resolve online/offline hints */
+  vehicleMissionMeta?: MissionMetaMaps;
   /** Optional return trajectories from the parent */
   returnTrajectories?: Record<string, [number, number, number][]>;
   /** Sensor detections to render in the scene */
@@ -84,6 +92,7 @@ interface MapScene3DProps {
 export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
   ({
     vehicles: vehiclesProp,
+    vehicleMissionMeta = {},
     returnTrajectories: returnTrajectoriesProp,
     detections = [],
     selectedDroneId,
@@ -110,6 +119,22 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
     const cameraControlsRef = useRef<CameraControls>(null);
     const vehicles = vehiclesProp ?? liveVehicles;
     const returnTrajectories = returnTrajectoriesProp ?? liveReturnTrajectories;
+    const offlineVehicleIds = useMemo(() => {
+      const ids = new Set<string>();
+      vehicles.forEach((vehicle) => {
+        const missionMeta = normalizeMissionMetaForVehicle(vehicle.id, vehicleMissionMeta);
+        const degraded = deriveVehicleDegradedState({
+          lastUpdate: vehicle.lastUpdate,
+          missionOnline: missionMeta.online,
+          deliveryMode: vehicle.deliveryMode,
+          isRetroactive: vehicle.isRetroactive,
+        });
+        if (degraded.offline) {
+          ids.add(normalizeVehicleId(vehicle.id));
+        }
+      });
+      return ids;
+    }, [vehicles, vehicleMissionMeta]);
 
     const telemetryDrones: Omit<DroneMarker3DProps, 'isSelected' | 'onClick'>[] = vehicles.map((vehicle) => {
       const trailPoints: [number, number, number][] = vehicle.trajectory.map((point) => [
@@ -117,17 +142,29 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
         point.y,
         point.z,
       ]);
+      const missionMeta = normalizeMissionMetaForVehicle(vehicle.id, vehicleMissionMeta);
+      const degraded = deriveVehicleDegradedState({
+        lastUpdate: vehicle.lastUpdate,
+        missionOnline: missionMeta.online,
+        deliveryMode: vehicle.deliveryMode,
+        isRetroactive: vehicle.isRetroactive,
+      });
 
       return {
         vehicleId: vehicle.id,
         vehicleName: vehicle.id.replace(/_/g, ' ').toUpperCase(),
         position: [vehicle.position.x, vehicle.position.y, vehicle.position.z],
         heading: (vehicle.heading * 180) / Math.PI,
-        status: 'active',
+        status: degraded.status === 'offline'
+          ? 'offline'
+          : degraded.status === 'warning'
+            ? 'warning'
+            : 'active',
         showTrail: trailPoints.length > 1,
         trailPoints,
         deliveryMode: vehicle.deliveryMode,
         isRetroactive: vehicle.isRetroactive,
+        lastContactAgeMs: degraded.lastContactAgeMs,
       };
     });
 
@@ -210,7 +247,11 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
           {/* Map tiles */}
           {visibility.map &&
             mapTiles.map((tile) => (
-              <MapTile3D key={tile.id} tile={tile} />
+              <MapTile3D
+                key={tile.id}
+                tile={tile}
+                isStale={!!tile.sourceVehicleId && offlineVehicleIds.has(normalizeVehicleId(tile.sourceVehicleId))}
+              />
             ))}
 
           {/* Render order: trails first so markers appear on top */}
@@ -327,7 +368,7 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
 
 MapScene3D.displayName = 'MapScene3D';
 
-function MapTile3D({ tile }: { tile: TileData }) {
+function MapTile3D({ tile, isStale = false }: { tile: TileData; isStale?: boolean }) {
   const texture = useMemo(() => {
     const loaded = new THREE.TextureLoader().load(tile.url);
     loaded.colorSpace = THREE.SRGBColorSpace;
@@ -353,9 +394,20 @@ function MapTile3D({ tile }: { tile: TileData }) {
         <meshBasicMaterial
           map={texture}
           transparent
-          opacity={0.96}
+          opacity={isStale ? 0.42 : 0.96}
         />
       </mesh>
+      {isStale && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.025, 0]}>
+          <planeGeometry args={[tile.size, tile.size]} />
+          <meshBasicMaterial
+            color="#71717a"
+            transparent
+            opacity={0.32}
+            wireframe
+          />
+        </mesh>
+      )}
       {showReplayBadge && (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
           <ringGeometry args={[tile.size * 0.42, tile.size * 0.48, 48]} />

--- a/software/viewer/src/components/pip/PiPVideoFeed.tsx
+++ b/software/viewer/src/components/pip/PiPVideoFeed.tsx
@@ -17,7 +17,7 @@ import { cn } from '@/lib/utils';
 interface Vehicle {
   id: string;
   name: string;
-  status: 'active' | 'idle' | 'warning' | 'returning' | 'error';
+  status: 'active' | 'idle' | 'warning' | 'returning' | 'error' | 'offline';
 }
 
 interface PiPVideoFeedProps {

--- a/software/viewer/src/components/pip/PiPVideoFeedSurface.test.mjs
+++ b/software/viewer/src/components/pip/PiPVideoFeedSurface.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const PAGE_PATH = path.join(process.cwd(), "src", "app", "page.tsx");
+
+test("PiP live badge stays off for replayed or last-known vehicles", () => {
+  const source = fs.readFileSync(PAGE_PATH, "utf8");
+
+  assert.match(
+    source,
+    /vehicle\.deliveryMode !== 'replayed'/,
+    "PiPVideoFeed should not mark replayed telemetry as live video"
+  );
+  assert.match(
+    source,
+    /vehicle\.isRetroactive !== true/,
+    "PiPVideoFeed should keep retroactive catch-up distinct from live feeds"
+  );
+  assert.match(
+    source,
+    /vehicle\.isLastKnown !== true/,
+    "PiPVideoFeed should not advertise last-known offline vehicles as live"
+  );
+});

--- a/software/viewer/src/components/sheets/VehicleCard.tsx
+++ b/software/viewer/src/components/sheets/VehicleCard.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { MapPin, Video, Home, Signal, Gauge, Radio } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatLastContactAge } from '@/lib/degradedVehicleState';
 
 /**
  * Vehicle operational status for UI display.
@@ -11,7 +12,7 @@ import { cn } from '@/lib/utils';
  * in the GCS. Critical statuses (error, returning) receive heightened visual
  * prominence to ensure operator awareness during multi-vehicle operations.
  */
-export type VehicleStatus = 'active' | 'warning' | 'error' | 'returning' | 'idle';
+export type VehicleStatus = 'active' | 'warning' | 'error' | 'returning' | 'idle' | 'offline';
 
 /**
  * Core telemetry snapshot for a single vehicle.
@@ -30,6 +31,8 @@ export interface VehicleInfo {
   linkQuality?: number;
   coverage?: number;
   slamMode?: string;
+  lastContactAgeMs?: number | null;
+  isLastKnown?: boolean;
 }
 
 /**
@@ -90,6 +93,12 @@ const statusConfig: Record<VehicleStatus, {
     color: 'text-white/40',
     glow: '',
     dot: 'bg-white/40'
+  },
+  offline: {
+    label: 'OFFLINE',
+    color: 'text-zinc-300',
+    glow: '',
+    dot: 'bg-zinc-500'
   },
 };
 
@@ -190,6 +199,7 @@ export function VehicleCard({
   onRTH,
 }: VehicleCardProps) {
   const status = statusConfig[vehicle.status];
+  const isOffline = vehicle.status === 'offline';
 
   return (
     <div
@@ -198,6 +208,7 @@ export function VehicleCard({
         'bg-white/[0.03] backdrop-blur-md',
         'border border-white/[0.06]',
         status.glow,
+        isOffline && 'grayscale opacity-75 bg-zinc-950/60 border-zinc-500/20',
         isSelected && 'ring-2 ring-cyan-500/50',
         vehicle.status === 'error' && 'border-red-500/20'
       )}
@@ -217,6 +228,14 @@ export function VehicleCard({
           >
             SLAM: {formatSlamModeLabel(vehicle.slamMode)}
           </span>
+          {isOffline && (
+            <span
+              className="text-[10px] font-semibold tracking-[0.16em] text-zinc-300"
+              data-testid="vehicle-last-known-age"
+            >
+              LAST CONTACT {formatLastContactAge(vehicle.lastContactAgeMs)}
+            </span>
+          )}
         </div>
 
         <div className="relative">

--- a/software/viewer/src/components/sheets/VehicleCard.tsx
+++ b/software/viewer/src/components/sheets/VehicleCard.tsx
@@ -33,6 +33,8 @@ export interface VehicleInfo {
   slamMode?: string;
   lastContactAgeMs?: number | null;
   isLastKnown?: boolean;
+  deliveryMode?: 'live' | 'replayed';
+  isRetroactive?: boolean;
 }
 
 /**

--- a/software/viewer/src/components/sheets/VehicleCardSurface.test.mjs
+++ b/software/viewer/src/components/sheets/VehicleCardSurface.test.mjs
@@ -114,3 +114,33 @@ test("VehicleCard slam mode formatter preserves explicit labels and UNKNOWN fall
   assert.ok(returnedLabels.has("VIO"), "VehicleCard should present the VIO label cleanly");
   assert.ok(returnedLabels.has("LIO-SAM"), "VehicleCard should present the LIO-SAM label cleanly");
 });
+
+test("VehicleCard exposes offline last-known status and timer copy", () => {
+  const cardPath = path.join(ROOT, "VehicleCard.tsx");
+  const { source, sourceFile } = parseTsx(cardPath);
+
+  assert.match(source, /offline:/, "VehicleCard should define an offline status config");
+  assert.match(source, /OFFLINE/, "VehicleCard should render an explicit OFFLINE label");
+  assert.match(source, /vehicle-last-known-age/, "VehicleCard should expose a targeted last-contact timer");
+
+  let importsLastContactFormatter = false;
+  let formatsLastContactAge = false;
+  walk(sourceFile, (node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      node.moduleSpecifier.getText(sourceFile).includes("degradedVehicleState")
+    ) {
+      importsLastContactFormatter = true;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(sourceFile) === "formatLastContactAge" &&
+      node.arguments[0]?.getText(sourceFile) === "vehicle.lastContactAgeMs"
+    ) {
+      formatsLastContactAge = true;
+    }
+  });
+
+  assert.ok(importsLastContactFormatter);
+  assert.ok(formatsLastContactAge);
+});

--- a/software/viewer/src/hooks/useMissionControl.ts
+++ b/software/viewer/src/hooks/useMissionControl.ts
@@ -61,6 +61,13 @@ export interface MissionControlState {
   completeMission: () => void;
   rosConnected: boolean;
   vehicleSlamModes: Record<string, string>;
+  vehicleMissionMeta: {
+    assignments: Record<string, string>;
+    assignmentLabels: Record<string, string>;
+    progress: Record<string, number>;
+    online: Record<string, boolean>;
+    slamModes: Record<string, string>;
+  };
 }
 
 /**
@@ -101,6 +108,9 @@ export function useMissionControl(): MissionControlState {
   const [startMissionError, setStartMissionError] = useState<string | null>(null);
   const [abortMissionError, setAbortMissionError] = useState<string | null>(null);
   const [vehicleSlamModes, setVehicleSlamModes] = useState<Record<string, string>>({});
+  const [vehicleMissionMeta, setVehicleMissionMeta] = useState(() =>
+    extractVehicleMissionMetaFromProgressPayload({})
+  );
 
   const hasValidStartZone =
     !!selectedZone && selectedZone.status === 'active' && selectedZone.polygon.length >= 3;
@@ -188,6 +198,7 @@ export function useMissionControl(): MissionControlState {
   useEffect(() => {
     if (!ros || !rosConnected) {
       setVehicleSlamModes({});
+      setVehicleMissionMeta(extractVehicleMissionMetaFromProgressPayload({}));
       return;
     }
 
@@ -262,8 +273,31 @@ export function useMissionControl(): MissionControlState {
           grid_completed?: number;
           grid_total?: number;
         };
-        const { slamModes } =
+        const extractedMeta =
           extractVehicleMissionMetaFromProgressPayload(parsedProgress);
+        const { slamModes } = extractedMeta;
+        setVehicleMissionMeta((previous) => ({
+          assignments: {
+            ...previous.assignments,
+            ...extractedMeta.assignments,
+          },
+          assignmentLabels: {
+            ...previous.assignmentLabels,
+            ...extractedMeta.assignmentLabels,
+          },
+          progress: {
+            ...previous.progress,
+            ...extractedMeta.progress,
+          },
+          online: {
+            ...previous.online,
+            ...extractedMeta.online,
+          },
+          slamModes: {
+            ...previous.slamModes,
+            ...extractedMeta.slamModes,
+          },
+        }));
         if (Object.keys(slamModes).length > 0) {
           setVehicleSlamModes((previous) => ({
             ...previous,
@@ -517,6 +551,7 @@ export function useMissionControl(): MissionControlState {
     abortMissionError,
     rosConnected,
     vehicleSlamModes,
+    vehicleMissionMeta,
   };
 }
 

--- a/software/viewer/src/hooks/useVehicleTelemetry.ts
+++ b/software/viewer/src/hooks/useVehicleTelemetry.ts
@@ -280,7 +280,7 @@ export function useVehicleTelemetry(options: UseVehicleTelemetryOptions = {}) {
       const interval = setInterval(() => {
           const currentVehicles = manager.getVehicles();
           setVehicleState((previous) => {
-            if (currentVehicles.length === previous.vehicles.length) {
+            if (currentVehicles.length === 0 && previous.vehicles.length === 0) {
               return previous;
             }
             return {

--- a/software/viewer/src/hooks/useVehicleTelemetrySurface.test.mjs
+++ b/software/viewer/src/hooks/useVehicleTelemetrySurface.test.mjs
@@ -157,6 +157,27 @@ test("MapScene3D disables duplicate subscriptions when parent props already prov
   );
 });
 
+test("MapScene3D derives offline marker and stale tile ownership from shared state", () => {
+  const mapScenePath = path.join(ROOT, "components", "map", "MapScene3D.tsx");
+  const source = fs.readFileSync(mapScenePath, "utf8");
+
+  assert.match(
+    source,
+    /vehicleMissionMeta\?: MissionMetaMaps/,
+    "MapScene3D should accept mission metadata from the shared page projection"
+  );
+  assert.match(
+    source,
+    /deriveVehicleDegradedState/,
+    "MapScene3D should use the canonical degraded-state helper for marker status"
+  );
+  assert.match(
+    source,
+    /offlineVehicleIds\.has\(normalizeVehicleId\(tile\.sourceVehicleId\)\)/,
+    "MapScene3D should only stale-style tiles owned by offline vehicles"
+  );
+});
+
 const SOURCE = fs.readFileSync(path.join(ROOT, "hooks", "useVehicleTelemetry.ts"), "utf8");
 
 test("buildTelemetryDedupeKey recognizes snake_case and camelCase vehicle ids", () => {

--- a/software/viewer/src/lib/degradedVehicleState.d.ts
+++ b/software/viewer/src/lib/degradedVehicleState.d.ts
@@ -1,0 +1,44 @@
+export const DEFAULT_TELEMETRY_STALE_TIMEOUT_MS: number;
+export const DEFAULT_LAST_KNOWN_RETENTION_MS: number;
+
+export interface MissionMetaMaps {
+  assignments?: Record<string, string>;
+  assignmentLabels?: Record<string, string>;
+  progress?: Record<string, number>;
+  online?: Record<string, boolean>;
+  slamModes?: Record<string, string>;
+}
+
+export interface VehicleMissionMeta {
+  assignment?: string;
+  assignmentLabel?: string;
+  progress?: number;
+  online?: boolean;
+  slamMode?: string;
+}
+
+export interface DegradedVehicleState {
+  status: "active" | "warning" | "offline";
+  offline: boolean;
+  retained: boolean;
+  replayed: boolean;
+  lastContactAgeMs: number | null;
+  staleSinceMs: number | null;
+}
+
+export function normalizeMissionMetaForVehicle(
+  vehicleId: string,
+  missionMeta?: MissionMetaMaps
+): VehicleMissionMeta;
+
+export function deriveVehicleDegradedState(input?: {
+  lastUpdate?: number;
+  missionOnline?: boolean;
+  deliveryMode?: "live" | "replayed";
+  isRetroactive?: boolean;
+  now?: number;
+  staleTimeoutMs?: number;
+  retentionMs?: number;
+}): DegradedVehicleState;
+
+export function formatLastContactAge(ageMs: number | null | undefined): string;

--- a/software/viewer/src/lib/degradedVehicleState.js
+++ b/software/viewer/src/lib/degradedVehicleState.js
@@ -1,0 +1,62 @@
+export const DEFAULT_TELEMETRY_STALE_TIMEOUT_MS = 5000;
+export const DEFAULT_LAST_KNOWN_RETENTION_MS = 120000;
+
+export function normalizeMissionMetaForVehicle(vehicleId, missionMeta = {}) {
+  const normalizedId = String(vehicleId ?? "").trim().toLowerCase().replace(/-/g, "_");
+  return {
+    assignment:
+      missionMeta.assignments?.[normalizedId] ??
+      missionMeta.assignments?.[vehicleId],
+    assignmentLabel:
+      missionMeta.assignmentLabels?.[normalizedId] ??
+      missionMeta.assignmentLabels?.[vehicleId],
+    progress:
+      missionMeta.progress?.[normalizedId] ??
+      missionMeta.progress?.[vehicleId],
+    online:
+      missionMeta.online?.[normalizedId] ??
+      missionMeta.online?.[vehicleId],
+    slamMode:
+      missionMeta.slamModes?.[normalizedId] ??
+      missionMeta.slamModes?.[vehicleId],
+  };
+}
+
+export function deriveVehicleDegradedState({
+  lastUpdate,
+  missionOnline,
+  deliveryMode,
+  isRetroactive,
+  now = Date.now(),
+  staleTimeoutMs = DEFAULT_TELEMETRY_STALE_TIMEOUT_MS,
+  retentionMs = DEFAULT_LAST_KNOWN_RETENTION_MS,
+} = {}) {
+  const ageMs = Number.isFinite(lastUpdate) ? Math.max(0, now - lastUpdate) : Infinity;
+  const telemetryStale = ageMs > staleTimeoutMs;
+  const missionOffline = missionOnline === false;
+  const offline = telemetryStale || missionOffline;
+  const retained = ageMs <= retentionMs;
+  const replayed = deliveryMode === "replayed" || isRetroactive === true;
+
+  return {
+    status: offline ? "offline" : replayed ? "warning" : "active",
+    offline,
+    retained,
+    replayed,
+    lastContactAgeMs: Number.isFinite(ageMs) ? ageMs : null,
+    staleSinceMs: offline && Number.isFinite(lastUpdate) ? lastUpdate + staleTimeoutMs : null,
+  };
+}
+
+export function formatLastContactAge(ageMs) {
+  if (!Number.isFinite(ageMs) || ageMs < 0) {
+    return "--";
+  }
+  const totalSeconds = Math.floor(ageMs / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}

--- a/software/viewer/src/lib/degradedVehicleState.js
+++ b/software/viewer/src/lib/degradedVehicleState.js
@@ -31,9 +31,11 @@ export function deriveVehicleDegradedState({
   staleTimeoutMs = DEFAULT_TELEMETRY_STALE_TIMEOUT_MS,
   retentionMs = DEFAULT_LAST_KNOWN_RETENTION_MS,
 } = {}) {
-  const ageMs = Number.isFinite(lastUpdate) ? Math.max(0, now - lastUpdate) : Infinity;
+  const hasTelemetry = Number.isFinite(lastUpdate);
+  const ageMs = hasTelemetry ? Math.max(0, now - lastUpdate) : Infinity;
   const telemetryStale = ageMs > staleTimeoutMs;
-  const missionOffline = missionOnline === false;
+  const telemetryFresh = hasTelemetry && ageMs <= staleTimeoutMs;
+  const missionOffline = missionOnline === false && !telemetryFresh;
   const offline = telemetryStale || missionOffline;
   const retained = ageMs <= retentionMs;
   const replayed = deliveryMode === "replayed" || isRetroactive === true;
@@ -43,8 +45,8 @@ export function deriveVehicleDegradedState({
     offline,
     retained,
     replayed,
-    lastContactAgeMs: Number.isFinite(ageMs) ? ageMs : null,
-    staleSinceMs: offline && Number.isFinite(lastUpdate) ? lastUpdate + staleTimeoutMs : null,
+    lastContactAgeMs: hasTelemetry ? ageMs : null,
+    staleSinceMs: offline && hasTelemetry ? lastUpdate + staleTimeoutMs : null,
   };
 }
 

--- a/software/viewer/src/lib/degradedVehicleState.test.mjs
+++ b/software/viewer/src/lib/degradedVehicleState.test.mjs
@@ -48,6 +48,20 @@ test("deriveVehicleDegradedState keeps last-known state through retention window
   );
 });
 
+test("deriveVehicleDegradedState treats fresh telemetry as authoritative over stale mission offline hints", () => {
+  const now = 300_000;
+  const degraded = deriveVehicleDegradedState({
+    lastUpdate: now - 1000,
+    missionOnline: false,
+    deliveryMode: "live",
+    now,
+  });
+
+  assert.equal(degraded.offline, false);
+  assert.equal(degraded.status, "active");
+  assert.equal(degraded.lastContactAgeMs, 1000);
+});
+
 test("normalizeMissionMetaForVehicle supports normalized and raw ids", () => {
   const meta = normalizeMissionMetaForVehicle("scout-1", {
     assignments: { scout_1: "SEARCHING" },

--- a/software/viewer/src/lib/degradedVehicleState.test.mjs
+++ b/software/viewer/src/lib/degradedVehicleState.test.mjs
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_LAST_KNOWN_RETENTION_MS,
+  DEFAULT_TELEMETRY_STALE_TIMEOUT_MS,
+  deriveVehicleDegradedState,
+  formatLastContactAge,
+  normalizeMissionMetaForVehicle,
+} from "./degradedVehicleState.js";
+
+test("deriveVehicleDegradedState separates replay from offline", () => {
+  const now = 100_000;
+  const replayed = deriveVehicleDegradedState({
+    lastUpdate: now - 1000,
+    deliveryMode: "replayed",
+    now,
+  });
+  assert.equal(replayed.status, "warning");
+  assert.equal(replayed.offline, false);
+  assert.equal(replayed.replayed, true);
+
+  const stale = deriveVehicleDegradedState({
+    lastUpdate: now - DEFAULT_TELEMETRY_STALE_TIMEOUT_MS - 1,
+    deliveryMode: "replayed",
+    now,
+  });
+  assert.equal(stale.status, "offline");
+  assert.equal(stale.offline, true);
+  assert.equal(stale.replayed, true);
+});
+
+test("deriveVehicleDegradedState keeps last-known state through retention window", () => {
+  const now = 200_000;
+  assert.equal(
+    deriveVehicleDegradedState({
+      lastUpdate: now - DEFAULT_LAST_KNOWN_RETENTION_MS + 1000,
+      now,
+    }).retained,
+    true
+  );
+  assert.equal(
+    deriveVehicleDegradedState({
+      lastUpdate: now - DEFAULT_LAST_KNOWN_RETENTION_MS - 1,
+      now,
+    }).retained,
+    false
+  );
+});
+
+test("normalizeMissionMetaForVehicle supports normalized and raw ids", () => {
+  const meta = normalizeMissionMetaForVehicle("scout-1", {
+    assignments: { scout_1: "SEARCHING" },
+    assignmentLabels: { scout_1: "SEARCHING:zone-a" },
+    progress: { scout_1: 32 },
+    online: { scout_1: false },
+    slamModes: { scout_1: "vio" },
+  });
+
+  assert.equal(meta.assignment, "SEARCHING");
+  assert.equal(meta.assignmentLabel, "SEARCHING:zone-a");
+  assert.equal(meta.progress, 32);
+  assert.equal(meta.online, false);
+  assert.equal(meta.slamMode, "vio");
+});
+
+test("formatLastContactAge renders compact operator timer labels", () => {
+  assert.equal(formatLastContactAge(9000), "9s");
+  assert.equal(formatLastContactAge(65_000), "1m 05s");
+  assert.equal(formatLastContactAge(null), "--");
+});

--- a/software/viewer/src/lib/fleetVehicleProjection.d.ts
+++ b/software/viewer/src/lib/fleetVehicleProjection.d.ts
@@ -1,4 +1,4 @@
-import type { VehicleInfo, VehicleStatus } from "@/types/vehicle";
+import type { VehicleStatus } from "@/types/vehicle";
 
 /**
  * Metadata overlay for vehicles participating in active missions.
@@ -32,7 +32,13 @@ export type VehicleMissionMeta = {
  * @param meta - Mission-specific metadata from progress updates
  * @returns VehicleInfo with mission context applied
  */
-export function applyVehicleMissionMeta(
-  vehicleInfo: VehicleInfo,
+export function applyVehicleMissionMeta<T extends Record<string, unknown> & { status?: string }>(
+  vehicleInfo: T,
   meta?: VehicleMissionMeta
-): VehicleInfo;
+): T & {
+  status: T["status"] | "offline" | "warning" | "active";
+  isOffline?: boolean;
+  lastContactAgeMs?: number | null;
+  staleSinceMs?: number | null;
+  isLastKnown?: boolean;
+};

--- a/software/viewer/src/lib/fleetVehicleProjection.js
+++ b/software/viewer/src/lib/fleetVehicleProjection.js
@@ -2,16 +2,26 @@
  * Fleet vehicle presentation helpers used by FleetPanel/VehicleCard rendering.
  */
 
+import { deriveVehicleDegradedState } from "./degradedVehicleState.js";
+
 export function applyVehicleMissionMeta(vehicleInfo, meta = {}) {
   const next = { ...vehicleInfo };
+  const degraded = deriveVehicleDegradedState({
+    lastUpdate: next.lastUpdate,
+    missionOnline: meta?.online,
+    deliveryMode: next.deliveryMode,
+    isRetroactive: next.isRetroactive,
+  });
+  const alreadyOffline = next.status === "offline";
+  next.status = alreadyOffline ? "offline" : degraded.status;
+  next.isOffline = alreadyOffline || degraded.offline;
+  next.lastContactAgeMs = degraded.lastContactAgeMs;
+  next.staleSinceMs = degraded.staleSinceMs;
+  next.isLastKnown = (alreadyOffline || degraded.offline) && degraded.retained;
 
   const commandStatusHint = meta?.commandStatusHint;
-  if (next.status !== "offline" && commandStatusHint) {
+  if (!alreadyOffline && !degraded.offline && commandStatusHint) {
     next.status = commandStatusHint;
-  }
-
-  if (meta?.online === false) {
-    next.status = "offline";
   }
 
   const assignmentLabel =

--- a/software/viewer/src/lib/fleetVehicleProjection.test.mjs
+++ b/software/viewer/src/lib/fleetVehicleProjection.test.mjs
@@ -7,6 +7,9 @@ function baseVehicle(overrides = {}) {
   return {
     id: "scout_1",
     status: "active",
+    lastUpdate: Date.now(),
+    deliveryMode: "live",
+    isRetroactive: false,
     batteryPercent: 95,
     signalStrength: 88,
     speed: 2.4,
@@ -56,6 +59,7 @@ test("applyVehicleMissionMeta forces offline when telemetry marks vehicle offlin
   });
 
   assert.equal(projected.status, "offline");
+  assert.equal(projected.isLastKnown, true);
 });
 
 test("applyVehicleMissionMeta keeps offline status when command hint arrives", () => {
@@ -81,4 +85,23 @@ test("applyVehicleMissionMeta projects normalized slam mode", () => {
   });
 
   assert.equal(projected.slamMode, "liosam");
+});
+
+test("applyVehicleMissionMeta marks stale telemetry offline without treating replay as offline", () => {
+  const now = Date.now();
+  const replayed = applyVehicleMissionMeta(baseVehicle({
+    lastUpdate: now,
+    deliveryMode: "replayed",
+    isRetroactive: true,
+  }));
+  assert.equal(replayed.status, "warning");
+  assert.equal(replayed.isOffline, false);
+
+  const stale = applyVehicleMissionMeta(baseVehicle({
+    lastUpdate: now - 6000,
+    deliveryMode: "live",
+  }));
+  assert.equal(stale.status, "offline");
+  assert.equal(stale.isOffline, true);
+  assert.ok(stale.lastContactAgeMs >= 5000);
 });

--- a/software/viewer/src/lib/fleetVehicleProjection.test.mjs
+++ b/software/viewer/src/lib/fleetVehicleProjection.test.mjs
@@ -52,14 +52,15 @@ test("applyVehicleMissionMeta applies command status hint only for online vehicl
   assert.equal(projected.status, "holding");
 });
 
-test("applyVehicleMissionMeta forces offline when telemetry marks vehicle offline", () => {
+test("applyVehicleMissionMeta does not let stale mission offline hints override fresh telemetry", () => {
   const projected = applyVehicleMissionMeta(baseVehicle({ status: "active" }), {
     commandStatusHint: "holding",
     online: false,
   });
 
-  assert.equal(projected.status, "offline");
-  assert.equal(projected.isLastKnown, true);
+  assert.equal(projected.status, "holding");
+  assert.equal(projected.isOffline, false);
+  assert.equal(projected.isLastKnown, false);
 });
 
 test("applyVehicleMissionMeta keeps offline status when command hint arrives", () => {

--- a/software/viewer/src/lib/map/MapTileManager.ts
+++ b/software/viewer/src/lib/map/MapTileManager.ts
@@ -23,6 +23,8 @@ export interface TileData {
   byteSize: number;
   /** Delivery provenance for retroactive map indicators */
   deliveryMode?: 'live' | 'replayed';
+  /** Vehicle that produced this tile. */
+  sourceVehicleId?: string;
   originalEventTsMs?: number;
   replayedAtTsMs?: number | null;
   isRetroactive?: boolean;
@@ -151,6 +153,7 @@ export class MapTileManager {
       timestamp: Date.now(),
       byteSize: message.byte_size,
       deliveryMode: normalizedDeliveryMode,
+      sourceVehicleId: normalizeSourceVehicleId(message.source_vehicle_id),
       originalEventTsMs: parseEpochMs(message.original_event_ts) ?? undefined,
       replayedAtTsMs: parseEpochMs(message.replayed_at_ts),
       isRetroactive: normalizedDeliveryMode === 'replayed',
@@ -291,4 +294,12 @@ function normalizeDeliveryMode(deliveryMode: unknown): 'live' | 'replayed' {
   return typeof deliveryMode === 'string' && deliveryMode.trim().toLowerCase() === 'replayed'
     ? 'replayed'
     : 'live';
+}
+
+function normalizeSourceVehicleId(sourceVehicleId: unknown): string | undefined {
+  if (typeof sourceVehicleId !== 'string') {
+    return undefined;
+  }
+  const normalized = sourceVehicleId.trim();
+  return normalized.length > 0 ? normalized : undefined;
 }

--- a/software/viewer/src/lib/ros/mapTile.ts
+++ b/software/viewer/src/lib/ros/mapTile.ts
@@ -20,6 +20,8 @@ export interface MapTileMessage {
   byte_size: number;
   /** Base64-encoded tile payload (PNG image data) */
   data?: string;
+  /** Vehicle that produced the tile, used for last-known/stale-region rendering */
+  source_vehicle_id?: string;
   /** ROS timestamp when the tile was published */
   published_at?: {
     sec: number;

--- a/software/viewer/src/lib/ros/mapTilePayload.js
+++ b/software/viewer/src/lib/ros/mapTilePayload.js
@@ -43,6 +43,14 @@ function normalizeDeliveryMode(value) {
   return value.trim().toLowerCase() === "replayed" ? "replayed" : "live";
 }
 
+function normalizeSourceVehicleId(value) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const sourceVehicleId = value.trim();
+  return sourceVehicleId.length > 0 ? sourceVehicleId : undefined;
+}
+
 export function normalizeMapTileMessage(rawMessage) {
   if (!rawMessage || typeof rawMessage !== "object") {
     return null;
@@ -72,6 +80,12 @@ export function normalizeMapTileMessage(rawMessage) {
   }
   if ("replayed_at_ts" in rawMessage || "replayedAtTs" in rawMessage) {
     normalized.replayed_at_ts = rawMessage.replayed_at_ts ?? rawMessage.replayedAtTs;
+  }
+  const sourceVehicleId = normalizeSourceVehicleId(
+    rawMessage.source_vehicle_id ?? rawMessage.sourceVehicleId
+  );
+  if (sourceVehicleId) {
+    normalized.source_vehicle_id = sourceVehicleId;
   }
 
   return normalized;

--- a/software/viewer/src/lib/ros/mapTilePayload.test.mjs
+++ b/software/viewer/src/lib/ros/mapTilePayload.test.mjs
@@ -23,6 +23,7 @@ test("normalizeMapTileMessage accepts camelCase payloads and replay metadata", (
     format: "image/png",
     byteSize: 1024,
     deliveryMode: "replayed",
+    sourceVehicleId: "scout-1",
     originalEventTs: { sec: 1700000000, nanosec: 0 },
     replayedAtTs: 1700000010,
   });
@@ -31,6 +32,7 @@ test("normalizeMapTileMessage accepts camelCase payloads and replay metadata", (
   assert.equal(normalized.tile_id, "17/20684/50622");
   assert.equal(normalized.byte_size, 1024);
   assert.equal(normalized.delivery_mode, "replayed");
+  assert.equal(normalized.source_vehicle_id, "scout-1");
   assert.deepEqual(normalized.original_event_ts, { sec: 1700000000, nanosec: 0 });
   assert.equal(normalized.replayed_at_ts, 1700000010);
 });

--- a/software/viewer/src/lib/vehicle/VehicleManager.ts
+++ b/software/viewer/src/lib/vehicle/VehicleManager.ts
@@ -2,6 +2,11 @@ import * as THREE from 'three';
 import { Vector3, Quaternion, Color } from 'three';
 import { ReplayDeliveryMetadata, VehicleTelemetryMessage, VehicleType } from '../ros/telemetry';
 import { geoToLocal, GeoCoordinates } from '../ros/mapTile';
+import {
+  DEFAULT_LAST_KNOWN_RETENTION_MS,
+  DEFAULT_TELEMETRY_STALE_TIMEOUT_MS,
+  deriveVehicleDegradedState,
+} from '../degradedVehicleState';
 
 export interface VehicleState {
   id: string;
@@ -24,6 +29,9 @@ export interface VehicleState {
   isRetroactive?: boolean;
   originalEventTsMs?: number;
   replayedAtTsMs?: number | null;
+  isOffline?: boolean;
+  lastContactAgeMs?: number | null;
+  staleSinceMs?: number | null;
   batteryPercent?: number;
   linkQualityPercent?: number;
   coveragePercent?: number;
@@ -38,7 +46,7 @@ export interface VehicleState {
  * - Coordinate transformation from geographic (lat/lon) to local Three.js coordinates
  * - Quaternion conversion from ROS (roll/pitch/yaw) to Three.js convention
  * - Trajectory buffering with time-based eviction (30 second window)
- * - Stale vehicle cleanup (10 second timeout)
+ * - Last-known vehicle retention after telemetry staleness
  *
  * Coordinate Systems:
  * - Input (ROS): latitude, longitude, altitude; roll, pitch, yaw
@@ -52,8 +60,8 @@ export class VehicleManager {
   /** Maximum trajectory history in milliseconds (30 seconds) */
   private maxTrajectoryTime: number = 30000;
 
-  /** Vehicle timeout threshold in milliseconds (10 seconds) */
-  private cleanupThreshold: number = 10000;
+  /** Vehicle retention threshold after last contact. */
+  private cleanupThreshold: number = DEFAULT_LAST_KNOWN_RETENTION_MS;
 
   constructor() {
     this.vehicles = new Map();
@@ -190,7 +198,22 @@ export class VehicleManager {
             this.lastTelemetry.delete(id);
         }
     }
-    return Array.from(this.vehicles.values());
+    return Array.from(this.vehicles.values()).map((vehicle) => {
+      const degraded = deriveVehicleDegradedState({
+        lastUpdate: vehicle.lastUpdate,
+        deliveryMode: vehicle.deliveryMode,
+        isRetroactive: vehicle.isRetroactive,
+        now,
+        staleTimeoutMs: DEFAULT_TELEMETRY_STALE_TIMEOUT_MS,
+        retentionMs: this.cleanupThreshold,
+      });
+      return {
+        ...vehicle,
+        isOffline: degraded.offline,
+        lastContactAgeMs: degraded.lastContactAgeMs,
+        staleSinceMs: degraded.staleSinceMs,
+      };
+    });
   }
 
   /**

--- a/test/test_rtabmap_vio_sim.py
+++ b/test/test_rtabmap_vio_sim.py
@@ -78,6 +78,8 @@ def test_launch_wires_openvins_and_rtabmap_nodes():
     assert "DeclareLaunchArgument('base_frame', default_value='base_link')" in text
     assert "DeclareLaunchArgument('map_frame', default_value='map')" in text
     assert "DeclareLaunchArgument('odom_frame', default_value='odom')" in text
+    assert "DeclareLaunchArgument(\n            'source_vehicle_id'," in text
+    assert "'source_vehicle_id': source_vehicle_id" in text
 
 
 def test_configs_include_expected_topic_and_frame_contracts():
@@ -100,6 +102,9 @@ def test_configs_include_expected_topic_and_frame_contracts():
     assert 'frame_id: base_link' in rtabmap_text
     assert 'subscribe_stereo: true' in rtabmap_text
     assert 'subscribe_imu: true' in rtabmap_text
+
+    map_tile_text = Path('software/edge/src/aeris_map/config/map_tile_stream.yaml').read_text()
+    assert 'source_vehicle_id: ""' in map_tile_text
 
 
 def test_parity_docs_and_trajectory_present():

--- a/test/test_video_abr_policy.py
+++ b/test/test_video_abr_policy.py
@@ -388,6 +388,14 @@ def test_store_forward_wires_abr_metrics_decisions_commands_and_acks() -> None:
     assert "self._abr_controller.update_ack_timeout(value)" in text
 
 
+def test_store_forward_prefers_existing_map_tile_provenance_before_fallback() -> None:
+    text = STORE_FORWARD_FILE.read_text(encoding="utf-8")
+    assert 'if message_kind == "map_tile":' in text
+    assert 'getattr(message, "source_vehicle_id", "")' in text
+    assert "if not source_vehicle_id:" in text
+    assert "source_vehicle_id = self._source_vehicle_id_from_message(" in text
+
+
 def test_ladder_parser_fails_on_unsorted_target_bitrate(tmp_path: Path) -> None:
     ladder_path = tmp_path / "abr_bad.yaml"
     ladder_path.write_text(


### PR DESCRIPTION
## Summary
- retain last-known vehicle positions after telemetry goes stale and show explicit offline timers in fleet cards and map markers
- preserve replay/backfill cues separately from offline status
- add map-tile vehicle provenance so stale-region styling only applies to tiles from offline vehicles
- document the rosbridge rebuild requirement for message schema changes

## Validation
- node --test src/lib/*.test.mjs src/lib/ros/*.test.mjs src/components/sheets/*.test.mjs src/hooks/*.test.mjs
- npm run lint
- npm run build
- python3 -m pytest -q test/test_store_forward_buffer.py test/test_video_abr_policy.py

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vehicles show an "offline" status with a last-contact label/age.
  * Map tiles visually indicate staleness when produced by offline vehicles.
  * Tiles now carry source-vehicle provenance so stale/last-known regions are attributed.

* **UX Behavior**
  * PiP and fleet logic treat returning vehicles as live while excluding replayed/last-known feeds.

* **Documentation**
  * Note: rebuild Docker images when message schemas change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces degraded-vehicle-state display across the tactical GCS: vehicles are now retained for 120 s after telemetry goes silent, map markers dim and show an offline age badge, stale map tiles from offline vehicles are visually distinguished, and fleet/vehicle cards gain an explicit OFFLINE status with a last-contact timer.

- **New `degradedVehicleState.js` module** centralizes the offline/warning/active classification and last-contact formatting, consumed by `VehicleManager`, `fleetVehicleProjection`, `MapScene3D`, and the sheet components.
- **`MapTile.msg` gains `source_vehicle_id`** so the GCS can scope stale-tile styling to tiles owned by offline vehicles only; the field flows through `store_forward_tiles.py`, `mapTilePayload.js`, `MapTileManager`, and `MapScene3D`.
- **`useVehicleTelemetry`'s polling guard** was relaxed to allow the 1-second interval to push updates when vehicles are offline and their age timers are advancing.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the three findings are limited in scope and none affect correctness of the core offline-state logic.

The degraded-state derivation, tile provenance plumbing, and fleet card changes are well-tested and logically sound. The main rough edges are: a duplicated formatting helper in `DroneMarker3D` that diverges from the shared one, a polling guard that now re-renders the full component tree every second even when all vehicles are live, and a `staleSinceMs` value that can be a future timestamp when the vehicle is offline only because the mission control says so. None of these break the feature, but the polling change in particular could become noticeable on larger fleets.

`useVehicleTelemetry.ts` (polling guard) and `degradedVehicleState.js` (`staleSinceMs` edge case) deserve a second look; the rest of the changeset is straightforward.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/viewer/src/lib/degradedVehicleState.js | New module centralizing offline/degraded state derivation; logic is correct but `staleSinceMs` can be a future timestamp when mission-offline overrides fresh telemetry. |
| software/viewer/src/hooks/useVehicleTelemetry.ts | Early-return guard relaxed to empty-only case; now fires a state update on every 1-second tick whenever any vehicles are present, causing unnecessary re-renders for all-live fleets. |
| software/viewer/src/lib/vehicle/VehicleManager.ts | Retention window extended from 10 s to 120 s and degraded state fields appended to each vehicle snapshot; cleanup logic remains consistent with the new threshold. |
| software/viewer/src/components/map/DroneMarker3D.tsx | Adds offline marker dimming and "Last Known" age badge; `formatMarkerAge` duplicates the already-exported `formatLastContactAge` from `degradedVehicleState`. |
| software/viewer/src/components/map/MapScene3D.tsx | Adds `vehicleMissionMeta` prop, derives offline IDs for stale-tile ownership checks, and passes `lastContactAgeMs` to drone markers; logic is correct. |
| software/viewer/src/lib/fleetVehicleProjection.js | Integrates `deriveVehicleDegradedState` for full degraded projection; offline/retained/replay flags are correctly derived and applied. |
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py | Moves `source_vehicle_id` extraction before route resolution and backfills it on map-tile messages that lack it; mutation is safe in Python ROS 2 once the message schema is rebuilt. |
| software/edge/src/aeris_msgs/msg/MapTile.msg | Adds optional `source_vehicle_id` string field for vehicle provenance; backward-compatible addition. |
| software/viewer/src/lib/map/MapTileManager.ts | Normalizes and surfaces `source_vehicle_id` from incoming tile messages into `TileData`; normalizer correctly trims whitespace and drops empty strings. |
| software/viewer/src/hooks/useMissionControl.ts | Exposes `vehicleMissionMeta` (including per-vehicle `online` flag) via merge-accumulate pattern; correctly resets on ROS disconnect. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ROS as ROS Telemetry
    participant VM as VehicleManager
    participant UVT as useVehicleTelemetry (1s poll)
    participant UMC as useMissionControl
    participant Page as page.tsx (fleetVehicles memo)
    participant DS as degradedVehicleState.js
    participant MS as MapScene3D
    participant FC as FleetCard / VehicleCard

    ROS->>VM: telemetry message (lastUpdate stamped)
    Note over VM: cleanupThreshold=120s
    UVT->>VM: getVehicles() every 1s
    VM->>DS: deriveVehicleDegradedState(lastUpdate, now)
    DS-->>VM: "{offline, lastContactAgeMs, staleSinceMs}"
    VM-->>UVT: VehicleState[] (with isOffline, lastContactAgeMs)
    ROS->>UMC: mission_progress message
    UMC-->>Page: "vehicleMissionMeta {online, assignments, ...}"
    Page->>DS: normalizeMissionMetaForVehicle + applyVehicleMissionMeta
    DS-->>Page: VehicleInfo with status offline/warning/active
    Page->>MS: vehicles + vehicleMissionMeta
    MS->>DS: deriveVehicleDegradedState (per vehicle)
    DS-->>MS: marker status + lastContactAgeMs
    MS->>MS: offlineVehicleIds for stale-tile check
    Page->>FC: fleetVehicles[]
    FC-->>FC: OFFLINE badge + LAST CONTACT timer
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `software/viewer/src/hooks/useVehicleTelemetry.ts`, line 280-293 ([link](https://github.com/aeris-drones/aeris/blob/858fb8961d576044a8abb19d9aa6144c791ae1cc/software/viewer/src/hooks/useVehicleTelemetry.ts#L280-L293)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **1 Hz polling now forces a state update on every tick whenever any vehicles are present**

   Previously `currentVehicles.length === previous.vehicles.length` served as a coarse deduplication bail-out; now the only bail-out is when both arrays are empty. Because `getVehicles()` returns a freshly mapped array on every call (the new `.map()` in `VehicleManager`), the fast path is never reached for an active fleet. Every tick will trigger a React reconcile cycle for all consumers — including the 3D scene — even for fleets where every vehicle is still live and the only difference is a 1 s increment to `lastContactAgeMs`. The change is necessary for offline timer accuracy, but it removes the only guard against redundant renders for fully-live fleets. A shallow comparison of `lastContactAgeMs` per vehicle, or a separate timerState slice for offline vehicles, would let active-only fleets skip most ticks.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/hooks/useVehicleTelemetry.ts
   Line: 280-293

   Comment:
   **1 Hz polling now forces a state update on every tick whenever any vehicles are present**

   Previously `currentVehicles.length === previous.vehicles.length` served as a coarse deduplication bail-out; now the only bail-out is when both arrays are empty. Because `getVehicles()` returns a freshly mapped array on every call (the new `.map()` in `VehicleManager`), the fast path is never reached for an active fleet. Every tick will trigger a React reconcile cycle for all consumers — including the 3D scene — even for fleets where every vehicle is still live and the only difference is a 1 s increment to `lastContactAgeMs`. The change is necessary for offline timer accuracy, but it removes the only guard against redundant renders for fully-live fleets. A shallow comparison of `lastContactAgeMs` per vehicle, or a separate timerState slice for offline vehicles, would let active-only fleets skip most ticks.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `software/viewer/src/hooks/useVehicleTelemetry.ts`, line 282-290 ([link](https://github.com/aeris-drones/aeris/blob/858fb8961d576044a8abb19d9aa6144c791ae1cc/software/viewer/src/hooks/useVehicleTelemetry.ts#L282-L290)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The original guard (`lengths equal → return previous`) was removed because vehicle data can change without the count changing. The replacement only skips when both sides are empty, which means the state updater fires on **every 1-second tick** whenever any vehicles exist. `getVehicles()` now calls `Date.now()` per vehicle (for `lastContactAgeMs`), so the array is always a new reference and React always schedules a re-render. For a fleet where all vehicles are live and no timers are advancing, this is unnecessary work every second. Checking whether any vehicle is actually offline narrows the churn to just the cases that need it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/hooks/useVehicleTelemetry.ts
   Line: 282-290

   Comment:
   The original guard (`lengths equal → return previous`) was removed because vehicle data can change without the count changing. The replacement only skips when both sides are empty, which means the state updater fires on **every 1-second tick** whenever any vehicles exist. `getVehicles()` now calls `Date.now()` per vehicle (for `lastContactAgeMs`), so the array is always a new reference and React always schedules a re-render. For a fleet where all vehicles are live and no timers are advancing, this is unnecessary work every second. Checking whether any vehicle is actually offline narrows the churn to just the cases that need it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
software/viewer/src/hooks/useVehicleTelemetry.ts:282-290
The original guard (`lengths equal → return previous`) was removed because vehicle data can change without the count changing. The replacement only skips when both sides are empty, which means the state updater fires on **every 1-second tick** whenever any vehicles exist. `getVehicles()` now calls `Date.now()` per vehicle (for `lastContactAgeMs`), so the array is always a new reference and React always schedules a re-render. For a fleet where all vehicles are live and no timers are advancing, this is unnecessary work every second. Checking whether any vehicle is actually offline narrows the churn to just the cases that need it.

```suggestion
          setVehicleState((previous) => {
            if (currentVehicles.length === 0 && previous.vehicles.length === 0) {
              return previous;
            }
            const anyOffline = currentVehicles.some((v) => v.isOffline);
            if (
              !anyOffline &&
              currentVehicles.length === previous.vehicles.length
            ) {
              return previous;
            }
            return {
              connection: previous.connection,
              vehicles: [...currentVehicles],
            };
          });
```

### Issue 2 of 3
software/viewer/src/lib/degradedVehicleState.js:47
`staleSinceMs` is computed as `lastUpdate + staleTimeoutMs` whenever `offline` is true, regardless of *why* the vehicle is offline. When the vehicle is offline solely because `missionOnline === false` but telemetry is still fresh (`ageMs < staleTimeoutMs`), the result is a timestamp in the **future** (`now - ageMs + staleTimeoutMs > now`). Any consumer of this field expecting a past "went-offline-at" timestamp would receive a misleading value. The fix is to condition on `telemetryStale` rather than `offline`.

```suggestion
    staleSinceMs: telemetryStale && Number.isFinite(lastUpdate) ? lastUpdate + staleTimeoutMs : null,
```

### Issue 3 of 3
software/viewer/src/components/map/DroneMarker3D.tsx:45-52
`formatMarkerAge` is a local re-implementation of the exported `formatLastContactAge` from `degradedVehicleState.js`. The two functions are functionally identical — the only visible difference is the null/undefined guard idiom. Using the shared utility removes the duplication and ensures both display surfaces stay in sync if the format ever changes.

```suggestion
import { formatLastContactAge as formatMarkerAge } from '@/lib/degradedVehicleState';
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["viewer: show degraded vehicle state"](https://github.com/aeris-drones/aeris/commit/858fb8961d576044a8abb19d9aa6144c791ae1cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32426404)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->