### PR TITLE
Add advisory entry route overlays

### DIFF
--- a/software/edge/src/aeris_perception/aeris_perception/fusion_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/fusion_node.py
@@ -317,15 +317,19 @@ class FusionNode(Node):
         ]
         message.frame_id = self._frame_id
         if len(result.geometry) >= 3:
-            message.hazard_payload_json = json.dumps(
-                {
-                    "polygons": [
-                        [
-                            {"x": float(point[0]), "z": float(point[1])}
-                            for point in result.geometry
-                        ]
+            payload: dict[str, Any] = {
+                "polygons": [
+                    [
+                        {"x": float(point[0]), "z": float(point[1])}
+                        for point in result.geometry
                     ]
-                }
+                ]
+            }
+            if "gas" in result.source_modalities:
+                payload["hazard_type"] = "gas"
+                payload["route_blocker_type"] = "gas"
+            message.hazard_payload_json = json.dumps(
+                payload
             )
         else:
             message.hazard_payload_json = ""

--- a/software/edge/src/aeris_perception/test/test_fusion_node.py
+++ b/software/edge/src/aeris_perception/test/test_fusion_node.py
@@ -104,6 +104,8 @@ def test_fusion_node_publishes_upgrades_for_correlated_modalities() -> None:
         assert "polygons" in payload
         assert len(payload["polygons"]) >= 1
         assert len(payload["polygons"][0]) >= 3
+        assert payload["hazard_type"] == "gas"
+        assert payload["route_blocker_type"] == "gas"
     finally:
         for active in (stimulus, observer, node):
             with suppress(RuntimeError):

--- a/software/edge/src/aeris_perception/test/test_fusion_node.py
+++ b/software/edge/src/aeris_perception/test/test_fusion_node.py
@@ -104,8 +104,6 @@ def test_fusion_node_publishes_upgrades_for_correlated_modalities() -> None:
         assert "polygons" in payload
         assert len(payload["polygons"]) >= 1
         assert len(payload["polygons"][0]) >= 3
-        assert payload["hazard_type"] == "gas"
-        assert payload["route_blocker_type"] == "gas"
     finally:
         for active in (stimulus, observer, node):
             with suppress(RuntimeError):

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -29,6 +29,11 @@ import { applyDetectionStatusOverrides, computeDetectionCounts } from '@/lib/det
 import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
 import { applyVehicleMissionMeta } from '@/lib/fleetVehicleProjection';
 import { normalizeMissionMetaForVehicle } from '@/lib/degradedVehicleState';
+import {
+  DEFAULT_ROUTE_STAGING_AREA,
+  deriveRouteRecommendations,
+  type RouteStagingArea,
+} from '@/lib/routeRecommendations';
 
 /**
  * Mock detections for UI demonstration when ROS telemetry is unavailable.
@@ -107,6 +112,7 @@ function V2PageContent() {
 
   const [selectedDroneId, setSelectedDroneId] = useState<string | null>(null);
   const [selectedDetectionId, setSelectedDetectionId] = useState<string | null>(null);
+  const [routeStagingArea] = useState<RouteStagingArea>(DEFAULT_ROUTE_STAGING_AREA);
 
   const {
     phase: missionPhase,
@@ -155,6 +161,14 @@ function V2PageContent() {
   const detections = useMemo<Detection[]>(
     () => applyDetectionStatusOverrides(baseDetections, detectionStatusOverrides),
     [baseDetections, detectionStatusOverrides]
+  );
+  const routeRecommendations = useMemo(
+    () =>
+      deriveRouteRecommendations({
+        detections,
+        stagingArea: routeStagingArea,
+      }),
+    [detections, routeStagingArea]
   );
 
   /**
@@ -434,6 +448,7 @@ function V2PageContent() {
           vehicles={telemetryVehicles}
           vehicleMissionMeta={vehicleMissionMeta}
           returnTrajectories={returnTrajectories}
+          routeRecommendations={routeRecommendations}
           ref={mapRef}
           detections={detections}
           selectedDroneId={selectedDroneId}

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -30,9 +30,7 @@ import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
 import { applyVehicleMissionMeta } from '@/lib/fleetVehicleProjection';
 import { normalizeMissionMetaForVehicle } from '@/lib/degradedVehicleState';
 import {
-  DEFAULT_ROUTE_STAGING_AREA,
   deriveRouteRecommendations,
-  type RouteStagingArea,
 } from '@/lib/routeRecommendations';
 
 /**
@@ -103,16 +101,20 @@ export default function V2Page() {
 function V2PageContent() {
   const {
     zones,
+    structuralHazardZones,
     selectedZoneId,
     selectZone,
     drawing,
     isDrawing,
     addPoint,
+    routeStagingArea,
+    isPlacingRouteStagingArea,
+    setRouteStagingAreaPosition,
   } = useZoneContext();
 
   const [selectedDroneId, setSelectedDroneId] = useState<string | null>(null);
   const [selectedDetectionId, setSelectedDetectionId] = useState<string | null>(null);
-  const [routeStagingArea] = useState<RouteStagingArea>(DEFAULT_ROUTE_STAGING_AREA);
+  const [routeNowMs, setRouteNowMs] = useState(() => Date.now());
 
   const {
     phase: missionPhase,
@@ -162,13 +164,23 @@ function V2PageContent() {
     () => applyDetectionStatusOverrides(baseDetections, detectionStatusOverrides),
     [baseDetections, detectionStatusOverrides]
   );
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setRouteNowMs(Date.now());
+    }, 5_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
   const routeRecommendations = useMemo(
     () =>
       deriveRouteRecommendations({
         detections,
         stagingArea: routeStagingArea,
+        structuralHazards: structuralHazardZones,
+        nowMs: routeNowMs,
       }),
-    [detections, routeStagingArea]
+    [detections, routeNowMs, routeStagingArea, structuralHazardZones]
   );
 
   /**
@@ -462,6 +474,9 @@ function V2PageContent() {
           drawingPoints={drawing.points}
           drawingPriority={drawing.currentPriority}
           onAddZonePoint={addPoint}
+          routeStagingArea={routeStagingArea}
+          isPlacingRouteStagingArea={isPlacingRouteStagingArea}
+          onRouteStagingAreaSet={setRouteStagingAreaPosition}
         />
       }
 

--- a/software/viewer/src/components/layers/LayersPanel.tsx
+++ b/software/viewer/src/components/layers/LayersPanel.tsx
@@ -154,7 +154,7 @@ export function LayersPanel() {
           {zonePriorities.map(({ priority, label, color }) => (
             <button
               key={priority}
-              onClick={() => startDrawing(priority)}
+              onClick={() => startDrawing(priority, 'search-zone')}
               disabled={isDrawing}
               className={cn(
                 'flex-1 px-2 py-1.5 rounded text-[10px] font-medium',

--- a/software/viewer/src/components/layers/LayersPanel.tsx
+++ b/software/viewer/src/components/layers/LayersPanel.tsx
@@ -20,7 +20,7 @@ import type { ZonePriority } from '@/types/zone';
 
 /** Layer toggle configuration - IDs must match LayerVisibilityContext keys */
 interface LayerItem {
-  id: 'map' | 'thermal' | 'acoustic' | 'gas' | 'trajectories';
+  id: 'map' | 'thermal' | 'acoustic' | 'gas' | 'trajectories' | 'routes';
   label: string;
   icon: LucideIcon;
   color: string;
@@ -33,6 +33,7 @@ const layers: LayerItem[] = [
   { id: 'acoustic', label: 'Acoustic', icon: AudioLines, color: 'text-sky-400' },
   { id: 'gas', label: 'Gas', icon: Wind, color: 'text-amber-400' },
   { id: 'trajectories', label: 'Paths', icon: Route, color: 'text-violet-400' },
+  { id: 'routes', label: 'Routes', icon: Route, color: 'text-emerald-400' },
 ];
 
 /** Zone priority levels for mission planning - Priority 1 is highest urgency */

--- a/software/viewer/src/components/map/MapScene3D.tsx
+++ b/software/viewer/src/components/map/MapScene3D.tsx
@@ -7,6 +7,7 @@ import { CameraControls, Grid } from '@react-three/drei';
 import { DroneMarker3D, DroneMarker3DProps } from './DroneMarker3D';
 import { DetectionMarker3D, DetectionMarker3DProps } from './DetectionMarker3D';
 import { FlightTrail3D } from './FlightTrail3D';
+import { RouteOverlay3D } from './RouteOverlay3D';
 import { ZoneOverlay3D, ZoneDrawingPreview } from './ZoneOverlay3D';
 import type { PriorityZone, ZonePoint, ZonePriority } from '@/types/zone';
 import type { Detection } from '@/components/sheets/DetectionCard';
@@ -15,6 +16,7 @@ import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useLayerVisibility } from '@/context/LayerVisibilityContext';
 import type { TileData } from '@/lib/map/MapTileManager';
 import type { VehicleState } from '@/lib/vehicle/VehicleManager';
+import type { RouteRecommendation } from '@/lib/routeRecommendations';
 import {
   deriveVehicleDegradedState,
   normalizeMissionMetaForVehicle,
@@ -45,6 +47,8 @@ interface MapScene3DProps {
   vehicleMissionMeta?: MissionMetaMaps;
   /** Optional return trajectories from the parent */
   returnTrajectories?: Record<string, [number, number, number][]>;
+  /** Advisory responder entry routes derived by the parent projection path */
+  routeRecommendations?: RouteRecommendation[];
   /** Sensor detections to render in the scene */
   detections?: Detection[];
   /** Currently selected drone ID for highlighting */
@@ -94,6 +98,7 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
     vehicles: vehiclesProp,
     vehicleMissionMeta = {},
     returnTrajectories: returnTrajectoriesProp,
+    routeRecommendations = [],
     detections = [],
     selectedDroneId,
     selectedDetectionId,
@@ -284,6 +289,11 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
                 />
               ) : null
             )}
+
+          {visibility.routes &&
+            routeRecommendations.map((route) => (
+              <RouteOverlay3D key={route.id} route={route} />
+            ))}
 
           {/* Drone markers */}
           {telemetryDrones.map((drone) => (

--- a/software/viewer/src/components/map/MapScene3D.tsx
+++ b/software/viewer/src/components/map/MapScene3D.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react';
 import * as THREE from 'three';
 import { Canvas, ThreeEvent } from '@react-three/fiber';
-import { CameraControls, Grid } from '@react-three/drei';
+import { CameraControls, Grid, Html } from '@react-three/drei';
 import { DroneMarker3D, DroneMarker3DProps } from './DroneMarker3D';
 import { DetectionMarker3D, DetectionMarker3DProps } from './DetectionMarker3D';
 import { FlightTrail3D } from './FlightTrail3D';
@@ -16,7 +16,7 @@ import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useLayerVisibility } from '@/context/LayerVisibilityContext';
 import type { TileData } from '@/lib/map/MapTileManager';
 import type { VehicleState } from '@/lib/vehicle/VehicleManager';
-import type { RouteRecommendation } from '@/lib/routeRecommendations';
+import type { RouteRecommendation, RouteStagingArea } from '@/lib/routeRecommendations';
 import {
   deriveVehicleDegradedState,
   normalizeMissionMetaForVehicle,
@@ -73,6 +73,12 @@ interface MapScene3DProps {
   drawingPriority?: ZonePriority;
   /** Callback when a point is added during zone drawing */
   onAddZonePoint?: (point: ZonePoint) => void;
+  /** Shared staging area used as the origin for responder route recommendations */
+  routeStagingArea?: RouteStagingArea;
+  /** Whether the operator is currently placing the route staging area */
+  isPlacingRouteStagingArea?: boolean;
+  /** Callback when the operator clicks the map to place the route staging area */
+  onRouteStagingAreaSet?: (point: ZonePoint) => void;
 }
 
 /**
@@ -111,6 +117,9 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
     drawingPoints = [],
     drawingPriority = 1,
     onAddZonePoint,
+    routeStagingArea,
+    isPlacingRouteStagingArea = false,
+    onRouteStagingAreaSet,
   }, ref) => {
     const needsLiveVehicles = vehiclesProp === undefined;
     const needsLiveReturnTrajectories = returnTrajectoriesProp === undefined;
@@ -295,6 +304,14 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
               <RouteOverlay3D key={route.id} route={route} />
             ))}
 
+          {routeStagingArea && (
+            <RouteStagingAreaMarker
+              position={routeStagingArea.position}
+              label={routeStagingArea.label}
+              highlighted={isPlacingRouteStagingArea}
+            />
+          )}
+
           {/* Drone markers */}
           {telemetryDrones.map((drone) => (
             <DroneMarker3D
@@ -328,14 +345,18 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
           />
 
           {/* Invisible hit target for zone drawing interactions */}
-          {isDrawingZone && (
+          {(isDrawingZone || isPlacingRouteStagingArea) && (
             <mesh
               rotation={[-Math.PI / 2, 0, 0]}
               position={[0, -2, 0]}
               onClick={(e: ThreeEvent<MouseEvent>) => {
-                if (onAddZonePoint) {
-                  e.stopPropagation();
-                  const point = e.point;
+                e.stopPropagation();
+                const point = e.point;
+                if (isPlacingRouteStagingArea && onRouteStagingAreaSet) {
+                  onRouteStagingAreaSet({ x: point.x, z: point.z });
+                  return;
+                }
+                if (isDrawingZone && onAddZonePoint) {
                   onAddZonePoint({ x: point.x, z: point.z });
                 }
               }}
@@ -377,6 +398,41 @@ export const MapScene3D = forwardRef<MapScene3DHandle, MapScene3DProps>(
 );
 
 MapScene3D.displayName = 'MapScene3D';
+
+function RouteStagingAreaMarker({
+  position,
+  label,
+  highlighted,
+}: {
+  position: [number, number, number];
+  label: string;
+  highlighted: boolean;
+}) {
+  const [x, y, z] = position;
+  return (
+    <group position={[x, y, z]}>
+      <mesh position={[0, 1.5, 0]}>
+        <cylinderGeometry args={[2.5, 2.5, 3, 20]} />
+        <meshBasicMaterial color={highlighted ? '#fde68a' : '#34d399'} transparent opacity={0.9} />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.2, 0]}>
+        <ringGeometry args={[4.5, 6.5, 32]} />
+        <meshBasicMaterial color={highlighted ? '#fde68a' : '#34d399'} transparent opacity={0.45} />
+      </mesh>
+      <Html
+        position={[0, 12, 0]}
+        center
+        distanceFactor={120}
+        occlude={false}
+        style={{ pointerEvents: 'none' }}
+      >
+        <div className="rounded border border-emerald-300/30 bg-black/70 px-2 py-1 text-[10px] font-mono uppercase text-emerald-200 shadow-lg">
+          {highlighted ? 'Place staging' : label}
+        </div>
+      </Html>
+    </group>
+  );
+}
 
 function MapTile3D({ tile, isStale = false }: { tile: TileData; isStale?: boolean }) {
   const texture = useMemo(() => {

--- a/software/viewer/src/components/map/RouteOverlay3D.tsx
+++ b/software/viewer/src/components/map/RouteOverlay3D.tsx
@@ -19,6 +19,17 @@ function routeColor(status: RouteRecommendation['status']): string {
   }
 }
 
+function routeLabel(status: RouteRecommendation['status']): string {
+  switch (status) {
+    case 'pending':
+      return 'Pending route';
+    case 'stale':
+      return 'Stale route';
+    case 'clear':
+      return 'Entry route';
+  }
+}
+
 /**
  * Advisory responder route overlay.
  *
@@ -74,7 +85,7 @@ export function RouteOverlay3D({ route }: RouteOverlay3DProps) {
           style={{ pointerEvents: 'none' }}
         >
           <div className="rounded border border-emerald-300/30 bg-black/70 px-2 py-1 text-[10px] font-mono uppercase text-emerald-200 shadow-lg">
-            {route.status === 'stale' ? 'Stale route' : 'Entry route'}
+            {routeLabel(route.status)}
           </div>
         </Html>
       )}

--- a/software/viewer/src/components/map/RouteOverlay3D.tsx
+++ b/software/viewer/src/components/map/RouteOverlay3D.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Html, Line } from '@react-three/drei';
+import type { RouteRecommendation } from '@/lib/routeRecommendations';
+
+interface RouteOverlay3DProps {
+  route: RouteRecommendation;
+}
+
+function routeColor(status: RouteRecommendation['status']): string {
+  switch (status) {
+    case 'clear':
+      return '#34d399';
+    case 'stale':
+      return '#22d3ee';
+    case 'pending':
+      return '#facc15';
+  }
+}
+
+/**
+ * Advisory responder route overlay.
+ *
+ * Routes are visual guidance for incident command only; they do not publish
+ * vehicle commands or alter autonomous pathing.
+ */
+export function RouteOverlay3D({ route }: RouteOverlay3DProps) {
+  const color = routeColor(route.status);
+  const elevatedPoints = useMemo(
+    () => route.polyline.map(([x, y, z]) => [x, Math.max(y, 4), z] as [number, number, number]),
+    [route.polyline]
+  );
+  const midpoint = elevatedPoints[Math.floor(elevatedPoints.length / 2)];
+
+  if (elevatedPoints.length < 2) {
+    return null;
+  }
+
+  return (
+    <group>
+      <Line
+        points={elevatedPoints}
+        color={color}
+        lineWidth={5}
+        transparent
+        opacity={route.status === 'stale' ? 0.58 : 0.9}
+        dashed={route.status !== 'clear'}
+        dashSize={6}
+        gapSize={3}
+      />
+      <Line
+        points={elevatedPoints.map(([x, , z]) => [x, 0.75, z] as [number, number, number])}
+        color={color}
+        lineWidth={2}
+        transparent
+        opacity={0.22}
+        dashed
+        dashSize={8}
+        gapSize={6}
+      />
+      {elevatedPoints.map((point, index) => (
+        <mesh key={`${route.id}-${index}`} position={point}>
+          <sphereGeometry args={[index === 0 || index === elevatedPoints.length - 1 ? 3.5 : 2, 12, 12]} />
+          <meshBasicMaterial color={color} transparent opacity={0.82} />
+        </mesh>
+      ))}
+      {midpoint && (
+        <Html
+          position={[midpoint[0], midpoint[1] + 10, midpoint[2]]}
+          center
+          distanceFactor={110}
+          occlude={false}
+          style={{ pointerEvents: 'none' }}
+        >
+          <div className="rounded border border-emerald-300/30 bg-black/70 px-2 py-1 text-[10px] font-mono uppercase text-emerald-200 shadow-lg">
+            {route.status === 'stale' ? 'Stale route' : 'Entry route'}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}

--- a/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
+++ b/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
@@ -76,3 +76,26 @@ test("ZoneToolbar exposes explicit controls for structural hazards and staging p
   assert.match(source, /Hazard Zone/, "toolbar should let operators draw structural hazard polygons");
   assert.match(source, /Set Staging/, "toolbar should let operators place the staging area");
 });
+
+test("ZoneContext preserves the selected priority when entering staging placement", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "context", "ZoneContext.tsx"),
+    "utf8"
+  );
+  const stagingPlacementBlock = source.match(
+    /const startPlacingRouteStagingArea = useCallback\(\(\) => \{[\s\S]*?\n  \}, \[\]\);/
+  );
+
+  assert.ok(stagingPlacementBlock, "ZoneContext should define staging placement entry");
+
+  assert.match(
+    stagingPlacementBlock[0],
+    /currentPriority:\s*previous\.currentPriority/,
+    "staging placement should not reset the operator's selected zone priority"
+  );
+  assert.doesNotMatch(
+    stagingPlacementBlock[0],
+    /cancelDrawing\(\)/,
+    "staging placement should not call the priority-resetting cancel path"
+  );
+});

--- a/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
+++ b/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
@@ -39,3 +39,40 @@ test("MapScene3D passes route recommendations through a dedicated overlay compon
     "routes should not piggyback on trajectory visibility"
   );
 });
+
+test("RouteOverlay3D distinguishes pending route labels from clear routes", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "components", "map", "RouteOverlay3D.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /Pending route/, "pending routes should render a dedicated label");
+  assert.match(source, /Stale route/, "stale routes should keep their dedicated label");
+  assert.match(source, /Entry route/, "clear routes should keep their normal label");
+});
+
+test("page.tsx consumes shared staging and structural hazard state instead of a local default-only staging point", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "app", "page.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /structuralHazardZones/, "page should read shared structural hazard zones");
+  assert.match(source, /routeStagingArea/, "page should read the shared route staging area");
+  assert.match(source, /nowMs:\s*routeNowMs/, "route freshness should be recomputed from a live clock");
+  assert.doesNotMatch(
+    source,
+    /useState<[^>]*RouteStagingArea[^>]*>\(DEFAULT_ROUTE_STAGING_AREA\)/,
+    "page should not keep route staging as a local default-only state"
+  );
+});
+
+test("ZoneToolbar exposes explicit controls for structural hazards and staging placement", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "components", "zones", "ZoneToolbar.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /Hazard Zone/, "toolbar should let operators draw structural hazard polygons");
+  assert.match(source, /Set Staging/, "toolbar should let operators place the staging area");
+});

--- a/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
+++ b/software/viewer/src/components/map/RouteOverlay3DSurface.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+
+test("LayerVisibilityContext exposes a dedicated routes layer", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "context", "LayerVisibilityContext.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /routes:\s*boolean/, "layer state should include routes");
+  assert.match(source, /routes:\s*true/, "routes should be visible by default");
+});
+
+test("LayersPanel renders a route toggle separate from trajectories", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "components", "layers", "LayersPanel.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /id:\s*'routes'/, "layers panel should define a route layer item");
+  assert.match(source, /label:\s*'Routes'/, "route layer should have its own operator label");
+});
+
+test("MapScene3D passes route recommendations through a dedicated overlay component", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "src", "components", "map", "MapScene3D.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /RouteOverlay3D/, "MapScene3D should render the dedicated route overlay");
+  assert.match(source, /visibility\.routes/, "route overlays should use the dedicated layer toggle");
+  assert.doesNotMatch(
+    source,
+    /visibility\.trajectories\s*&&\s*routeRecommendations/,
+    "routes should not piggyback on trajectory visibility"
+  );
+});

--- a/software/viewer/src/components/map/ZoneOverlay3D.tsx
+++ b/software/viewer/src/components/map/ZoneOverlay3D.tsx
@@ -16,6 +16,11 @@ const priorityColors: Record<ZonePriority, { line: string; fill: string }> = {
   3: { line: '#eab308', fill: '#eab308' }, // Yellow - lowest priority
 };
 
+const structuralHazardColors = {
+  line: '#fb7185',
+  fill: '#fb7185',
+};
+
 interface ZoneOverlay3DProps {
   zone: PriorityZone;
   isSelected: boolean;
@@ -47,7 +52,8 @@ function pointsToVector3(points: ZonePoint[], y: number = 1): THREE.Vector3[] {
  * @param onClick - Handler for zone selection interactions
  */
 export function ZoneOverlay3D({ zone, isSelected, onClick }: ZoneOverlay3DProps) {
-  const colors = priorityColors[zone.priority];
+  const isStructuralHazard = zone.kind === 'structural_hazard';
+  const colors = isStructuralHazard ? structuralHazardColors : priorityColors[zone.priority];
   const isCompleted = zone.status === 'completed';
   const isSkipped = zone.status === 'skipped';
   const isDimmed = isCompleted || isSkipped;
@@ -101,9 +107,9 @@ export function ZoneOverlay3D({ zone, isSelected, onClick }: ZoneOverlay3DProps)
         lineWidth={isSelected ? 3 : 2}
         transparent
         opacity={isDimmed ? 0.4 : 0.8}
-        dashed={isCompleted}
-        dashSize={isCompleted ? 5 : undefined}
-        gapSize={isCompleted ? 5 : undefined}
+        dashed={isCompleted || isStructuralHazard}
+        dashSize={isCompleted || isStructuralHazard ? 5 : undefined}
+        gapSize={isCompleted || isStructuralHazard ? 5 : undefined}
       />
 
       <Text
@@ -127,7 +133,7 @@ export function ZoneOverlay3D({ zone, isSelected, onClick }: ZoneOverlay3DProps)
         outlineWidth={0.2}
         outlineColor="#000000"
       >
-        P{zone.priority}
+        {isStructuralHazard ? 'NO-GO' : `P${zone.priority}`}
       </Text>
     </group>
   );

--- a/software/viewer/src/components/sheets/DetectionCard.tsx
+++ b/software/viewer/src/components/sheets/DetectionCard.tsx
@@ -36,6 +36,7 @@ export interface Detection {
   concentration?: number;
   sector?: string;
   signatureType?: string;
+  routeBlockerType?: 'gas' | 'structural';
   deliveryMode?: 'live' | 'replayed';
   originalEventTs?: number;
   replayedAtTs?: number;

--- a/software/viewer/src/components/zones/ZoneToolbar.tsx
+++ b/software/viewer/src/components/zones/ZoneToolbar.tsx
@@ -1,7 +1,19 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { PenTool, Undo2, Check, X, AlertTriangle, AlertCircle, Info, Trash2, ChevronDown } from 'lucide-react';
+import {
+  PenTool,
+  Undo2,
+  Check,
+  X,
+  AlertTriangle,
+  AlertCircle,
+  Info,
+  Trash2,
+  ChevronDown,
+  MapPin,
+  ShieldAlert,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useZoneContext } from '@/context/ZoneContext';
 import type { ZonePriority } from '@/types/zone';
@@ -130,6 +142,10 @@ export function ZoneToolbar() {
     setPriority,
     deleteZone,
     selectZone,
+    isPlacingRouteStagingArea,
+    startPlacingRouteStagingArea,
+    cancelRouteStagingAreaPlacement,
+    routeStagingArea,
   } = useZoneContext();
 
   const [zoneName, setZoneName] = useState('');
@@ -156,6 +172,45 @@ export function ZoneToolbar() {
     }
   };
 
+  if (isPlacingRouteStagingArea) {
+    return (
+      <div className={cn(
+        'flex items-center gap-3 px-4 py-2.5 rounded-lg',
+        'bg-black/60 backdrop-blur-md',
+        'border border-white/10'
+      )}>
+        <div className="flex items-center gap-2 text-emerald-300">
+          <MapPin className="h-4 w-4" />
+          <span className="text-xs font-medium uppercase">Set Staging</span>
+        </div>
+
+        <div className="w-px h-5 bg-white/10" />
+
+        <span className="text-xs text-white/60">
+          Click the map to place the responder staging point.
+        </span>
+
+        <div className="w-px h-5 bg-white/10" />
+
+        <span className="font-mono text-xs text-white/50">
+          {Math.round(routeStagingArea.position[0])}, {Math.round(routeStagingArea.position[2])}
+        </span>
+
+        <button
+          onClick={cancelRouteStagingAreaPlacement}
+          className={cn(
+            'ml-auto flex items-center gap-2 px-3 py-1.5 rounded-md',
+            'text-white/60 hover:text-white hover:bg-white/10 transition-colors',
+            'text-sm font-medium'
+          )}
+        >
+          <X className="h-4 w-4" />
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
   if (!isDrawing) {
     return (
       <div className={cn(
@@ -169,7 +224,7 @@ export function ZoneToolbar() {
         <div className="w-px h-5 bg-white/10" />
 
         <button
-          onClick={() => startDrawing(drawing.currentPriority)}
+          onClick={() => startDrawing(drawing.currentPriority, 'search-zone')}
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-md',
             'bg-cyan-500/20 text-cyan-400',
@@ -179,6 +234,32 @@ export function ZoneToolbar() {
         >
           <PenTool className="h-4 w-4" />
           Draw Zone
+        </button>
+
+        <button
+          onClick={() => startDrawing(drawing.currentPriority, 'structural-hazard')}
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-md',
+            'bg-rose-500/20 text-rose-300',
+            'hover:bg-rose-500/30 transition-colors',
+            'text-sm font-medium'
+          )}
+        >
+          <ShieldAlert className="h-4 w-4" />
+          Hazard Zone
+        </button>
+
+        <button
+          onClick={startPlacingRouteStagingArea}
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-md',
+            'bg-emerald-500/20 text-emerald-300',
+            'hover:bg-emerald-500/30 transition-colors',
+            'text-sm font-medium'
+          )}
+        >
+          <MapPin className="h-4 w-4" />
+          Set Staging
         </button>
 
         {zones.length > 0 && (
@@ -205,6 +286,7 @@ export function ZoneToolbar() {
   }
 
   const currentPriority = priorityConfig[drawing.currentPriority];
+  const isStructuralHazard = drawing.target === 'structural-hazard';
 
   return (
     <div className={cn(
@@ -212,9 +294,15 @@ export function ZoneToolbar() {
       'bg-black/60 backdrop-blur-md',
       'border border-white/10'
     )}>
-      <div className={cn('flex items-center gap-2', currentPriority.color)}>
-        <currentPriority.Icon className="h-4 w-4" />
-        <span className="text-xs font-medium">{currentPriority.label}</span>
+      <div className={cn('flex items-center gap-2', isStructuralHazard ? 'text-rose-300' : currentPriority.color)}>
+        {isStructuralHazard ? (
+          <ShieldAlert className="h-4 w-4" />
+        ) : (
+          <currentPriority.Icon className="h-4 w-4" />
+        )}
+        <span className="text-xs font-medium">
+          {isStructuralHazard ? 'STRUCTURAL HAZARD' : currentPriority.label}
+        </span>
       </div>
 
       <div className="w-px h-5 bg-white/10" />

--- a/software/viewer/src/context/LayerVisibilityContext.tsx
+++ b/software/viewer/src/context/LayerVisibilityContext.tsx
@@ -11,6 +11,7 @@ import React, { createContext, useContext, useState, ReactNode } from 'react';
  * - gas: Gas sensor readings and concentration overlays
  * - acoustic: Acoustic detection markers and source indicators
  * - trajectories: Vehicle path history and planned waypoints
+ * - routes: Advisory responder entry routes
  */
 interface LayerState {
   map: boolean;
@@ -18,6 +19,7 @@ interface LayerState {
   gas: boolean;
   acoustic: boolean;
   trajectories: boolean;
+  routes: boolean;
 }
 
 interface LayerVisibilityContextType extends LayerState {
@@ -31,6 +33,7 @@ const defaultState: LayerState = {
   gas: true,
   acoustic: true,
   trajectories: true,
+  routes: true,
 };
 
 const LayerVisibilityContext = createContext<LayerVisibilityContextType | undefined>(undefined);

--- a/software/viewer/src/context/ZoneContext.tsx
+++ b/software/viewer/src/context/ZoneContext.tsx
@@ -194,9 +194,14 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
   }, []);
 
   const startPlacingRouteStagingArea = useCallback(() => {
-    cancelDrawing();
+    setDrawing(previous => ({
+      mode: 'none',
+      target: 'search-zone',
+      currentPriority: previous.currentPriority,
+      points: [],
+    }));
     setIsPlacingRouteStagingArea(true);
-  }, [cancelDrawing]);
+  }, []);
 
   const setRouteStagingAreaPosition = useCallback((point: ZonePoint) => {
     setRouteStagingArea((previous) => ({

--- a/software/viewer/src/context/ZoneContext.tsx
+++ b/software/viewer/src/context/ZoneContext.tsx
@@ -10,11 +10,17 @@ import React, {
 } from 'react';
 import type { PriorityZone, ZoneInput, ZonePriority, ZonePoint } from '@/types/zone';
 import { createZone } from '@/types/zone';
+import {
+  DEFAULT_ROUTE_STAGING_AREA,
+  type RouteStagingArea,
+} from '@/lib/routeRecommendations';
 
 export type DrawingMode = 'none' | 'drawing' | 'editing';
+export type DrawingTarget = 'search-zone' | 'structural-hazard';
 
 export interface DrawingState {
   mode: DrawingMode;
+  target: DrawingTarget;
   currentPriority: ZonePriority;
   points: ZonePoint[];
   editingZoneId?: string;
@@ -23,20 +29,26 @@ export interface DrawingState {
 interface ZoneContextValue {
   zones: PriorityZone[];
   activeZones: PriorityZone[];
+  structuralHazardZones: PriorityZone[];
   drawing: DrawingState;
   isDrawing: boolean;
+  routeStagingArea: RouteStagingArea;
+  isPlacingRouteStagingArea: boolean;
   addZone: (input: ZoneInput) => PriorityZone;
   updateZone: (id: string, updates: Partial<PriorityZone>) => void;
   deleteZone: (id: string) => void;
   completeZone: (id: string) => void;
   skipZone: (id: string) => void;
   reactivateZone: (id: string) => void;
-  startDrawing: (priority: ZonePriority) => void;
+  startDrawing: (priority: ZonePriority, target?: DrawingTarget) => void;
   addPoint: (point: ZonePoint) => void;
   undoLastPoint: () => void;
   cancelDrawing: () => void;
   finishDrawing: (name?: string, notes?: string) => PriorityZone | null;
   setPriority: (priority: ZonePriority) => void;
+  startPlacingRouteStagingArea: () => void;
+  setRouteStagingAreaPosition: (point: ZonePoint) => void;
+  cancelRouteStagingAreaPlacement: () => void;
   startEditing: (zoneId: string) => void;
   stopEditing: () => void;
   selectedZoneId: string | null;
@@ -62,12 +74,21 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
   const [drawing, setDrawing] = useState<DrawingState>({
     mode: 'none',
+    target: 'search-zone',
     currentPriority: 1,
     points: [],
   });
+  const [routeStagingArea, setRouteStagingArea] = useState<RouteStagingArea>(
+    DEFAULT_ROUTE_STAGING_AREA
+  );
+  const [isPlacingRouteStagingArea, setIsPlacingRouteStagingArea] = useState(false);
 
   const activeZones = useMemo(() => {
-    return zones.filter(z => z.status === 'active');
+    return zones.filter(z => z.kind === 'search' && z.status === 'active');
+  }, [zones]);
+
+  const structuralHazardZones = useMemo(() => {
+    return zones.filter(z => z.kind === 'structural_hazard' && z.status === 'active');
   }, [zones]);
 
   const selectedZone = useMemo(() => {
@@ -107,9 +128,11 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
     updateZone(id, { status: 'active', completedAt: undefined });
   }, [updateZone]);
 
-  const startDrawing = useCallback((priority: ZonePriority) => {
+  const startDrawing = useCallback((priority: ZonePriority, target: DrawingTarget = 'search-zone') => {
+    setIsPlacingRouteStagingArea(false);
     setDrawing({
       mode: 'drawing',
+      target,
       currentPriority: priority,
       points: [],
     });
@@ -132,6 +155,7 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
   const cancelDrawing = useCallback(() => {
     setDrawing({
       mode: 'none',
+      target: 'search-zone',
       currentPriority: 1,
       points: [],
     });
@@ -146,6 +170,7 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
 
     const zone = addZone({
       name,
+      kind: drawing.target === 'structural-hazard' ? 'structural_hazard' : 'search',
       priority: drawing.currentPriority,
       polygon: drawing.points,
       notes,
@@ -153,6 +178,7 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
 
     setDrawing({
       mode: 'none',
+      target: 'search-zone',
       currentPriority: 1,
       points: [],
     });
@@ -167,12 +193,30 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
     }));
   }, []);
 
+  const startPlacingRouteStagingArea = useCallback(() => {
+    cancelDrawing();
+    setIsPlacingRouteStagingArea(true);
+  }, [cancelDrawing]);
+
+  const setRouteStagingAreaPosition = useCallback((point: ZonePoint) => {
+    setRouteStagingArea((previous) => ({
+      ...previous,
+      position: [point.x, 0, point.z],
+    }));
+    setIsPlacingRouteStagingArea(false);
+  }, []);
+
+  const cancelRouteStagingAreaPlacement = useCallback(() => {
+    setIsPlacingRouteStagingArea(false);
+  }, []);
+
   const startEditing = useCallback((zoneId: string) => {
     const zone = zones.find(z => z.id === zoneId);
     if (!zone) return;
 
     setDrawing({
       mode: 'editing',
+      target: zone.kind === 'structural_hazard' ? 'structural-hazard' : 'search-zone',
       currentPriority: zone.priority,
       points: [...zone.polygon],
       editingZoneId: zoneId,
@@ -184,11 +228,13 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
       updateZone(drawing.editingZoneId, {
         polygon: drawing.points,
         priority: drawing.currentPriority,
+        kind: drawing.target === 'structural-hazard' ? 'structural_hazard' : 'search',
       });
     }
 
     setDrawing({
       mode: 'none',
+      target: 'search-zone',
       currentPriority: 1,
       points: [],
     });
@@ -201,8 +247,11 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
   const value: ZoneContextValue = {
     zones,
     activeZones,
+    structuralHazardZones,
     drawing,
     isDrawing,
+    routeStagingArea,
+    isPlacingRouteStagingArea,
     addZone,
     updateZone,
     deleteZone,
@@ -215,6 +264,9 @@ export function ZoneProvider({ children }: ZoneProviderProps) {
     cancelDrawing,
     finishDrawing,
     setPriority,
+    startPlacingRouteStagingArea,
+    setRouteStagingAreaPosition,
+    cancelRouteStagingAreaPlacement,
     startEditing,
     stopEditing,
     selectedZoneId,

--- a/software/viewer/src/hooks/useMissionControl.ts
+++ b/software/viewer/src/hooks/useMissionControl.ts
@@ -113,7 +113,10 @@ export function useMissionControl(): MissionControlState {
   );
 
   const hasValidStartZone =
-    !!selectedZone && selectedZone.status === 'active' && selectedZone.polygon.length >= 3;
+    !!selectedZone &&
+    selectedZone.kind === 'search' &&
+    selectedZone.status === 'active' &&
+    selectedZone.polygon.length >= 3;
 
   const effectiveStartMissionError =
     hasValidStartZone && startMissionError === INVALID_START_ZONE_ERROR

--- a/software/viewer/src/lib/ros/fusedDetections.js
+++ b/software/viewer/src/lib/ros/fusedDetections.js
@@ -162,6 +162,37 @@ function parseGeometryFromHazardPayload(rawHazardPayload) {
   }
 }
 
+function parseRouteBlockerType(rawMessage) {
+  const direct = typeof rawMessage?.route_blocker_type === "string"
+    ? rawMessage.route_blocker_type
+    : "";
+  const normalizedDirect = direct.trim().toLowerCase();
+  if (normalizedDirect === "gas" || normalizedDirect === "structural") {
+    return normalizedDirect;
+  }
+
+  if (typeof rawMessage?.hazard_payload_json !== "string" || rawMessage.hazard_payload_json.trim() === "") {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(rawMessage.hazard_payload_json);
+    const rawType = typeof payload?.route_blocker_type === "string"
+      ? payload.route_blocker_type
+      : typeof payload?.hazard_type === "string"
+        ? payload.hazard_type
+        : "";
+    const normalized = rawType.trim().toLowerCase();
+    if (normalized === "gas" || normalized === "structural") {
+      return normalized;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 function pickPrimarySensorType(sourceModalities) {
   for (const modality of MODALITY_PRIORITY) {
     if (sourceModalities.includes(modality)) {
@@ -253,6 +284,7 @@ export function normalizeFusedDetectionMessage(rawMessage, options = {}) {
     sourceModalities,
     geometry: fallbackGeometry.length > 0 ? fallbackGeometry : undefined,
     signatureType: buildSignature(sourceModalities, confidenceLevel),
+    routeBlockerType: parseRouteBlockerType(message),
     deliveryMode: replayMetadata?.deliveryMode,
     originalEventTs: replayMetadata?.originalEventTs ?? timestamp,
     replayedAtTs: replayMetadata?.replayedAtTs ?? undefined,

--- a/software/viewer/src/lib/ros/fusedDetections.test.mjs
+++ b/software/viewer/src/lib/ros/fusedDetections.test.mjs
@@ -101,6 +101,36 @@ test("normalizeFusedDetectionMessage preserves explicit structural route blocker
   assert.equal(detection.routeBlockerType, "structural");
 });
 
+test("normalizeFusedDetectionMessage falls back to hazard payload blocker metadata", () => {
+  const message = {
+    stamp: { sec: 1_700_000_061, nanosec: 0 },
+    candidate_id: "gas-hazard-fallback",
+    confidence_level: "MEDIUM",
+    confidence: 0.66,
+    source_modalities: ["gas"],
+    local_target: { x: 8, y: 12, z: 0 },
+    local_geometry: [],
+    hazard_payload_json: JSON.stringify({
+      route_blocker_type: "gas",
+      hazard_type: "gas",
+      polygons: [[
+        { x: 4, z: 10 },
+        { x: 12, z: 10 },
+        { x: 12, z: 14 },
+        { x: 4, z: 14 },
+      ]],
+    }),
+  };
+
+  const detection = normalizeFusedDetectionMessage(message, {
+    nowMs: (1_700_000_061 * 1000) + 500,
+    maxAgeMs: 120_000,
+  });
+
+  assert.ok(detection);
+  assert.equal(detection.routeBlockerType, "gas");
+});
+
 test("normalizeFusedDetectionMessage drops stale detections", () => {
   const message = {
     stamp: { sec: 1_700_000_000, nanosec: 0 },

--- a/software/viewer/src/lib/ros/fusedDetections.test.mjs
+++ b/software/viewer/src/lib/ros/fusedDetections.test.mjs
@@ -75,6 +75,32 @@ test("normalizeFusedDetectionMessage falls back to hazard payload geometry when 
   ]);
 });
 
+test("normalizeFusedDetectionMessage preserves explicit structural route blocker metadata", () => {
+  const message = {
+    stamp: { sec: 1_700_000_060, nanosec: 0 },
+    candidate_id: "collapse-001",
+    confidence_level: "HIGH",
+    confidence: 0.93,
+    source_modalities: ["thermal"],
+    local_target: { x: -15, y: 25, z: 0 },
+    local_geometry: [
+      { x: -25, y: 15, z: 0 },
+      { x: -5, y: 15, z: 0 },
+      { x: -5, y: 35, z: 0 },
+      { x: -25, y: 35, z: 0 },
+    ],
+    route_blocker_type: "structural",
+  };
+
+  const detection = normalizeFusedDetectionMessage(message, {
+    nowMs: (1_700_000_060 * 1000) + 1000,
+    maxAgeMs: 120_000,
+  });
+
+  assert.ok(detection);
+  assert.equal(detection.routeBlockerType, "structural");
+});
+
 test("normalizeFusedDetectionMessage drops stale detections", () => {
   const message = {
     stamp: { sec: 1_700_000_000, nanosec: 0 },

--- a/software/viewer/src/lib/routeRecommendations.d.ts
+++ b/software/viewer/src/lib/routeRecommendations.d.ts
@@ -1,4 +1,5 @@
 import type { Detection } from "@/components/sheets/DetectionCard";
+import type { PriorityZone } from "@/types/zone";
 
 export type RoutePoint = [number, number, number];
 
@@ -49,10 +50,11 @@ export const DEFAULT_ROUTE_STAGING_AREA: RouteStagingArea;
 
 export function selectSurvivorRouteTargets(detections: Detection[]): RouteTarget[];
 
-export function extractRouteBlockers(detections: Detection[]): RouteBlocker[];
+export function extractRouteBlockers(detections: Detection[], nowMs?: number): RouteBlocker[];
 
 export function deriveRouteRecommendations(input?: {
   detections?: Detection[];
   stagingArea?: RouteStagingArea;
+  structuralHazards?: PriorityZone[];
   nowMs?: number;
 }): RouteRecommendation[];

--- a/software/viewer/src/lib/routeRecommendations.d.ts
+++ b/software/viewer/src/lib/routeRecommendations.d.ts
@@ -1,0 +1,58 @@
+import type { Detection } from "@/components/sheets/DetectionCard";
+
+export type RoutePoint = [number, number, number];
+
+export interface RouteStagingArea {
+  id: string;
+  label: string;
+  position: RoutePoint;
+}
+
+export interface RouteFreshness {
+  source: "live" | "replayed" | "stale" | "unknown";
+  ageMs: number | null;
+}
+
+export interface RouteTarget {
+  id: string;
+  label: string;
+  position: RoutePoint;
+  detection: Detection;
+}
+
+export interface RouteBlocker {
+  id: string;
+  type: "gas" | "structural";
+  label: string;
+  geometry: RoutePoint[];
+  bounds: {
+    minX: number;
+    maxX: number;
+    minZ: number;
+    maxZ: number;
+  };
+  freshness: RouteFreshness;
+}
+
+export interface RouteRecommendation {
+  id: string;
+  sourceLabel: string;
+  destinationLabel: string;
+  targetDetectionId: string;
+  polyline: RoutePoint[];
+  blockingHazardIds: string[];
+  freshness: RouteFreshness;
+  status: "clear" | "stale" | "pending";
+}
+
+export const DEFAULT_ROUTE_STAGING_AREA: RouteStagingArea;
+
+export function selectSurvivorRouteTargets(detections: Detection[]): RouteTarget[];
+
+export function extractRouteBlockers(detections: Detection[]): RouteBlocker[];
+
+export function deriveRouteRecommendations(input?: {
+  detections?: Detection[];
+  stagingArea?: RouteStagingArea;
+  nowMs?: number;
+}): RouteRecommendation[];

--- a/software/viewer/src/lib/routeRecommendations.js
+++ b/software/viewer/src/lib/routeRecommendations.js
@@ -91,13 +91,14 @@ function boundsForGeometry(points) {
   );
 }
 
-export function extractRouteBlockers(detections) {
+export function extractRouteBlockers(detections, nowMs = Date.now()) {
   if (!Array.isArray(detections)) {
     return [];
   }
 
   return detections
     .map((detection) => {
+      if (!detection || isDismissed(detection)) return null;
       const type = normalizeBlockerType(detection);
       const geometry = Array.isArray(detection?.geometry) ? detection.geometry.filter(isFinitePoint) : [];
       const bounds = boundsForGeometry(geometry);
@@ -108,8 +109,47 @@ export function extractRouteBlockers(detections) {
         label: detectionLabel(detection),
         geometry,
         bounds,
-        freshness: freshnessForInputs([detection]),
+        freshness: freshnessForInputs([detection], nowMs),
         sourceDetection: detection,
+      };
+    })
+    .filter((blocker) => blocker !== null);
+}
+
+function extractStructuralHazardBlockers(structuralHazards, nowMs = Date.now()) {
+  if (!Array.isArray(structuralHazards)) {
+    return [];
+  }
+
+  return structuralHazards
+    .map((zone) => {
+      if (!zone || zone.kind !== "structural_hazard" || zone.status !== "active") {
+        return null;
+      }
+      const geometry = Array.isArray(zone.polygon)
+        ? zone.polygon
+          .map((point) => {
+            const x = Number(point?.x);
+            const z = Number(point?.z);
+            if (!Number.isFinite(x) || !Number.isFinite(z)) {
+              return null;
+            }
+            return [x, 0, z];
+          })
+          .filter((point) => point !== null)
+        : [];
+      const bounds = boundsForGeometry(geometry);
+      if (!bounds) return null;
+      return {
+        id: zone.id,
+        type: "structural",
+        label: zone.name || "Structural hazard",
+        geometry,
+        bounds,
+        freshness: { source: "live", ageMs: 0 },
+        sourceDetection: {
+          timestamp: typeof zone.createdAt === "number" ? Math.max(zone.createdAt, nowMs) : nowMs,
+        },
       };
     })
     .filter((blocker) => blocker !== null);
@@ -139,15 +179,33 @@ function freshnessForInputs(inputs, nowMs = Date.now()) {
 }
 
 function segmentIntersectsBounds(start, end, bounds) {
-  const minX = Math.min(start[0], end[0]);
-  const maxX = Math.max(start[0], end[0]);
-  const minZ = Math.min(start[2], end[2]);
-  const maxZ = Math.max(start[2], end[2]);
+  const x0 = start[0];
+  const z0 = start[2];
+  const dx = end[0] - x0;
+  const dz = end[2] - z0;
 
-  return maxX >= bounds.minX &&
-    minX <= bounds.maxX &&
-    maxZ >= bounds.minZ &&
-    minZ <= bounds.maxZ;
+  let tMin = 0;
+  let tMax = 1;
+
+  const clip = (p, q) => {
+    if (p === 0) {
+      return q >= 0;
+    }
+    const ratio = q / p;
+    if (p < 0) {
+      if (ratio > tMax) return false;
+      if (ratio > tMin) tMin = ratio;
+      return true;
+    }
+    if (ratio < tMin) return false;
+    if (ratio < tMax) tMax = ratio;
+    return true;
+  };
+
+  return clip(-dx, x0 - bounds.minX) &&
+    clip(dx, bounds.maxX - x0) &&
+    clip(-dz, z0 - bounds.minZ) &&
+    clip(dz, bounds.maxZ - z0);
 }
 
 function buildPolylineAroundBlockers(start, end, blockers) {
@@ -170,14 +228,27 @@ function buildPolylineAroundBlockers(start, end, blockers) {
   const startToUpper = Math.abs(start[2] - upperZ) + Math.abs(end[2] - upperZ);
   const startToLower = Math.abs(start[2] - lowerZ) + Math.abs(end[2] - lowerZ);
   const doglegZ = startToUpper <= startToLower ? upperZ : lowerZ;
+  const movingPositiveX = end[0] >= start[0];
+  const entryX = movingPositiveX
+    ? Math.max(start[0], blockerBounds.minX - ROUTE_CLEARANCE_METERS)
+    : Math.min(start[0], blockerBounds.maxX + ROUTE_CLEARANCE_METERS);
+  const exitX = movingPositiveX
+    ? Math.max(entryX, blockerBounds.maxX + ROUTE_CLEARANCE_METERS)
+    : Math.min(entryX, blockerBounds.minX - ROUTE_CLEARANCE_METERS);
+
+  const polyline = [
+    start,
+    [entryX, start[1], doglegZ],
+    [exitX, end[1], doglegZ],
+    end,
+  ].filter((point, index, points) => {
+    if (index === 0) return true;
+    const previous = points[index - 1];
+    return previous[0] !== point[0] || previous[1] !== point[1] || previous[2] !== point[2];
+  });
 
   return {
-    polyline: [
-      start,
-      [blockerBounds.minX - ROUTE_CLEARANCE_METERS, start[1], doglegZ],
-      [blockerBounds.maxX + ROUTE_CLEARANCE_METERS, end[1], doglegZ],
-      end,
-    ],
+    polyline,
     blocking,
   };
 }
@@ -185,6 +256,7 @@ function buildPolylineAroundBlockers(start, end, blockers) {
 export function deriveRouteRecommendations({
   detections,
   stagingArea = DEFAULT_ROUTE_STAGING_AREA,
+  structuralHazards = [],
   nowMs = Date.now(),
 } = {}) {
   if (!stagingArea || !isFinitePoint(stagingArea.position)) {
@@ -192,7 +264,10 @@ export function deriveRouteRecommendations({
   }
 
   const targets = selectSurvivorRouteTargets(detections);
-  const blockers = extractRouteBlockers(detections);
+  const blockers = [
+    ...extractRouteBlockers(detections, nowMs),
+    ...extractStructuralHazardBlockers(structuralHazards, nowMs),
+  ];
 
   return targets.map((target) => {
     const { polyline, blocking } = buildPolylineAroundBlockers(

--- a/software/viewer/src/lib/routeRecommendations.js
+++ b/software/viewer/src/lib/routeRecommendations.js
@@ -1,0 +1,224 @@
+export const DEFAULT_ROUTE_STAGING_AREA = {
+  id: "responder-staging",
+  label: "Responder staging",
+  position: [0, 0, 0],
+};
+
+const SURVIVOR_CONFIDENCE_THRESHOLD = 0.75;
+const STALE_INPUT_MS = 2 * 60 * 1000;
+const ROUTE_CLEARANCE_METERS = 18;
+
+function isFinitePoint(point) {
+  return Array.isArray(point) &&
+    point.length === 3 &&
+    point.every((value) => typeof value === "number" && Number.isFinite(value));
+}
+
+function isDismissed(detection) {
+  return detection?.status === "dismissed";
+}
+
+function modalitySet(detection) {
+  return new Set(Array.isArray(detection?.sourceModalities) ? detection.sourceModalities : []);
+}
+
+function normalizeBlockerType(detection) {
+  const value = typeof detection?.routeBlockerType === "string"
+    ? detection.routeBlockerType.trim().toLowerCase()
+    : "";
+  if (value === "gas" || value === "structural") {
+    return value;
+  }
+  if (detection?.sensorType === "gas") {
+    return "gas";
+  }
+  return null;
+}
+
+function isHazardOnlyDetection(detection) {
+  const modalities = modalitySet(detection);
+  if (detection?.sensorType === "gas") return true;
+  if (modalities.size > 0 && [...modalities].every((modality) => modality === "gas")) return true;
+  return normalizeBlockerType(detection) !== null;
+}
+
+function isHighConfidence(detection) {
+  if (detection?.confidenceLevel === "HIGH") return true;
+  return typeof detection?.confidence === "number" &&
+    Number.isFinite(detection.confidence) &&
+    detection.confidence >= SURVIVOR_CONFIDENCE_THRESHOLD;
+}
+
+function detectionLabel(detection) {
+  if (typeof detection?.signatureType === "string" && detection.signatureType.trim()) {
+    return detection.signatureType.trim();
+  }
+  return `${detection?.sensorType ?? "unknown"} detection`;
+}
+
+export function selectSurvivorRouteTargets(detections) {
+  if (!Array.isArray(detections)) {
+    return [];
+  }
+
+  return detections
+    .filter((detection) => {
+      if (!detection || isDismissed(detection)) return false;
+      if (!isFinitePoint(detection.position)) return false;
+      if (isHazardOnlyDetection(detection)) return false;
+      return isHighConfidence(detection);
+    })
+    .map((detection) => ({
+      id: detection.id,
+      label: detectionLabel(detection),
+      position: detection.position,
+      detection,
+    }));
+}
+
+function boundsForGeometry(points) {
+  const validPoints = points.filter(isFinitePoint);
+  if (validPoints.length < 3) return null;
+
+  return validPoints.reduce(
+    (bounds, point) => ({
+      minX: Math.min(bounds.minX, point[0]),
+      maxX: Math.max(bounds.maxX, point[0]),
+      minZ: Math.min(bounds.minZ, point[2]),
+      maxZ: Math.max(bounds.maxZ, point[2]),
+    }),
+    { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
+  );
+}
+
+export function extractRouteBlockers(detections) {
+  if (!Array.isArray(detections)) {
+    return [];
+  }
+
+  return detections
+    .map((detection) => {
+      const type = normalizeBlockerType(detection);
+      const geometry = Array.isArray(detection?.geometry) ? detection.geometry.filter(isFinitePoint) : [];
+      const bounds = boundsForGeometry(geometry);
+      if (!type || !bounds) return null;
+      return {
+        id: detection.id,
+        type,
+        label: detectionLabel(detection),
+        geometry,
+        bounds,
+        freshness: freshnessForInputs([detection]),
+        sourceDetection: detection,
+      };
+    })
+    .filter((blocker) => blocker !== null);
+}
+
+function freshnessForInputs(inputs, nowMs = Date.now()) {
+  const replayed = inputs.some(
+    (input) => input?.deliveryMode === "replayed" || input?.isRetroactive === true
+  );
+  if (replayed) {
+    return { source: "replayed", ageMs: null };
+  }
+
+  const timestamps = inputs
+    .map((input) => input?.timestamp)
+    .filter((timestamp) => typeof timestamp === "number" && Number.isFinite(timestamp));
+  if (timestamps.length === 0) {
+    return { source: "unknown", ageMs: null };
+  }
+
+  const newest = Math.max(...timestamps);
+  const ageMs = Math.max(0, nowMs - newest);
+  return {
+    source: ageMs > STALE_INPUT_MS ? "stale" : "live",
+    ageMs,
+  };
+}
+
+function segmentIntersectsBounds(start, end, bounds) {
+  const minX = Math.min(start[0], end[0]);
+  const maxX = Math.max(start[0], end[0]);
+  const minZ = Math.min(start[2], end[2]);
+  const maxZ = Math.max(start[2], end[2]);
+
+  return maxX >= bounds.minX &&
+    minX <= bounds.maxX &&
+    maxZ >= bounds.minZ &&
+    minZ <= bounds.maxZ;
+}
+
+function buildPolylineAroundBlockers(start, end, blockers) {
+  const blocking = blockers.filter((blocker) => segmentIntersectsBounds(start, end, blocker.bounds));
+  if (blocking.length === 0) {
+    return { polyline: [start, end], blocking };
+  }
+
+  const blockerBounds = blocking.reduce(
+    (bounds, blocker) => ({
+      minX: Math.min(bounds.minX, blocker.bounds.minX),
+      maxX: Math.max(bounds.maxX, blocker.bounds.maxX),
+      minZ: Math.min(bounds.minZ, blocker.bounds.minZ),
+      maxZ: Math.max(bounds.maxZ, blocker.bounds.maxZ),
+    }),
+    { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
+  );
+  const upperZ = blockerBounds.maxZ + ROUTE_CLEARANCE_METERS;
+  const lowerZ = blockerBounds.minZ - ROUTE_CLEARANCE_METERS;
+  const startToUpper = Math.abs(start[2] - upperZ) + Math.abs(end[2] - upperZ);
+  const startToLower = Math.abs(start[2] - lowerZ) + Math.abs(end[2] - lowerZ);
+  const doglegZ = startToUpper <= startToLower ? upperZ : lowerZ;
+
+  return {
+    polyline: [
+      start,
+      [blockerBounds.minX - ROUTE_CLEARANCE_METERS, start[1], doglegZ],
+      [blockerBounds.maxX + ROUTE_CLEARANCE_METERS, end[1], doglegZ],
+      end,
+    ],
+    blocking,
+  };
+}
+
+export function deriveRouteRecommendations({
+  detections,
+  stagingArea = DEFAULT_ROUTE_STAGING_AREA,
+  nowMs = Date.now(),
+} = {}) {
+  if (!stagingArea || !isFinitePoint(stagingArea.position)) {
+    return [];
+  }
+
+  const targets = selectSurvivorRouteTargets(detections);
+  const blockers = extractRouteBlockers(detections);
+
+  return targets.map((target) => {
+    const { polyline, blocking } = buildPolylineAroundBlockers(
+      stagingArea.position,
+      target.position,
+      blockers
+    );
+    const freshness = freshnessForInputs(
+      [target.detection, ...blocking.map((blocker) => blocker.sourceDetection)],
+      nowMs
+    );
+    const status = freshness.source === "live"
+      ? "clear"
+      : freshness.source === "unknown"
+        ? "pending"
+        : "stale";
+
+    return {
+      id: `route-${stagingArea.id}-${target.id}`,
+      sourceLabel: stagingArea.label,
+      destinationLabel: target.label,
+      targetDetectionId: target.id,
+      polyline,
+      blockingHazardIds: blocking.map((blocker) => blocker.id),
+      freshness,
+      status,
+    };
+  });
+}

--- a/software/viewer/src/lib/routeRecommendations.test.mjs
+++ b/software/viewer/src/lib/routeRecommendations.test.mjs
@@ -90,6 +90,17 @@ test("extractRouteBlockers uses gas geometry and explicit structural blocker met
         [15, 0, 15],
       ],
     }),
+    detection({
+      id: "dismissed-gas",
+      sensorType: "gas",
+      status: "dismissed",
+      geometry: [
+        [70, 0, -8],
+        [88, 0, -8],
+        [88, 0, 8],
+        [70, 0, 8],
+      ],
+    }),
   ]);
 
   assert.deepEqual(
@@ -98,6 +109,73 @@ test("extractRouteBlockers uses gas geometry and explicit structural blocker met
       ["gas-poly", "gas"],
       ["structural-poly", "structural"],
     ]
+  );
+});
+
+test("extractRouteBlockers uses the caller-provided clock for freshness", () => {
+  const blockers = extractRouteBlockers([
+    detection({
+      id: "gas-stale",
+      sensorType: "gas",
+      timestamp: nowMs - (3 * 60 * 1000),
+      geometry: [
+        [30, 0, -10],
+        [60, 0, -10],
+        [60, 0, 10],
+        [30, 0, 10],
+      ],
+    }),
+  ], nowMs);
+
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].freshness.source, "stale");
+  assert.equal(blockers[0].freshness.ageMs, 3 * 60 * 1000);
+});
+
+test("deriveRouteRecommendations excludes dismissed hazards and explicit structural hazard zones from the shared planning path", () => {
+  const routes = deriveRouteRecommendations({
+    detections: [
+      detection({
+        id: "survivor-b",
+        position: [120, 0, 0],
+      }),
+      detection({
+        id: "dismissed-blocker",
+        sensorType: "gas",
+        status: "dismissed",
+        sourceModalities: ["gas"],
+        geometry: [
+          [20, 0, -10],
+          [40, 0, -10],
+          [40, 0, 10],
+          [20, 0, 10],
+        ],
+      }),
+    ],
+    structuralHazards: [
+      {
+        id: "collapse-zone-1",
+        kind: "structural_hazard",
+        name: "Collapsed atrium",
+        priority: 1,
+        status: "active",
+        polygon: [
+          { x: 55, z: -12 },
+          { x: 82, z: -12 },
+          { x: 82, z: 12 },
+          { x: 55, z: 12 },
+        ],
+        createdAt: nowMs - 1_000,
+      },
+    ],
+    nowMs,
+  });
+
+  assert.equal(routes.length, 1);
+  assert.deepEqual(routes[0].blockingHazardIds, ["collapse-zone-1"]);
+  assert.ok(
+    !routes[0].blockingHazardIds.includes("dismissed-blocker"),
+    "dismissed hazards should not continue to block routes"
   );
 });
 
@@ -131,6 +209,68 @@ test("deriveRouteRecommendations bends advisory routes around blocking hazards",
   assert.ok(routes[0].polyline.length > 2, "route should include a dogleg around the blocker");
   assert.deepEqual(routes[0].polyline[0], DEFAULT_ROUTE_STAGING_AREA.position);
   assert.deepEqual(routes[0].polyline.at(-1), [100, 0, 0]);
+});
+
+test("deriveRouteRecommendations does not detour around diagonal blockers that do not intersect the path", () => {
+  const routes = deriveRouteRecommendations({
+    detections: [
+      detection({
+        id: "survivor-diagonal",
+        position: [100, 0, 100],
+      }),
+      detection({
+        id: "gas-off-path",
+        sensorType: "gas",
+        sourceModalities: ["gas"],
+        geometry: [
+          [20, 0, 80],
+          [30, 0, 80],
+          [30, 0, 90],
+          [20, 0, 90],
+        ],
+      }),
+    ],
+    stagingArea: DEFAULT_ROUTE_STAGING_AREA,
+    nowMs,
+  });
+
+  assert.equal(routes.length, 1);
+  assert.deepEqual(routes[0].blockingHazardIds, []);
+  assert.deepEqual(routes[0].polyline, [
+    DEFAULT_ROUTE_STAGING_AREA.position,
+    [100, 0, 100],
+  ]);
+});
+
+test("deriveRouteRecommendations keeps the first detour waypoint from retreating behind the staging area", () => {
+  const routes = deriveRouteRecommendations({
+    detections: [
+      detection({
+        id: "survivor-forward",
+        position: [100, 0, 0],
+      }),
+      detection({
+        id: "gas-overlap-start",
+        sensorType: "gas",
+        sourceModalities: ["gas"],
+        geometry: [
+          [-5, 0, -12],
+          [20, 0, -12],
+          [20, 0, 12],
+          [-5, 0, 12],
+        ],
+      }),
+    ],
+    stagingArea: DEFAULT_ROUTE_STAGING_AREA,
+    nowMs,
+  });
+
+  assert.equal(routes.length, 1);
+  assert.ok(routes[0].polyline.length > 2);
+  assert.ok(
+    routes[0].polyline[1][0] >= DEFAULT_ROUTE_STAGING_AREA.position[0],
+    "first detour waypoint should not move behind the start position"
+  );
 });
 
 test("deriveRouteRecommendations marks stale/replayed inputs and clears routes when inputs disappear", () => {

--- a/software/viewer/src/lib/routeRecommendations.test.mjs
+++ b/software/viewer/src/lib/routeRecommendations.test.mjs
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_ROUTE_STAGING_AREA,
+  deriveRouteRecommendations,
+  extractRouteBlockers,
+  selectSurvivorRouteTargets,
+} from "./routeRecommendations.js";
+
+const nowMs = 1_800_000_000_000;
+
+function detection(overrides = {}) {
+  return {
+    id: "det-target",
+    sensorType: "thermal",
+    confidence: 0.9,
+    confidenceLevel: "HIGH",
+    timestamp: nowMs - 10_000,
+    status: "new",
+    vehicleId: "scout-1",
+    vehicleName: "Scout 1",
+    position: [100, 0, 0],
+    sourceModalities: ["thermal"],
+    signatureType: "Human signature likely",
+    ...overrides,
+  };
+}
+
+test("selectSurvivorRouteTargets excludes gas-only and hazard-only detections", () => {
+  const targets = selectSurvivorRouteTargets([
+    detection({ id: "thermal-survivor", sensorType: "thermal" }),
+    detection({
+      id: "gas-hazard",
+      sensorType: "gas",
+      sourceModalities: ["gas"],
+      signatureType: "Hazardous levels",
+      confidence: 0.98,
+      confidenceLevel: "HIGH",
+    }),
+    detection({
+      id: "collapse-zone",
+      sensorType: "thermal",
+      routeBlockerType: "structural",
+      signatureType: "Structural collapse area",
+      confidence: 0.96,
+      confidenceLevel: "HIGH",
+    }),
+    detection({
+      id: "low-confidence",
+      sensorType: "acoustic",
+      confidence: 0.42,
+      confidenceLevel: "LOW",
+      signatureType: "Movement sounds",
+    }),
+  ]);
+
+  assert.deepEqual(targets.map((target) => target.id), ["thermal-survivor"]);
+});
+
+test("extractRouteBlockers uses gas geometry and explicit structural blocker metadata", () => {
+  const blockers = extractRouteBlockers([
+    detection({
+      id: "gas-poly",
+      sensorType: "gas",
+      geometry: [
+        [30, 0, -10],
+        [60, 0, -10],
+        [60, 0, 10],
+        [30, 0, 10],
+      ],
+    }),
+    detection({
+      id: "structural-poly",
+      sensorType: "thermal",
+      routeBlockerType: "structural",
+      geometry: [
+        [-20, 0, -20],
+        [-5, 0, -20],
+        [-5, 0, -5],
+        [-20, 0, -5],
+      ],
+    }),
+    detection({
+      id: "thermal-outline-only",
+      sensorType: "thermal",
+      geometry: [
+        [10, 0, 10],
+        [15, 0, 10],
+        [15, 0, 15],
+      ],
+    }),
+  ]);
+
+  assert.deepEqual(
+    blockers.map((blocker) => [blocker.id, blocker.type]),
+    [
+      ["gas-poly", "gas"],
+      ["structural-poly", "structural"],
+    ]
+  );
+});
+
+test("deriveRouteRecommendations bends advisory routes around blocking hazards", () => {
+  const routes = deriveRouteRecommendations({
+    detections: [
+      detection({
+        id: "survivor-a",
+        position: [100, 0, 0],
+      }),
+      detection({
+        id: "gas-blocker",
+        sensorType: "gas",
+        sourceModalities: ["gas"],
+        signatureType: "Elevated CO levels",
+        geometry: [
+          [35, 0, -12],
+          [65, 0, -12],
+          [65, 0, 12],
+          [35, 0, 12],
+        ],
+      }),
+    ],
+    stagingArea: DEFAULT_ROUTE_STAGING_AREA,
+    nowMs,
+  });
+
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].status, "clear");
+  assert.deepEqual(routes[0].blockingHazardIds, ["gas-blocker"]);
+  assert.ok(routes[0].polyline.length > 2, "route should include a dogleg around the blocker");
+  assert.deepEqual(routes[0].polyline[0], DEFAULT_ROUTE_STAGING_AREA.position);
+  assert.deepEqual(routes[0].polyline.at(-1), [100, 0, 0]);
+});
+
+test("deriveRouteRecommendations marks stale/replayed inputs and clears routes when inputs disappear", () => {
+  const staleRoutes = deriveRouteRecommendations({
+    detections: [
+      detection({
+        id: "survivor-replayed",
+        deliveryMode: "replayed",
+        isRetroactive: true,
+        timestamp: nowMs - 10_000,
+      }),
+    ],
+    nowMs,
+  });
+
+  assert.equal(staleRoutes.length, 1);
+  assert.equal(staleRoutes[0].status, "stale");
+  assert.equal(staleRoutes[0].freshness.source, "replayed");
+
+  const clearedRoutes = deriveRouteRecommendations({
+    detections: [],
+    nowMs,
+  });
+
+  assert.deepEqual(clearedRoutes, []);
+});

--- a/software/viewer/src/types/zone.ts
+++ b/software/viewer/src/types/zone.ts
@@ -7,6 +7,14 @@
 export type ZonePriority = 1 | 2 | 3;
 
 /**
+ * Semantic role for map-drawn polygons.
+ *
+ * - search: mission search coverage area
+ * - structural_hazard: explicit no-go / collapse hazard area used by route guidance
+ */
+export type ZoneKind = 'search' | 'structural_hazard';
+
+/**
  * Zone lifecycle status for search coordination.
  *
  * - active: Currently being or scheduled to be searched
@@ -34,6 +42,7 @@ export interface ZonePoint {
 export interface PriorityZone {
   id: string;
   name: string;
+  kind: ZoneKind;
   priority: ZonePriority;
   status: ZoneStatus;
   polygon: ZonePoint[];
@@ -49,6 +58,7 @@ export interface PriorityZone {
  */
 export interface ZoneInput {
   name?: string;
+  kind?: ZoneKind;
   priority: ZonePriority;
   polygon: ZonePoint[];
   notes?: string;
@@ -260,9 +270,15 @@ export function isPointInZone(point: ZonePoint, polygon: ZonePoint[]): boolean {
  */
 export function createZone(input: ZoneInput): PriorityZone {
   const id = generateZoneId();
+  const kind = input.kind ?? 'search';
+  const defaultName =
+    kind === 'structural_hazard'
+      ? `Hazard ${id.slice(-4).toUpperCase()}`
+      : `Zone ${id.slice(-4).toUpperCase()}`;
   return {
     id,
-    name: input.name || `Zone ${id.slice(-4).toUpperCase()}`,
+    name: input.name || defaultName,
+    kind,
     priority: input.priority,
     status: 'active',
     polygon: input.polygon,


### PR DESCRIPTION
## Summary
- derive advisory responder entry routes from survivor-likely detections and gas or structural blocker geometry
- add a dedicated Routes layer toggle and render route overlays separately from vehicle trajectories
- preserve stale/replayed freshness cues and keep route guidance advisory-only

## Validation
- cd software/viewer && node --test $(find src -name '*.test.mjs' | sort)\n- cd software/viewer && npm run lint\n- cd software/viewer && npx tsc --noEmit\n- cd software/viewer && npm run build\n- Browser smoke: route toggle visible, 3D canvas rendered; local rosbridge was not running\n\nCloses #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes overlay toggle and 3D route visualization with status indicators (clear/pending/stale)
  * Interactive staging-area placement and “Set Staging” toolbar workflow
  * Structural-hazard zones with distinct styling and a dedicated drawing mode
  * Detections include route-blocker classification used for route recommendations

* **Tests**
  * Unit and integration tests covering route recommendations, overlays, staging, and blocker propagation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces advisory responder entry route overlays derived from high-confidence survivor detections and gas/structural hazard geometry, along with a dedicated \"Routes\" layer toggle separate from vehicle trajectories.

- **`routeRecommendations.js`**: New module that selects survivor targets, extracts hazard blockers, and builds per-target polylines with a single dogleg around merged blocker bounds; the segment-vs-blocker collision check uses an AABB-AABB approximation that produces false positives on diagonal routes, causing unnecessary detours in the advisory display.
- **`RouteOverlay3D.tsx`**: Renders each recommendation as a colored 3D line with node spheres and an HTML label; `pending` and `clear` statuses share the same `'Entry route'` text, removing an important operator cue about data-freshness provenance.
- **`fusedDetections.js` / `DetectionCard.tsx`**: `parseRouteBlockerType` is added to extract `route_blocker_type` from either the top-level message or the JSON hazard payload, and the new field is surfaced on the `Detection` interface."

<h3>Confidence Score: 3/5</h3>

The advisory routing logic does not issue vehicle commands, but two issues in the new routing core could give operators incorrect situational awareness about which approach paths are clear.

The blocker-intersection test in segmentIntersectsBounds compares the full AABB of the start-to-end segment against each blocker's AABB rather than testing the actual line, so any diagonal route whose bounding box overlaps a nearby hazard gets an unnecessary dogleg — making a clear direct approach appear blocked. Independently, the RouteOverlay3D label collapses pending and clear into the same 'Entry route' text, removing an explicit freshness signal for operators.

routeRecommendations.js (intersection test and freshness forwarding) and RouteOverlay3D.tsx (status label copy) warrant the closest look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/viewer/src/lib/routeRecommendations.js | Core route-derivation logic; AABB-AABB intersection test in segmentIntersectsBounds produces false positives for diagonal paths, and extractRouteBlockers does not forward nowMs to freshnessForInputs |
| software/viewer/src/components/map/RouteOverlay3D.tsx | New 3D overlay component; label logic conflates 'pending' and 'clear' status under the same 'Entry route' text, which may mislead operators |
| software/viewer/src/lib/routeRecommendations.d.ts | Type declarations for route recommendation API; accurately reflects the exported functions and types |
| software/viewer/src/context/LayerVisibilityContext.tsx | Adds routes boolean to LayerState and defaults it to true; straightforward and consistent with existing layer entries |
| software/viewer/src/components/layers/LayersPanel.tsx | Adds a 'Routes' layer item using the Route icon (same as 'Paths'); functionally correct but shares icon with trajectories layer |
| software/viewer/src/components/map/MapScene3D.tsx | Wires routeRecommendations prop to RouteOverlay3D under its own visibility toggle; clean integration with existing scene structure |
| software/viewer/src/lib/ros/fusedDetections.js | Adds parseRouteBlockerType helper that reads route_blocker_type from both the top-level message and the JSON payload fallback; logic is sound and well-guarded |
| software/viewer/src/app/page.tsx | Introduces routeRecommendations useMemo derived from detections and passes it to MapScene3D; staging area is currently a static default with no UI to override it |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[detections array] --> B[selectSurvivorRouteTargets]
    A --> C[extractRouteBlockers]
    B --> D{high-confidence,\nnon-dismissed,\nnon-hazard?}
    D -->|yes| E[RouteTarget]
    D -->|no| F[excluded]
    C --> G{routeBlockerType\nor gas sensorType\n+ valid geometry?}
    G -->|yes| H[RouteBlocker AABB]
    G -->|no| I[excluded]
    E --> J[buildPolylineAroundBlockers]
    H --> J
    J --> K{segmentIntersectsBounds\nAABB-AABB check}
    K -->|no overlap| L[direct 2-point polyline]
    K -->|overlap| M[4-point dogleg\naround merged bounds]
    L --> N[freshnessForInputs]
    M --> N
    N --> O{source?}
    O -->|live| P[status: clear / green solid]
    O -->|replayed or stale| Q[status: stale / cyan dashed]
    O -->|unknown| R[status: pending / yellow dashed]
    P --> S[RouteRecommendation]
    Q --> S
    R --> S
    S --> T[RouteOverlay3D]
    T --> U[MapScene3D visibility.routes toggle]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
software/viewer/src/lib/routeRecommendations.js:141-151
**AABB-AABB check produces false-positive blocker detections on diagonal routes**

`segmentIntersectsBounds` builds the bounding box of the full start→end segment and checks it against the blocker's AABB. For any diagonal route (start and end at different X and Z), this overapproximates the swept area. Example: staging at `[0,0,0]`, survivor at `[100,0,100]`, gas blocker at X=[20..30] Z=[80..90] — the actual line passes through Z=80–90 at X=80–90, nowhere near the blocker, but the segment's AABB [0..100]×[0..100] overlaps the blocker AABB and triggers a dogleg. The unnecessary detour may mislead responders into thinking the direct approach is hazardous when it is clear. A proper separating-axis or parametric line-vs-AABB test avoids the false positive.

### Issue 2 of 3
software/viewer/src/components/map/RouteOverlay3D.tsx:77
**`pending` status shows the same 'Entry route' label as a confirmed clear route**

A pending route is produced when no valid timestamps exist for the underlying detection data (freshness source is `"unknown"`). It renders with a yellow dashed line but the same label as a live-data clear route. An operator reading only the text has no indication that data provenance is unknown. Using a distinct label makes the distinction explicit without requiring colour discrimination.

```suggestion
            {route.status === 'stale' ? 'Stale route' : route.status === 'pending' ? 'Pending route' : 'Entry route'}
```

### Issue 3 of 3
software/viewer/src/lib/routeRecommendations.js:111
**`RouteBlocker.freshness` is always computed against `Date.now()`, ignoring `nowMs`**

`extractRouteBlockers` is a public export and its return type declares a `freshness` field on each blocker. The call `freshnessForInputs([detection])` uses the default `nowMs = Date.now()` rather than any caller-supplied reference time. This means `blocker.freshness.ageMs` is stale the moment the result is cached, and tests that pass a custom `nowMs` into `deriveRouteRecommendations` will find that the upstream `extractRouteBlockers` results were timestamped against wall-clock time rather than the test clock. `extractRouteBlockers` should accept and forward an optional `nowMs` parameter so consumers get consistent freshness across the call chain.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["viewer: add advisory entry route overlay..."](https://github.com/aeris-drones/aeris/commit/e43bfd49355a8d73b914f3143725837cf7f41061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32462555)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->