### PR TITLE
Add read-only incident commander tactical view

### DIFF
--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseTsx(filePath) {
+  const source = fs.readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  return { source, sourceFile };
+}
+
+function walk(node, visitor) {
+  visitor(node);
+  ts.forEachChild(node, (child) => walk(child, visitor));
+}
+
+test("page owns one URL-aware IC view mode flag", () => {
+  const pagePath = path.join(ROOT, "app", "page.tsx");
+  const { source, sourceFile } = parseTsx(pagePath);
+
+  assert.match(source, /useSearchParams/, "IC mode should use App Router search params");
+  assert.match(source, /isIcViewModeQueryValue/, "IC mode should normalize URL values in one helper");
+  assert.match(source, /setIcViewModeEnabled/, "IC mode should have one canonical page-shell state setter");
+
+  let passesModeToLayout = false;
+  let passesModeToDock = false;
+  walk(sourceFile, (node) => {
+    if (
+      ts.isJsxAttribute(node) &&
+      node.name.text === "viewMode" &&
+      node.initializer?.getText(sourceFile).includes("icViewModeEnabled ? 'ic' : 'operator'")
+    ) {
+      passesModeToLayout = true;
+    }
+    if (
+      ts.isJsxAttribute(node) &&
+      node.name.text === "mode" &&
+      node.initializer?.getText(sourceFile).includes("icViewModeEnabled ? 'ic' : 'operator'")
+    ) {
+      passesModeToDock = true;
+    }
+  });
+
+  assert.ok(passesModeToLayout, "layout should receive the canonical IC mode flag");
+  assert.ok(passesModeToDock, "command dock should receive the canonical IC mode flag");
+});
+
+test("IC mode guards state-changing mission, detection, zone, and vehicle actions", () => {
+  const pagePath = path.join(ROOT, "app", "page.tsx");
+  const { source } = parseTsx(pagePath);
+
+  assert.match(source, /if \(icViewModeEnabled\) \{\s*return;\s*\}\s*setDetectionStatusOverrides/s);
+  assert.match(source, /onDroneSelect=\{icViewModeEnabled \? undefined : handleDroneSelect\}/);
+  assert.match(source, /onDetectionSelect=\{icViewModeEnabled \? handleLocateDetection : handleDetectionSelect\}/);
+  assert.match(source, /onZoneSelect=\{icViewModeEnabled \? undefined : selectZone\}/);
+  assert.match(source, /onAddZonePoint=\{icViewModeEnabled \? undefined : addPoint\}/);
+  assert.match(source, /onRouteStagingAreaSet=\{icViewModeEnabled \? undefined : setRouteStagingAreaPosition\}/);
+  assert.doesNotMatch(source, /zoneToolbar=\{<ZoneToolbar \/>}/);
+});
+
+test("IC mode keeps tactical summaries visible while removing operator controls", () => {
+  const pagePath = path.join(ROOT, "app", "page.tsx");
+  const { source } = parseTsx(pagePath);
+
+  assert.match(source, /icTacticalSummary/, "page should compose a dedicated IC tactical summary");
+  assert.match(source, /text-base/, "IC tactical text should be distance-readable");
+  assert.match(source, /controlsCard=\{icViewModeEnabled \? undefined : \(/);
+  assert.match(source, /readOnly=\{icViewModeEnabled\}/);
+  assert.match(source, /IC VIEW/, "page should expose a visible mode toggle label");
+});

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -19,62 +19,85 @@ function parseTsx(filePath) {
   return { source, sourceFile };
 }
 
-function walk(node, visitor) {
-  visitor(node);
-  ts.forEachChild(node, (child) => walk(child, visitor));
+function findFunction(sourceFile, name) {
+  let match = null;
+  function walk(node) {
+    if (match) return;
+    if ((ts.isFunctionDeclaration(node) || ts.isVariableDeclaration(node)) && node.name?.getText(sourceFile) === name) {
+      match = node;
+      return;
+    }
+    ts.forEachChild(node, walk);
+  }
+  walk(sourceFile);
+  return match;
 }
 
-test("page owns one URL-aware IC view mode flag", () => {
+test("IC mode keeps one canonical page-shell flag and propagates it", () => {
+  const pagePath = path.join(ROOT, "app", "page.tsx");
+  const { source } = parseTsx(pagePath);
+
+  assert.match(source, /useSearchParams/);
+  assert.match(source, /isIcViewModeQueryValue/);
+  assert.match(source, /setIcViewModeEnabled/);
+  assert.match(source, /viewMode=\{icViewModeEnabled \? 'ic' : 'operator'\}/);
+  assert.match(source, /mode=\{icViewModeEnabled \? 'ic' : 'operator'\}/);
+});
+
+test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   const pagePath = path.join(ROOT, "app", "page.tsx");
   const { source, sourceFile } = parseTsx(pagePath);
 
-  assert.match(source, /useSearchParams/, "IC mode should use App Router search params");
-  assert.match(source, /isIcViewModeQueryValue/, "IC mode should normalize URL values in one helper");
-  assert.match(source, /setIcViewModeEnabled/, "IC mode should have one canonical page-shell state setter");
+  const handleViewFeed = findFunction(sourceFile, "handleViewFeed");
+  assert.ok(handleViewFeed, "page should define a dedicated feed handler");
+  const handleViewFeedText = handleViewFeed.getText(sourceFile);
+  assert.match(handleViewFeedText, /if \(icViewModeEnabled\) \{\s*return;\s*\}/s);
+  assert.match(handleViewFeedText, /setPipVehicleId\(id\)/);
 
-  let passesModeToLayout = false;
-  let passesModeToDock = false;
-  walk(sourceFile, (node) => {
-    if (
-      ts.isJsxAttribute(node) &&
-      node.name.text === "viewMode" &&
-      node.initializer?.getText(sourceFile).includes("icViewModeEnabled ? 'ic' : 'operator'")
-    ) {
-      passesModeToLayout = true;
-    }
-    if (
-      ts.isJsxAttribute(node) &&
-      node.name.text === "mode" &&
-      node.initializer?.getText(sourceFile).includes("icViewModeEnabled ? 'ic' : 'operator'")
-    ) {
-      passesModeToDock = true;
-    }
-  });
-
-  assert.ok(passesModeToLayout, "layout should receive the canonical IC mode flag");
-  assert.ok(passesModeToDock, "command dock should receive the canonical IC mode flag");
+  const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);
+  assert.ok(keyboardEffect, "page should keep keyboard handling localized");
+  const keyboardText = keyboardEffect[1];
+  assert.match(keyboardText, /case 'Escape':[\s\S]*if \(icViewModeEnabled\) \{\s*break;\s*\}/);
+  assert.match(keyboardText, /case '1':[\s\S]*case '6':[\s\S]*if \(icViewModeEnabled\) \{\s*break;\s*\}/);
+  assert.match(keyboardText, /case 'r':[\s\S]*case 'R':[\s\S]*if \(icViewModeEnabled\) \{\s*break;\s*\}/);
 });
 
-test("IC mode guards state-changing mission, detection, zone, and vehicle actions", () => {
-  const pagePath = path.join(ROOT, "app", "page.tsx");
-  const { source } = parseTsx(pagePath);
+test("FleetSheet only exposes feed action when the parent passes it", () => {
+  const fleetSheetPath = path.join(ROOT, "components", "sheets", "FleetSheet.tsx");
+  const { source } = parseTsx(fleetSheetPath);
 
-  assert.match(source, /if \(icViewModeEnabled\) \{\s*return;\s*\}\s*setDetectionStatusOverrides/s);
-  assert.match(source, /onDroneSelect=\{icViewModeEnabled \? undefined : handleDroneSelect\}/);
-  assert.match(source, /onDetectionSelect=\{icViewModeEnabled \? handleLocateDetection : handleDetectionSelect\}/);
-  assert.match(source, /onZoneSelect=\{icViewModeEnabled \? undefined : selectZone\}/);
-  assert.match(source, /onAddZonePoint=\{icViewModeEnabled \? undefined : addPoint\}/);
-  assert.match(source, /onRouteStagingAreaSet=\{icViewModeEnabled \? undefined : setRouteStagingAreaPosition\}/);
-  assert.doesNotMatch(source, /zoneToolbar=\{<ZoneToolbar \/>}/);
+  assert.match(source, /onViewFeed=\{\(\) => handleViewFeed\(vehicle\.id\)\}/);
 });
 
-test("IC mode keeps tactical summaries visible while removing operator controls", () => {
-  const pagePath = path.join(ROOT, "app", "page.tsx");
-  const { source } = parseTsx(pagePath);
+test("IC mode typography upgrades keep key tactical labels at text-base or larger", () => {
+  const files = [
+    path.join(ROOT, "app", "page.tsx"),
+    path.join(ROOT, "components", "layout", "StatusPill.tsx"),
+    path.join(ROOT, "components", "cards", "FleetCard.tsx"),
+    path.join(ROOT, "components", "cards", "DetectionsCard.tsx"),
+    path.join(ROOT, "components", "sheets", "VehicleCard.tsx"),
+    path.join(ROOT, "components", "sheets", "DetectionCard.tsx"),
+  ];
 
-  assert.match(source, /icTacticalSummary/, "page should compose a dedicated IC tactical summary");
-  assert.match(source, /text-base/, "IC tactical text should be distance-readable");
-  assert.match(source, /controlsCard=\{icViewModeEnabled \? undefined : \(/);
-  assert.match(source, /readOnly=\{icViewModeEnabled\}/);
-  assert.match(source, /IC VIEW/, "page should expose a visible mode toggle label");
+  const combined = files.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+  assert.match(combined, /text-base text-white\/75">fleet active/);
+  assert.match(combined, /text-base text-white\/75">pending alerts/);
+  assert.match(combined, /isIcMode \? 'text-lg' : 'text-xs'/);
+  assert.match(combined, /isIcMode \? 'text-lg text-white\/85' : 'text-xs text-white\/50'/);
+  assert.match(combined, /text-base font-medium tracking-\[0\.12em\] text-white\/55/);
+  assert.match(combined, /text-base text-white\/45 uppercase tracking-wide">Alt \(m\)</);
+});
+
+test("DetectionCard read-only mode keeps locate while removing triage actions", () => {
+  const detectionCardPath = path.join(ROOT, "components", "sheets", "DetectionCard.tsx");
+  const { source } = parseTsx(detectionCardPath);
+
+  const actionableBlock = source.match(/\{isActionable && \(([\s\S]*?)\n\s*\)\}/);
+  assert.ok(actionableBlock, "DetectionCard should keep a dedicated actionable footer");
+  assert.match(actionableBlock[1], /Locate/);
+
+  const readOnlyBranch = source.match(/\{!readOnly && \(([\s\S]*?)\n\s*\)\}/);
+  assert.ok(readOnlyBranch, "triage controls should be gated behind readOnly");
+  assert.match(readOnlyBranch[1], /Dismiss/);
+  assert.match(readOnlyBranch[1], /Confirm/);
 });

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { Suspense, useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { GCSLayout } from '@/components/layout/GCSLayout';
 import { StatusPill, MissionPhase } from '@/components/layout/StatusPill';
 import { CommandDock } from '@/components/layout/CommandDock';
@@ -14,6 +15,7 @@ import { Detection } from '@/components/sheets/DetectionCard';
 import { VehicleInfo } from '@/components/sheets/VehicleCard';
 import { LayersPanel } from '@/components/layers/LayersPanel';
 import { LayerVisibilityProvider } from '@/context/LayerVisibilityContext';
+import { useLayerVisibility } from '@/context/LayerVisibilityContext';
 import { ZoneProvider, useZoneContext } from '@/context/ZoneContext';
 import { CoordinateOriginProvider } from '@/context/CoordinateOriginContext';
 import { ROSConnectionProvider } from '@/context/ROSConnectionContext';
@@ -22,6 +24,7 @@ import { ZoneToolbar } from '@/components/zones/ZoneToolbar';
 import { PiPVideoFeed } from '@/components/pip/PiPVideoFeed';
 import { AlertToaster, showAlert, dismissAlert, type Alert } from '@/components/alerts';
 import { KeyboardShortcutsOverlay } from '@/components/ui/KeyboardShortcuts';
+import { Switch } from '@/components/ui/switch';
 import { useMissionControl } from '@/hooks/useMissionControl';
 import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useFusedDetections } from '@/hooks/useFusedDetections';
@@ -29,6 +32,7 @@ import { applyDetectionStatusOverrides, computeDetectionCounts } from '@/lib/det
 import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
 import { applyVehicleMissionMeta } from '@/lib/fleetVehicleProjection';
 import { normalizeMissionMetaForVehicle } from '@/lib/degradedVehicleState';
+import { isIcViewModeQueryValue } from '@/lib/icViewMode';
 import {
   deriveRouteRecommendations,
 } from '@/lib/routeRecommendations';
@@ -87,7 +91,9 @@ export default function V2Page() {
         <LayerVisibilityProvider>
           <ZoneProvider>
             <MissionProvider>
-              <V2PageContent />
+              <Suspense fallback={null}>
+                <V2PageContent />
+              </Suspense>
               <AlertToaster visibleToasts={5} />
               <KeyboardShortcutsOverlay />
             </MissionProvider>
@@ -99,6 +105,10 @@ export default function V2Page() {
 }
 
 function V2PageContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const layerVisibility = useLayerVisibility();
   const {
     zones,
     structuralHazardZones,
@@ -115,6 +125,9 @@ function V2PageContent() {
   const [selectedDroneId, setSelectedDroneId] = useState<string | null>(null);
   const [selectedDetectionId, setSelectedDetectionId] = useState<string | null>(null);
   const [routeNowMs, setRouteNowMs] = useState(() => Date.now());
+  const [icViewModeEnabled, setIcViewModeEnabled] = useState(() =>
+    isIcViewModeQueryValue(searchParams.get('ic'))
+  );
 
   const {
     phase: missionPhase,
@@ -150,6 +163,36 @@ function V2PageContent() {
   } = useFusedDetections(telemetryVehicles);
   const allowMockFallback =
     process.env.NODE_ENV !== 'production' && !rosConnected;
+
+  useEffect(() => {
+    setIcViewModeEnabled(isIcViewModeQueryValue(searchParams.get('ic')));
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!icViewModeEnabled) {
+      return;
+    }
+
+    (['map', 'thermal', 'gas', 'acoustic', 'trajectories', 'routes'] as const).forEach((layer) => {
+      if (!layerVisibility[layer]) {
+        layerVisibility.setLayer(layer, true);
+      }
+    });
+  }, [icViewModeEnabled, layerVisibility]);
+
+  const setIcModeFromUi = useCallback((enabled: boolean) => {
+    setIcViewModeEnabled(enabled);
+
+    const params = new URLSearchParams(searchParams.toString());
+    if (enabled) {
+      params.set('ic', '1');
+    } else {
+      params.delete('ic');
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
 
   const baseDetections = useMemo<Detection[]>(
     () => {
@@ -337,18 +380,26 @@ function V2PageContent() {
   }, [detections]);
 
   const handleConfirmDetection = useCallback((id: string) => {
+    if (icViewModeEnabled) {
+      return;
+    }
+
     setDetectionStatusOverrides((previous) => ({
       ...previous,
       [id]: 'confirmed',
     }));
-  }, []);
+  }, [icViewModeEnabled]);
 
   const handleDismissDetection = useCallback((id: string) => {
+    if (icViewModeEnabled) {
+      return;
+    }
+
     setDetectionStatusOverrides((previous) => ({
       ...previous,
       [id]: 'dismissed',
     }));
-  }, []);
+  }, [icViewModeEnabled]);
 
   const handleLocateDetection = useCallback((id: string) => {
     const detection = detections.find(d => d.id === id);
@@ -367,8 +418,11 @@ function V2PageContent() {
   }, []);
 
   const handleRTH = useCallback((id: string) => {
+    if (icViewModeEnabled) {
+      return;
+    }
     void id;
-  }, []);
+  }, [icViewModeEnabled]);
 
   const handleAlertClick = useCallback(() => {
     if (!allowMockFallback || storedAlerts.length === 0) {
@@ -395,8 +449,16 @@ function V2PageContent() {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
 
       switch (e.key) {
+        case 'i':
+        case 'I':
+          e.preventDefault();
+          setIcModeFromUi(!icViewModeEnabled);
+          break;
         case ' ': // Space - Pause/Resume mission
           e.preventDefault();
+          if (icViewModeEnabled) {
+            break;
+          }
           if (missionPhase === 'SEARCHING' || missionPhase === 'TRACKING') {
             if (isPaused) {
               resumeMission();
@@ -434,7 +496,7 @@ function V2PageContent() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [missionPhase, isPaused, pauseMission, resumeMission, handleLocateVehicle, fleetVehicles]);
+  }, [missionPhase, isPaused, pauseMission, resumeMission, handleLocateVehicle, fleetVehicles, icViewModeEnabled, setIcModeFromUi]);
 
   const activeVehicles = fleetVehicles.filter(v => v.status === 'active' || v.status === 'warning');
   const batteryReadings = fleetVehicles
@@ -452,9 +514,35 @@ function V2PageContent() {
     [detections]
   );
   const statusAlertCount = detectionCounts.pending;
+  const icTacticalSummary = (
+    <div className="pointer-events-auto flex max-w-[360px] flex-col gap-3 text-base">
+      <div className="rounded-lg border border-white/25 bg-black/75 px-4 py-3 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
+        <div className="text-sm font-semibold uppercase tracking-wide text-white/65">IC VIEW</div>
+        <div className="mt-2 grid grid-cols-2 gap-3 text-white">
+          <div>
+            <div className="font-mono text-2xl font-semibold">{activeVehicles.length}/{fleetVehicles.length}</div>
+            <div className="text-sm text-white/70">fleet active</div>
+          </div>
+          <div>
+            <div className="font-mono text-2xl font-semibold">{detectionCounts.pending}</div>
+            <div className="text-sm text-white/70">pending alerts</div>
+          </div>
+          <div>
+            <div className="font-mono text-2xl font-semibold">{routeRecommendations.length}</div>
+            <div className="text-sm text-white/70">entry routes</div>
+          </div>
+          <div>
+            <div className="font-mono text-2xl font-semibold">{structuralHazardZones.length}</div>
+            <div className="text-sm text-white/70">hazard zones</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <GCSLayout
+      viewMode={icViewModeEnabled ? 'ic' : 'operator'}
       map={
         <MapScene3D
           vehicles={telemetryVehicles}
@@ -465,18 +553,18 @@ function V2PageContent() {
           detections={detections}
           selectedDroneId={selectedDroneId}
           selectedDetectionId={selectedDetectionId}
-          onDroneSelect={handleDroneSelect}
-          onDetectionSelect={handleDetectionSelect}
+          onDroneSelect={icViewModeEnabled ? undefined : handleDroneSelect}
+          onDetectionSelect={icViewModeEnabled ? handleLocateDetection : handleDetectionSelect}
           zones={zones}
           selectedZoneId={selectedZoneId}
-          onZoneSelect={selectZone}
-          isDrawingZone={isDrawing}
+          onZoneSelect={icViewModeEnabled ? undefined : selectZone}
+          isDrawingZone={icViewModeEnabled ? false : isDrawing}
           drawingPoints={drawing.points}
           drawingPriority={drawing.currentPriority}
-          onAddZonePoint={addPoint}
+          onAddZonePoint={icViewModeEnabled ? undefined : addPoint}
           routeStagingArea={routeStagingArea}
-          isPlacingRouteStagingArea={isPlacingRouteStagingArea}
-          onRouteStagingAreaSet={setRouteStagingAreaPosition}
+          isPlacingRouteStagingArea={icViewModeEnabled ? false : isPlacingRouteStagingArea}
+          onRouteStagingAreaSet={icViewModeEnabled ? undefined : setRouteStagingAreaPosition}
         />
       }
 
@@ -490,22 +578,35 @@ function V2PageContent() {
           alertCount={statusAlertCount}
           hasUnreadAlerts={statusAlertCount > 0}
           onAlertClick={handleAlertClick}
+          viewMode={icViewModeEnabled ? 'ic' : 'operator'}
         />
       }
 
-      layersPanel={<LayersPanel />}
+      layersPanel={
+        icViewModeEnabled ? (
+          <div className="space-y-3">
+            {icTacticalSummary}
+            <div className="rounded-lg border border-white/20 bg-black/70 px-4 py-3 text-base text-white/85">
+              Read-only shared tactical picture
+            </div>
+          </div>
+        ) : (
+          <LayersPanel />
+        )
+      }
 
-      zoneToolbar={<ZoneToolbar />}
+      zoneToolbar={icViewModeEnabled ? undefined : <ZoneToolbar />}
 
       commandDock={
         <CommandDock
+          mode={icViewModeEnabled ? 'ic' : 'operator'}
           fleetCard={
             <FleetSheet
               vehicles={fleetVehicles}
               selectedVehicleId={selectedDroneId}
               onLocate={handleLocateVehicle}
               onViewFeed={handleViewFeed}
-              onRTH={handleRTH}
+              onRTH={icViewModeEnabled ? undefined : handleRTH}
               trigger={
                 <FleetCard
                   vehicles={fleetVehicles}
@@ -514,6 +615,7 @@ function V2PageContent() {
                   avgBattery={avgBattery}
                   avgAltitude={avgAltitude}
                   warnings={fleetWarnings}
+                  viewMode={icViewModeEnabled ? 'ic' : 'operator'}
                 />
               }
             />
@@ -524,6 +626,7 @@ function V2PageContent() {
               onConfirm={handleConfirmDetection}
               onDismiss={handleDismissDetection}
               onLocate={handleLocateDetection}
+              readOnly={icViewModeEnabled}
               trigger={
                 <DetectionsCard
                   thermalCount={detectionCounts.thermal}
@@ -531,11 +634,12 @@ function V2PageContent() {
                   gasCount={detectionCounts.gas}
                   pendingCount={detectionCounts.pending}
                   confirmedCount={detectionCounts.confirmed}
+                  viewMode={icViewModeEnabled ? 'ic' : 'operator'}
                 />
               }
             />
           }
-          controlsCard={
+          controlsCard={icViewModeEnabled ? undefined : (
             <ControlsCard
               missionPhase={missionPhase}
               isPaused={isPaused}
@@ -551,7 +655,7 @@ function V2PageContent() {
               onResume={resumeMission}
               onAbort={abortMission}
             />
-          }
+          )}
         />
       }
 
@@ -586,6 +690,16 @@ function V2PageContent() {
         })() : undefined
       }
       alerts={undefined}
+      statusToggle={
+        <label className="pointer-events-auto absolute right-4 top-4 flex h-12 items-center gap-3 rounded-full border border-white/20 bg-black/70 px-4 text-base font-semibold text-white shadow-[0_0_28px_rgba(0,0,0,0.35)]">
+          <span>IC VIEW</span>
+          <Switch
+            checked={icViewModeEnabled}
+            onCheckedChange={setIcModeFromUi}
+            aria-label="Toggle IC view"
+          />
+        </label>
+      }
     />
   );
 }

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -181,8 +181,6 @@ function V2PageContent() {
   }, [icViewModeEnabled, layerVisibility]);
 
   const setIcModeFromUi = useCallback((enabled: boolean) => {
-    setIcViewModeEnabled(enabled);
-
     const params = new URLSearchParams(searchParams.toString());
     if (enabled) {
       params.set('ic', '1');
@@ -303,8 +301,12 @@ function V2PageContent() {
   }, [vehiclePositionById]);
 
   const handleViewFeed = useCallback((id: string) => {
+    if (icViewModeEnabled) {
+      return;
+    }
+
     setPipVehicleId(id);
-  }, []);
+  }, [icViewModeEnabled]);
 
   /**
    * Static alerts for demonstration. In production, these are fed from
@@ -469,6 +471,9 @@ function V2PageContent() {
           break;
         case 'Escape': // Cancel current action
           e.preventDefault();
+          if (icViewModeEnabled) {
+            break;
+          }
           setSelectedDroneId(null);
           setSelectedDetectionId(null);
           break;
@@ -478,6 +483,9 @@ function V2PageContent() {
         case '4':
         case '5':
         case '6':
+          if (icViewModeEnabled) {
+            break;
+          }
           // Select drone 1-6
           const droneIndex = parseInt(e.key) - 1;
           if (droneIndex < fleetVehicles.length) {
@@ -486,6 +494,9 @@ function V2PageContent() {
           break;
         case 'r':
         case 'R':
+          if (icViewModeEnabled) {
+            break;
+          }
           // Reset camera to default view
           if (mapRef.current) {
             mapRef.current.teleportTo(0, 0);
@@ -515,25 +526,25 @@ function V2PageContent() {
   );
   const statusAlertCount = detectionCounts.pending;
   const icTacticalSummary = (
-    <div className="pointer-events-auto flex max-w-[360px] flex-col gap-3 text-base">
+    <div className="pointer-events-auto flex max-w-[360px] flex-col gap-3 text-lg">
       <div className="rounded-lg border border-white/25 bg-black/75 px-4 py-3 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
-        <div className="text-sm font-semibold uppercase tracking-wide text-white/65">IC VIEW</div>
+        <div className="text-base font-semibold uppercase tracking-wide text-white/75">IC VIEW</div>
         <div className="mt-2 grid grid-cols-2 gap-3 text-white">
           <div>
             <div className="font-mono text-2xl font-semibold">{activeVehicles.length}/{fleetVehicles.length}</div>
-            <div className="text-sm text-white/70">fleet active</div>
+            <div className="text-base text-white/75">fleet active</div>
           </div>
           <div>
             <div className="font-mono text-2xl font-semibold">{detectionCounts.pending}</div>
-            <div className="text-sm text-white/70">pending alerts</div>
+            <div className="text-base text-white/75">pending alerts</div>
           </div>
           <div>
             <div className="font-mono text-2xl font-semibold">{routeRecommendations.length}</div>
-            <div className="text-sm text-white/70">entry routes</div>
+            <div className="text-base text-white/75">entry routes</div>
           </div>
           <div>
             <div className="font-mono text-2xl font-semibold">{structuralHazardZones.length}</div>
-            <div className="text-sm text-white/70">hazard zones</div>
+            <div className="text-base text-white/75">hazard zones</div>
           </div>
         </div>
       </div>
@@ -586,7 +597,7 @@ function V2PageContent() {
         icViewModeEnabled ? (
           <div className="space-y-3">
             {icTacticalSummary}
-            <div className="rounded-lg border border-white/20 bg-black/70 px-4 py-3 text-base text-white/85">
+            <div className="rounded-lg border border-white/20 bg-black/70 px-4 py-3 text-lg text-white/90">
               Read-only shared tactical picture
             </div>
           </div>

--- a/software/viewer/src/components/cards/DetectionsCard.tsx
+++ b/software/viewer/src/components/cards/DetectionsCard.tsx
@@ -24,6 +24,7 @@ export interface DetectionsCardProps {
   pendingCount: number;
   confirmedCount: number;
   latestDetection?: Detection;
+  viewMode?: 'operator' | 'ic';
 }
 
 /**
@@ -75,9 +76,11 @@ export function DetectionsCard({
   gasCount,
   pendingCount,
   confirmedCount,
+  viewMode = 'operator',
 }: DetectionsCardProps) {
   const totalCount = thermalCount + acousticCount + gasCount;
   const hasPending = pendingCount > 0;
+  const isIcMode = viewMode === 'ic';
 
   return (
     <Card
@@ -85,11 +88,12 @@ export function DetectionsCard({
         'flex h-full cursor-pointer flex-col justify-between p-4 transition-all',
         'hover:bg-[var(--surface-3)]',
         'active:scale-[0.98]',
+        isIcMode && 'border-white/25 bg-black/75 p-5',
         hasPending && 'border-[var(--success)]/30'
       )}
     >
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-wider text-white/50">
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-base text-white/80' : 'text-xs text-white/50')}>
           Detections
         </span>
         {hasPending && (
@@ -102,21 +106,21 @@ export function DetectionsCard({
       <div className="flex items-center gap-2">
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.thermal.bg)}>
           <Flame className={cn('h-4 w-4', sensorConfig.thermal.color)} />
-          <span className={cn('font-mono text-sm font-bold', sensorConfig.thermal.color)}>
+          <span className={cn('font-mono font-bold', sensorConfig.thermal.color, isIcMode ? 'text-base' : 'text-sm')}>
             {thermalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.acoustic.bg)}>
           <AudioLines className={cn('h-4 w-4', sensorConfig.acoustic.color)} />
-          <span className={cn('font-mono text-sm font-bold', sensorConfig.acoustic.color)}>
+          <span className={cn('font-mono font-bold', sensorConfig.acoustic.color, isIcMode ? 'text-base' : 'text-sm')}>
             {acousticCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.gas.bg)}>
           <Wind className={cn('h-4 w-4', sensorConfig.gas.color)} />
-          <span className={cn('font-mono text-sm font-bold', sensorConfig.gas.color)}>
+          <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-base' : 'text-sm')}>
             {gasCount}
           </span>
         </div>
@@ -124,11 +128,11 @@ export function DetectionsCard({
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <span className="font-mono text-sm text-[var(--success)]">
+          <span className={cn('font-mono text-[var(--success)]', isIcMode ? 'text-base' : 'text-sm')}>
             {confirmedCount}
           </span>
           <span className="text-xs text-white/40">/</span>
-          <span className="font-mono text-sm text-white/60">{totalCount}</span>
+          <span className={cn('font-mono text-white/70', isIcMode ? 'text-base' : 'text-sm')}>{totalCount}</span>
         </div>
 
         <div className="flex items-center gap-1 text-white/40">

--- a/software/viewer/src/components/cards/DetectionsCard.tsx
+++ b/software/viewer/src/components/cards/DetectionsCard.tsx
@@ -93,12 +93,12 @@ export function DetectionsCard({
       )}
     >
       <div className="flex items-center justify-between">
-        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-base text-white/80' : 'text-xs text-white/50')}>
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-lg text-white/85' : 'text-xs text-white/50')}>
           Detections
         </span>
         {hasPending && (
           <Badge variant="success" className="px-2 py-0.5">
-            <span className="text-xs">{pendingCount} pending</span>
+            <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>{pendingCount} pending</span>
           </Badge>
         )}
       </div>
@@ -106,21 +106,21 @@ export function DetectionsCard({
       <div className="flex items-center gap-2">
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.thermal.bg)}>
           <Flame className={cn('h-4 w-4', sensorConfig.thermal.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.thermal.color, isIcMode ? 'text-base' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.thermal.color, isIcMode ? 'text-lg' : 'text-sm')}>
             {thermalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.acoustic.bg)}>
           <AudioLines className={cn('h-4 w-4', sensorConfig.acoustic.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.acoustic.color, isIcMode ? 'text-base' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.acoustic.color, isIcMode ? 'text-lg' : 'text-sm')}>
             {acousticCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.gas.bg)}>
           <Wind className={cn('h-4 w-4', sensorConfig.gas.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-base' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-lg' : 'text-sm')}>
             {gasCount}
           </span>
         </div>
@@ -128,15 +128,15 @@ export function DetectionsCard({
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <span className={cn('font-mono text-[var(--success)]', isIcMode ? 'text-base' : 'text-sm')}>
+          <span className={cn('font-mono text-[var(--success)]', isIcMode ? 'text-lg' : 'text-sm')}>
             {confirmedCount}
           </span>
-          <span className="text-xs text-white/40">/</span>
-          <span className={cn('font-mono text-white/70', isIcMode ? 'text-base' : 'text-sm')}>{totalCount}</span>
+          <span className={cn(isIcMode ? 'text-base text-white/55' : 'text-xs text-white/40')}>/</span>
+          <span className={cn('font-mono text-white/70', isIcMode ? 'text-lg' : 'text-sm')}>{totalCount}</span>
         </div>
 
         <div className="flex items-center gap-1 text-white/40">
-          <span className="text-xs">Review</span>
+          <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>Review</span>
           <ChevronRight className="h-4 w-4" />
         </div>
       </div>

--- a/software/viewer/src/components/cards/FleetCard.tsx
+++ b/software/viewer/src/components/cards/FleetCard.tsx
@@ -117,7 +117,7 @@ export function FleetCard({
       )}
     >
       <div className="flex items-center justify-between">
-        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-base text-white/80' : 'text-xs text-white/50')}>
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-lg text-white/85' : 'text-xs text-white/50')}>
           Fleet
         </span>
         {hasWarnings && (
@@ -126,7 +126,7 @@ export function FleetCard({
             className="flex items-center gap-1 px-2 py-0.5"
           >
             <AlertTriangle className="h-3.5 w-3.5" />
-            <span className="text-xs">{warnings.length}</span>
+            <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>{warnings.length}</span>
           </Badge>
         )}
       </div>
@@ -155,14 +155,14 @@ export function FleetCard({
           <span className={cn('font-mono font-bold text-white', isIcMode ? 'text-3xl' : 'text-xl')}>
             {activeCount}
           </span>
-          <span className={cn(isIcMode ? 'text-base text-white/70' : 'text-sm text-white/50')}>
+          <span className={cn(isIcMode ? 'text-lg text-white/75' : 'text-sm text-white/50')}>
             /{totalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5', getBatteryColor(avgBattery))}>
           {getBatteryIcon(avgBattery)}
-          <span className={cn('font-mono', isIcMode ? 'text-base' : 'text-sm')}>
+          <span className={cn('font-mono', isIcMode ? 'text-lg' : 'text-sm')}>
             {avgBattery === null ? '--' : `${avgBattery}%`}
           </span>
         </div>

--- a/software/viewer/src/components/cards/FleetCard.tsx
+++ b/software/viewer/src/components/cards/FleetCard.tsx
@@ -37,6 +37,7 @@ export interface FleetCardProps {
   avgBattery: number | null;
   avgAltitude: number;
   warnings: VehicleWarning[];
+  viewMode?: 'operator' | 'ic';
 }
 
 /**
@@ -99,9 +100,11 @@ export function FleetCard({
   totalCount,
   avgBattery,
   warnings,
+  viewMode = 'operator',
 }: FleetCardProps) {
   const hasWarnings = warnings.length > 0;
   const criticalWarnings = warnings.filter(w => w.severity === 'critical').length;
+  const isIcMode = viewMode === 'ic';
 
   return (
     <Card
@@ -109,11 +112,12 @@ export function FleetCard({
         'flex h-full cursor-pointer flex-col justify-between p-4 transition-all',
         'hover:bg-[var(--surface-3)]',
         'active:scale-[0.98]',
+        isIcMode && 'border-white/25 bg-black/75 p-5',
         hasWarnings && 'border-[var(--warning)]/30'
       )}
     >
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-wider text-white/50">
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-base text-white/80' : 'text-xs text-white/50')}>
           Fleet
         </span>
         {hasWarnings && (
@@ -148,17 +152,17 @@ export function FleetCard({
 
       <div className="flex items-center justify-between">
         <div className="flex items-baseline gap-1.5">
-          <span className="font-mono text-xl font-bold text-white">
+          <span className={cn('font-mono font-bold text-white', isIcMode ? 'text-3xl' : 'text-xl')}>
             {activeCount}
           </span>
-          <span className="text-sm text-white/50">
+          <span className={cn(isIcMode ? 'text-base text-white/70' : 'text-sm text-white/50')}>
             /{totalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5', getBatteryColor(avgBattery))}>
           {getBatteryIcon(avgBattery)}
-          <span className="font-mono text-sm">
+          <span className={cn('font-mono', isIcMode ? 'text-base' : 'text-sm')}>
             {avgBattery === null ? '--' : `${avgBattery}%`}
           </span>
         </div>

--- a/software/viewer/src/components/layout/CommandDock.tsx
+++ b/software/viewer/src/components/layout/CommandDock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 /** Props for the CommandDock component using the slot pattern for composition */
 interface CommandDockProps {
@@ -9,7 +10,9 @@ interface CommandDockProps {
   /** Detections card - shows sensor detections and confidence scores */
   detectionsCard: ReactNode;
   /** Controls card - mission control buttons and actions */
-  controlsCard: ReactNode;
+  controlsCard?: ReactNode;
+  /** Mode-specific composition for operator controls vs IC read-only summaries */
+  mode?: 'operator' | 'ic';
 }
 
 /**
@@ -32,7 +35,20 @@ export function CommandDock({
   fleetCard,
   detectionsCard,
   controlsCard,
+  mode = 'operator',
 }: CommandDockProps) {
+  if (mode === 'ic') {
+    return (
+      <div
+        className="flex items-stretch justify-center gap-4 px-6 pb-6 pt-12"
+        style={{ minHeight: '132px' }}
+      >
+        <div className="w-[360px] min-h-[108px]">{fleetCard}</div>
+        <div className="w-[360px] min-h-[108px]">{detectionsCard}</div>
+      </div>
+    );
+  }
+
   return (
     <div
       className="flex items-stretch justify-center gap-4 p-4 pb-6"
@@ -40,7 +56,9 @@ export function CommandDock({
     >
       <div className="w-[280px] min-h-[140px]">{fleetCard}</div>
       <div className="w-[280px] min-h-[140px]">{detectionsCard}</div>
-      <div className="w-[280px] min-h-[140px]">{controlsCard}</div>
+      <div className={cn('w-[280px] min-h-[140px]', !controlsCard && 'hidden')}>
+        {controlsCard}
+      </div>
     </div>
   );
 }

--- a/software/viewer/src/components/layout/GCSLayout.tsx
+++ b/software/viewer/src/components/layout/GCSLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 /**
  * Props for the GCSLayout component using the slot pattern for flexible composition.
@@ -23,6 +24,10 @@ interface GCSLayoutProps {
   alerts?: ReactNode;
   /** Optional zone toolbar - top-center below status pill for zone drawing tools */
   zoneToolbar?: ReactNode;
+  /** Presentation mode controls overlay spacing and read-only shell treatment */
+  viewMode?: 'operator' | 'ic';
+  /** Optional top-right mode toggle */
+  statusToggle?: ReactNode;
 }
 
 /**
@@ -53,7 +58,11 @@ export function GCSLayout({
   pipFeed,
   alerts,
   zoneToolbar,
+  viewMode = 'operator',
+  statusToggle,
 }: GCSLayoutProps) {
+  const isIcMode = viewMode === 'ic';
+
   return (
     <div className="relative h-dvh w-full overflow-hidden bg-[var(--surface-0)]">
       <div className="absolute inset-0 z-0">
@@ -72,7 +81,10 @@ export function GCSLayout({
         )}
 
         {pipFeed && (
-          <div className="pointer-events-auto absolute bottom-[160px] right-4">
+          <div className={cn(
+            'pointer-events-auto absolute right-4',
+            isIcMode ? 'bottom-32' : 'bottom-[160px]'
+          )}>
             {pipFeed}
           </div>
         )}
@@ -88,9 +100,14 @@ export function GCSLayout({
             {alerts}
           </div>
         )}
+
+        {statusToggle}
       </div>
 
-      <div className="absolute inset-x-0 bottom-0 z-20">
+      <div className={cn(
+        'absolute inset-x-0 bottom-0 z-20',
+        isIcMode && 'bg-gradient-to-t from-black/70 via-black/25 to-transparent'
+      )}>
         {commandDock}
       </div>
     </div>

--- a/software/viewer/src/components/layout/StatusPill.tsx
+++ b/software/viewer/src/components/layout/StatusPill.tsx
@@ -45,6 +45,8 @@ export interface StatusPillProps {
   detectionCounts?: DetectionStatusCounts;
   /** Callback when alert bell is clicked */
   onAlertClick?: () => void;
+  /** Presentation mode adjusts typography and contrast for shared displays */
+  viewMode?: 'operator' | 'ic';
 }
 
 /** Mission phase UI configuration - drives badge color and pulse animation */
@@ -111,6 +113,7 @@ export function StatusPill({
   hasUnreadAlerts,
   detectionCounts,
   onAlertClick,
+  viewMode = 'operator',
 }: StatusPillProps) {
   const phase = phaseConfig[missionPhase];
   const connection = connectionConfig[connectionStatus];
@@ -122,15 +125,27 @@ export function StatusPill({
     pending: 0,
     confirmed: 0,
   };
+  const isIcMode = viewMode === 'ic';
 
   return (
     <div
-      className="flex items-center gap-1 rounded-full border border-[var(--glass-border)] bg-[var(--glass-bg)] px-1 py-1 backdrop-blur-xl"
+      className={cn(
+        'flex items-center gap-1 rounded-full border px-1 py-1 backdrop-blur-xl',
+        isIcMode
+          ? 'border-white/30 bg-black/80 shadow-[0_0_32px_rgba(0,0,0,0.45)]'
+          : 'border-[var(--glass-border)] bg-[var(--glass-bg)]'
+      )}
       style={{ boxShadow: 'var(--glass-shadow)' }}
     >
-      <div className="flex h-8 items-center justify-center rounded-full bg-[var(--surface-2)] px-3">
+      <div className={cn(
+        'flex items-center justify-center rounded-full bg-[var(--surface-2)] px-3',
+        isIcMode ? 'h-11' : 'h-8'
+      )}>
         {logo || (
-          <span className="font-mono text-xs font-bold tracking-wider text-[var(--foreground)]">
+          <span className={cn(
+            'font-mono font-bold tracking-wider text-[var(--foreground)]',
+            isIcMode ? 'text-base' : 'text-xs'
+          )}>
             AERIS
           </span>
         )}
@@ -138,7 +153,10 @@ export function StatusPill({
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
-      <Badge variant={phase.variant} className="flex items-center gap-2 rounded-full px-3 py-1.5">
+      <Badge
+        variant={phase.variant}
+        className={cn('flex items-center gap-2 rounded-full px-3 py-1.5', isIcMode && 'text-base')}
+      >
         {phase.pulse ? (
           <span className="relative flex h-2 w-2">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-current opacity-75" />
@@ -149,13 +167,18 @@ export function StatusPill({
         ) : (
           <span className="h-2 w-2 rounded-full bg-current opacity-50" />
         )}
-        <span className="text-xs font-semibold tracking-wide">{phase.label}</span>
+        <span className={cn('font-semibold tracking-wide', isIcMode ? 'text-base' : 'text-xs')}>
+          {phase.label}
+        </span>
       </Badge>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center px-3">
-        <span className="font-mono text-sm font-medium tabular-nums text-[var(--foreground)]">
+        <span className={cn(
+          'font-mono font-medium tabular-nums text-[var(--foreground)]',
+          isIcMode ? 'text-base' : 'text-sm'
+        )}>
           {formatElapsedTime(elapsedTime)}
         </span>
       </div>
@@ -163,14 +186,16 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-2 px-3">
-        <span className="text-[10px] uppercase tracking-wide text-white/50">Progress</span>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-sm text-white/80' : 'text-[10px] text-white/50')}>
+          Progress
+        </span>
         <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
           <div
             className="absolute inset-y-0 left-0 rounded-full bg-[var(--success)] transition-all duration-300"
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <span className="font-mono text-xs tabular-nums text-white/70">
+        <span className={cn('font-mono tabular-nums', isIcMode ? 'text-base text-white' : 'text-xs text-white/70')}>
           {progressPercent}%
         </span>
       </div>
@@ -178,20 +203,22 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-1.5 px-3">
-        <span className="text-[10px] uppercase tracking-wide text-white/50">Det</span>
-        <span className="font-mono text-xs text-orange-400">T{liveDetections.thermal}</span>
-        <span className="font-mono text-xs text-sky-400">A{liveDetections.acoustic}</span>
-        <span className="font-mono text-xs text-amber-400">G{liveDetections.gas}</span>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-sm text-white/80' : 'text-[10px] text-white/50')}>
+          Det
+        </span>
+        <span className={cn('font-mono text-orange-400', isIcMode ? 'text-base' : 'text-xs')}>T{liveDetections.thermal}</span>
+        <span className={cn('font-mono text-sky-400', isIcMode ? 'text-base' : 'text-xs')}>A{liveDetections.acoustic}</span>
+        <span className={cn('font-mono text-amber-400', isIcMode ? 'text-base' : 'text-xs')}>G{liveDetections.gas}</span>
         <span className="text-white/25">|</span>
-        <span className="font-mono text-xs text-emerald-400">P{liveDetections.pending}</span>
-        <span className="font-mono text-xs text-white/70">C{liveDetections.confirmed}</span>
+        <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-base' : 'text-xs')}>P{liveDetections.pending}</span>
+        <span className={cn('font-mono', isIcMode ? 'text-base text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className={cn('flex items-center gap-1.5 px-3', connection.colorClass)}>
         <ConnectionIcon className="h-3.5 w-3.5" />
-        <span className="text-xs font-medium">{connection.label}</span>
+        <span className={cn('font-medium', isIcMode ? 'text-base' : 'text-xs')}>{connection.label}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />

--- a/software/viewer/src/components/layout/StatusPill.tsx
+++ b/software/viewer/src/components/layout/StatusPill.tsx
@@ -135,7 +135,7 @@ export function StatusPill({
           ? 'border-white/30 bg-black/80 shadow-[0_0_32px_rgba(0,0,0,0.45)]'
           : 'border-[var(--glass-border)] bg-[var(--glass-bg)]'
       )}
-      style={{ boxShadow: 'var(--glass-shadow)' }}
+      style={isIcMode ? undefined : { boxShadow: 'var(--glass-shadow)' }}
     >
       <div className={cn(
         'flex items-center justify-center rounded-full bg-[var(--surface-2)] px-3',
@@ -144,7 +144,7 @@ export function StatusPill({
         {logo || (
           <span className={cn(
             'font-mono font-bold tracking-wider text-[var(--foreground)]',
-            isIcMode ? 'text-base' : 'text-xs'
+            isIcMode ? 'text-lg' : 'text-xs'
           )}>
             AERIS
           </span>
@@ -155,7 +155,7 @@ export function StatusPill({
 
       <Badge
         variant={phase.variant}
-        className={cn('flex items-center gap-2 rounded-full px-3 py-1.5', isIcMode && 'text-base')}
+        className={cn('flex items-center gap-2 rounded-full px-3 py-1.5', isIcMode && 'text-lg')}
       >
         {phase.pulse ? (
           <span className="relative flex h-2 w-2">
@@ -167,7 +167,7 @@ export function StatusPill({
         ) : (
           <span className="h-2 w-2 rounded-full bg-current opacity-50" />
         )}
-        <span className={cn('font-semibold tracking-wide', isIcMode ? 'text-base' : 'text-xs')}>
+        <span className={cn('font-semibold tracking-wide', isIcMode ? 'text-lg' : 'text-xs')}>
           {phase.label}
         </span>
       </Badge>
@@ -177,7 +177,7 @@ export function StatusPill({
       <div className="flex items-center px-3">
         <span className={cn(
           'font-mono font-medium tabular-nums text-[var(--foreground)]',
-          isIcMode ? 'text-base' : 'text-sm'
+          isIcMode ? 'text-lg' : 'text-sm'
         )}>
           {formatElapsedTime(elapsedTime)}
         </span>
@@ -186,7 +186,7 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-2 px-3">
-        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-sm text-white/80' : 'text-[10px] text-white/50')}>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-base text-white/85' : 'text-[10px] text-white/50')}>
           Progress
         </span>
         <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
@@ -195,7 +195,7 @@ export function StatusPill({
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <span className={cn('font-mono tabular-nums', isIcMode ? 'text-base text-white' : 'text-xs text-white/70')}>
+        <span className={cn('font-mono tabular-nums', isIcMode ? 'text-lg text-white' : 'text-xs text-white/70')}>
           {progressPercent}%
         </span>
       </div>
@@ -203,22 +203,22 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-1.5 px-3">
-        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-sm text-white/80' : 'text-[10px] text-white/50')}>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-base text-white/85' : 'text-[10px] text-white/50')}>
           Det
         </span>
-        <span className={cn('font-mono text-orange-400', isIcMode ? 'text-base' : 'text-xs')}>T{liveDetections.thermal}</span>
-        <span className={cn('font-mono text-sky-400', isIcMode ? 'text-base' : 'text-xs')}>A{liveDetections.acoustic}</span>
-        <span className={cn('font-mono text-amber-400', isIcMode ? 'text-base' : 'text-xs')}>G{liveDetections.gas}</span>
+        <span className={cn('font-mono text-orange-400', isIcMode ? 'text-lg' : 'text-xs')}>T{liveDetections.thermal}</span>
+        <span className={cn('font-mono text-sky-400', isIcMode ? 'text-lg' : 'text-xs')}>A{liveDetections.acoustic}</span>
+        <span className={cn('font-mono text-amber-400', isIcMode ? 'text-lg' : 'text-xs')}>G{liveDetections.gas}</span>
         <span className="text-white/25">|</span>
-        <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-base' : 'text-xs')}>P{liveDetections.pending}</span>
-        <span className={cn('font-mono', isIcMode ? 'text-base text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>
+        <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-lg' : 'text-xs')}>P{liveDetections.pending}</span>
+        <span className={cn('font-mono', isIcMode ? 'text-lg text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className={cn('flex items-center gap-1.5 px-3', connection.colorClass)}>
-        <ConnectionIcon className="h-3.5 w-3.5" />
-        <span className={cn('font-medium', isIcMode ? 'text-base' : 'text-xs')}>{connection.label}</span>
+        <ConnectionIcon className={cn(isIcMode ? 'h-4.5 w-4.5' : 'h-3.5 w-3.5')} />
+        <span className={cn('font-medium', isIcMode ? 'text-lg' : 'text-xs')}>{connection.label}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
@@ -226,13 +226,13 @@ export function StatusPill({
       <button
         onClick={onAlertClick}
         className={cn(
-          'relative flex h-8 items-center gap-1.5 rounded-full px-3 transition-colors',
+          'relative flex items-center gap-1.5 rounded-full px-3 transition-colors', isIcMode ? 'h-11' : 'h-8',
           alertCount > 0 ? 'hover:bg-[var(--surface-3)]' : 'opacity-50'
         )}
       >
-        <Bell className="h-4 w-4" />
+        <Bell className={cn(isIcMode ? 'h-5 w-5' : 'h-4 w-4')} />
         {alertCount > 0 && (
-          <span className="text-xs font-medium text-[var(--foreground)]">
+          <span className={cn('font-medium text-[var(--foreground)]', isIcMode ? 'text-base' : 'text-xs')}>
             {alertCount}
           </span>
         )}

--- a/software/viewer/src/components/sheets/DetectionCard.tsx
+++ b/software/viewer/src/components/sheets/DetectionCard.tsx
@@ -155,21 +155,21 @@ export function DetectionCard({
       <div className="flex items-center gap-3 px-4 py-3">
         <div className={cn('flex items-center gap-2 px-2.5 py-1 rounded-md', sensor.bg)}>
           <SensorIcon className={cn('h-4 w-4', sensor.color)} />
-          <span className={cn('text-xs font-medium', sensor.color)}>{sensor.label}</span>
+          <span className={cn('text-base font-medium', sensor.color)}>{sensor.label}</span>
         </div>
 
         {isNew && (
-          <span className="px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-400 text-[10px] font-medium uppercase">
+          <span className="px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-400 text-base font-medium uppercase">
             New
           </span>
         )}
         {detection.status === 'confirmed' && (
-          <span className="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400/70 text-[10px] font-medium uppercase flex items-center gap-1">
+          <span className="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400/70 text-base font-medium uppercase flex items-center gap-1">
             <Check className="h-3 w-3" /> Confirmed
           </span>
         )}
         {isRetroactive && (
-          <span className="px-2 py-0.5 rounded bg-cyan-500/15 text-cyan-300 text-[10px] font-medium uppercase flex items-center gap-1">
+          <span className="px-2 py-0.5 rounded bg-cyan-500/15 text-cyan-300 text-base font-medium uppercase flex items-center gap-1">
             <History className="h-3 w-3" /> Retroactive
           </span>
         )}
@@ -177,13 +177,13 @@ export function DetectionCard({
         <div className="flex-1" />
 
         {/* Confidence percentage with color coding */}
-        <span className={cn('font-mono text-xl font-medium', getConfidenceTextClass(detection))}>
+        <span className={cn('font-mono text-2xl font-medium', getConfidenceTextClass(detection))}>
           {conf}%
         </span>
       </div>
 
       <div className="px-4 pb-3 space-y-2">
-        <div className="flex items-center gap-3 text-xs text-white/50">
+        <div className="flex items-center gap-3 text-base text-white/60">
           <span>{formatTime(detection.timestamp)}</span>
           <span>·</span>
           <span>{detection.vehicleName}</span>
@@ -195,7 +195,7 @@ export function DetectionCard({
           <span className="font-mono">{reading}</span>
         </div>
 
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex items-center gap-2 text-base">
           <MapPin className="h-3.5 w-3.5 text-white/30" />
           <span className="text-white/60">{sector}</span>
           <span className="text-white/20">|</span>
@@ -208,7 +208,7 @@ export function DetectionCard({
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 px-3 text-xs text-white/50 hover:text-white"
+            className="h-10 px-4 text-base text-white/60 hover:text-white"
             onClick={(e) => { e.stopPropagation(); onLocate(); }}
           >
             <Crosshair className="mr-1.5 h-3.5 w-3.5" />
@@ -220,7 +220,7 @@ export function DetectionCard({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 px-3 text-xs text-white/50 hover:text-red-400"
+                className="h-10 px-4 text-base text-white/60 hover:text-red-400"
                 onClick={(e) => { e.stopPropagation(); onDismiss(); }}
               >
                 <X className="mr-1.5 h-3.5 w-3.5" />
@@ -229,7 +229,7 @@ export function DetectionCard({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 px-3 text-xs bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20"
+                className="h-10 px-4 text-base bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20"
                 onClick={(e) => { e.stopPropagation(); onConfirm(); }}
               >
                 <Check className="mr-1.5 h-3.5 w-3.5" />
@@ -245,7 +245,7 @@ export function DetectionCard({
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 px-3 text-xs text-white/50 hover:text-white"
+            className="h-10 px-4 text-base text-white/60 hover:text-white"
             onClick={(e) => { e.stopPropagation(); onLocate(); }}
           >
             <Crosshair className="mr-1.5 h-3.5 w-3.5" />

--- a/software/viewer/src/components/sheets/DetectionCard.tsx
+++ b/software/viewer/src/components/sheets/DetectionCard.tsx
@@ -53,6 +53,8 @@ export interface DetectionCardProps {
   onDismiss: () => void;
   /** Callback to center map on detection location */
   onLocate: () => void;
+  /** Hides triage actions for read-only presentation modes */
+  readOnly?: boolean;
 }
 
 const sensorConfig = {
@@ -122,6 +124,7 @@ export function DetectionCard({
   onConfirm,
   onDismiss,
   onLocate,
+  readOnly = false,
 }: DetectionCardProps) {
   const sensor = sensorConfig[detection.sensorType];
   const SensorIcon = sensor.Icon;
@@ -212,24 +215,28 @@ export function DetectionCard({
             Locate
           </Button>
           <div className="flex-1" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 px-3 text-xs text-white/50 hover:text-red-400"
-            onClick={(e) => { e.stopPropagation(); onDismiss(); }}
-          >
-            <X className="mr-1.5 h-3.5 w-3.5" />
-            Dismiss
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 px-3 text-xs bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20"
-            onClick={(e) => { e.stopPropagation(); onConfirm(); }}
-          >
-            <Check className="mr-1.5 h-3.5 w-3.5" />
-            Confirm
-          </Button>
+          {!readOnly && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-3 text-xs text-white/50 hover:text-red-400"
+                onClick={(e) => { e.stopPropagation(); onDismiss(); }}
+              >
+                <X className="mr-1.5 h-3.5 w-3.5" />
+                Dismiss
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-3 text-xs bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20"
+                onClick={(e) => { e.stopPropagation(); onConfirm(); }}
+              >
+                <Check className="mr-1.5 h-3.5 w-3.5" />
+                Confirm
+              </Button>
+            </>
+          )}
         </div>
       )}
 

--- a/software/viewer/src/components/sheets/DetectionSheet.tsx
+++ b/software/viewer/src/components/sheets/DetectionSheet.tsx
@@ -79,8 +79,8 @@ export function DetectionSheet({
       <DrawerContent className="max-h-[80vh] bg-[#0c0c0e] border-white/5">
         <div className="mx-auto w-full max-w-xl">
           <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
-            <h2 className="text-sm font-medium text-white">Detections</h2>
-            <span className="text-xs text-white/40">
+            <h2 className="text-lg font-medium text-white">Detections</h2>
+            <span className="text-base text-white/55">
               {counts.pending} pending
             </span>
           </div>
@@ -91,7 +91,7 @@ export function DetectionSheet({
                 key={tab}
                 onClick={() => setActiveFilter(tab)}
                 className={cn(
-                  'flex-1 py-2.5 text-xs font-medium transition-colors',
+                  'flex-1 py-3 text-base font-medium transition-colors',
                   activeFilter === tab
                     ? 'text-white border-b-2 border-white'
                     : 'text-white/40 hover:text-white/60'

--- a/software/viewer/src/components/sheets/DetectionSheet.tsx
+++ b/software/viewer/src/components/sheets/DetectionSheet.tsx
@@ -22,6 +22,8 @@ interface DetectionSheetProps {
   onLocate: (id: string) => void;
   /** Trigger element that opens the drawer */
   trigger: React.ReactNode;
+  /** Hides detection triage controls for read-only presentation modes */
+  readOnly?: boolean;
 }
 
 /**
@@ -48,6 +50,7 @@ export function DetectionSheet({
   onDismiss,
   onLocate,
   trigger,
+  readOnly = false,
 }: DetectionSheetProps) {
   const [activeFilter, setActiveFilter] = useState<FilterTab>('all');
 
@@ -115,6 +118,7 @@ export function DetectionSheet({
                     onConfirm={() => onConfirm(detection.id)}
                     onDismiss={() => onDismiss(detection.id)}
                     onLocate={() => onLocate(detection.id)}
+                    readOnly={readOnly}
                   />
                 ))}
               </div>

--- a/software/viewer/src/components/sheets/FleetSheet.tsx
+++ b/software/viewer/src/components/sheets/FleetSheet.tsx
@@ -101,24 +101,24 @@ export function FleetSheet({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <Plane className="h-5 w-5 text-white/40" />
-                <DrawerTitle className="text-lg font-light text-white tracking-wide">
+                <DrawerTitle className="text-xl font-medium text-white tracking-wide">
                   Fleet
                 </DrawerTitle>
               </div>
-              <div className="flex items-center gap-5 text-xs">
+              <div className="flex items-center gap-5 text-base">
                 <span className="text-emerald-400">
-                  <span className="font-mono text-sm">{activeCount}</span>
+                  <span className="font-mono text-lg">{activeCount}</span>
                   <span className="ml-1 text-white/40">active</span>
                 </span>
                 {warningCount > 0 && (
                   <span className="flex items-center gap-1 text-amber-400">
                     <AlertTriangle className="h-3 w-3" />
-                    <span className="font-mono text-sm">{warningCount}</span>
+                    <span className="font-mono text-lg">{warningCount}</span>
                   </span>
                 )}
                 <span className="flex items-center gap-1.5 text-white/50">
                   <Battery className="h-3.5 w-3.5" />
-                  <span className="font-mono text-sm">
+                  <span className="font-mono text-lg">
                     {avgBattery === null ? '--' : `${avgBattery}%`}
                   </span>
                   <span className="text-white/30">avg</span>

--- a/software/viewer/src/components/sheets/FleetSheet.tsx
+++ b/software/viewer/src/components/sheets/FleetSheet.tsx
@@ -23,7 +23,7 @@ interface FleetSheetProps {
   /** Callback to open video feed for vehicle */
   onViewFeed: (id: string) => void;
   /** Callback to initiate return-to-home for vehicle */
-  onRTH: (id: string) => void;
+  onRTH?: (id: string) => void;
   /** Callback for emergency recall of all vehicles */
   onRecallAll?: () => void;
   /** Callback to pause all vehicles at current positions */
@@ -84,6 +84,7 @@ export function FleetSheet({
         batteryReadings.reduce((sum, battery) => sum + battery, 0) / batteryReadings.length
       )
     : null;
+  const hasFleetCommandActions = Boolean(onRecallAll || onHoldPositions);
 
   // Fleet status bar provides immediate visual health assessment
 
@@ -153,7 +154,7 @@ export function FleetSheet({
                   isSelected={selectedVehicleId === vehicle.id}
                   onLocate={() => handleLocate(vehicle.id)}
                   onViewFeed={() => handleViewFeed(vehicle.id)}
-                  onRTH={() => onRTH(vehicle.id)}
+                  onRTH={onRTH ? () => onRTH(vehicle.id) : undefined}
                 />
               ))}
             </div>
@@ -166,33 +167,38 @@ export function FleetSheet({
             )}
           </div>
 
-          {/* Emergency controls positioned for thumb accessibility on tablets */}
-          <div className="flex items-center justify-center gap-3 px-4 py-4 border-t border-white/[0.04]">
-            <Button
-              variant="outline"
-              className={cn(
-                'flex-1 h-10 max-w-[200px]',
-                'border-red-500/30 text-red-400',
-                'hover:bg-red-500/10 hover:border-red-500/50'
+          {hasFleetCommandActions && (
+            <div className="flex items-center justify-center gap-3 px-4 py-4 border-t border-white/[0.04]">
+              {onRecallAll && (
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'flex-1 h-10 max-w-[200px]',
+                    'border-red-500/30 text-red-400',
+                    'hover:bg-red-500/10 hover:border-red-500/50'
+                  )}
+                  onClick={onRecallAll}
+                >
+                  <OctagonX className="mr-2 h-4 w-4" />
+                  Recall All
+                </Button>
               )}
-              onClick={onRecallAll}
-            >
-              <OctagonX className="mr-2 h-4 w-4" />
-              Recall All
-            </Button>
-            <Button
-              variant="outline"
-              className={cn(
-                'flex-1 h-10 max-w-[200px]',
-                'border-amber-500/30 text-amber-400',
-                'hover:bg-amber-500/10 hover:border-amber-500/50'
+              {onHoldPositions && (
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'flex-1 h-10 max-w-[200px]',
+                    'border-amber-500/30 text-amber-400',
+                    'hover:bg-amber-500/10 hover:border-amber-500/50'
+                  )}
+                  onClick={onHoldPositions}
+                >
+                  <Pause className="mr-2 h-4 w-4" />
+                  Hold Positions
+                </Button>
               )}
-              onClick={onHoldPositions}
-            >
-              <Pause className="mr-2 h-4 w-4" />
-              Hold Positions
-            </Button>
-          </div>
+            </div>
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/software/viewer/src/components/sheets/VehicleCard.tsx
+++ b/software/viewer/src/components/sheets/VehicleCard.tsx
@@ -220,19 +220,19 @@ export function VehicleCard({
           <span className="text-lg font-light text-white">{vehicle.name}</span>
           <div className="flex items-center gap-2">
             <span className={cn('h-1.5 w-1.5 rounded-full animate-pulse', status.dot)} />
-            <span className={cn('text-[10px] font-semibold tracking-wider', status.color)}>
+            <span className={cn('text-base font-semibold tracking-wider', status.color)}>
               {status.label}
             </span>
           </div>
           <span
-            className="text-[10px] font-medium tracking-[0.18em] text-white/35"
+            className="text-base font-medium tracking-[0.12em] text-white/55"
             data-testid="vehicle-slam-mode"
           >
             SLAM: {formatSlamModeLabel(vehicle.slamMode)}
           </span>
           {isOffline && (
             <span
-              className="text-[10px] font-semibold tracking-[0.16em] text-zinc-300"
+              className="text-base font-semibold tracking-[0.12em] text-zinc-200"
               data-testid="vehicle-last-known-age"
             >
               LAST CONTACT {formatLastContactAge(vehicle.lastContactAgeMs)}
@@ -246,7 +246,7 @@ export function VehicleCard({
             <span className={cn('font-mono text-base font-light tabular-nums', getBatteryColor(vehicle.battery))}>
               {vehicle.battery ?? '--'}
             </span>
-            <span className="text-[8px] text-white/30">{vehicle.battery === null ? '' : '%'}</span>
+            <span className="text-base text-white/45">{vehicle.battery === null ? '' : '%'}</span>
           </div>
         </div>
       </div>
@@ -255,18 +255,18 @@ export function VehicleCard({
       <div className="grid grid-cols-3 gap-px bg-white/[0.02] mx-3 my-2 rounded-lg overflow-hidden">
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Gauge className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-xs text-white/70">{vehicle.altitude}</span>
-          <span className="text-[8px] text-white/30 uppercase tracking-wider">Alt (m)</span>
+          <span className="font-mono text-base text-white/80">{vehicle.altitude}</span>
+          <span className="text-base text-white/45 uppercase tracking-wide">Alt (m)</span>
         </div>
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Radio className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-xs text-white/70">{vehicle.linkQuality ?? '--'}</span>
-          <span className="text-[8px] text-white/30 uppercase tracking-wider">Link %</span>
+          <span className="font-mono text-base text-white/80">{vehicle.linkQuality ?? '--'}</span>
+          <span className="text-base text-white/45 uppercase tracking-wide">Link %</span>
         </div>
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Signal className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-xs text-white/70">{vehicle.coverage ?? '--'}</span>
-          <span className="text-[8px] text-white/30 uppercase tracking-wider">Cover %</span>
+          <span className="font-mono text-base text-white/80">{vehicle.coverage ?? '--'}</span>
+          <span className="text-base text-white/45 uppercase tracking-wide">Cover %</span>
         </div>
       </div>
 
@@ -276,7 +276,7 @@ export function VehicleCard({
           variant="ghost"
           size="sm"
           className={cn(
-            'flex-1 h-8 rounded-lg text-xs',
+            'flex-1 h-10 rounded-lg text-base',
             'text-white/50 hover:text-white hover:bg-white/10'
           )}
           onClick={onLocate}
@@ -288,7 +288,7 @@ export function VehicleCard({
           variant="ghost"
           size="sm"
           className={cn(
-            'flex-1 h-8 rounded-lg text-xs',
+            'flex-1 h-10 rounded-lg text-base',
             'text-white/50 hover:text-white hover:bg-white/10'
           )}
           onClick={onViewFeed}
@@ -301,7 +301,7 @@ export function VehicleCard({
             variant="ghost"
             size="sm"
             className={cn(
-              'h-8 px-2 rounded-lg text-xs',
+              'h-10 px-3 rounded-lg text-base',
               'text-amber-400/70 hover:text-amber-400 hover:bg-amber-500/10'
             )}
             onClick={onRTH}

--- a/software/viewer/src/context/LayerVisibilityContext.tsx
+++ b/software/viewer/src/context/LayerVisibilityContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState, ReactNode } from 'react';
 
 /**
  * Layer visibility state for the 3D map scene.
@@ -49,16 +49,21 @@ const LayerVisibilityContext = createContext<LayerVisibilityContextType | undefi
 export function LayerVisibilityProvider({ children }: { children: ReactNode }) {
   const [layers, setLayers] = useState<LayerState>(defaultState);
 
-  const toggleLayer = (layer: keyof LayerState) => {
+  const toggleLayer = useCallback((layer: keyof LayerState) => {
     setLayers((prev) => ({ ...prev, [layer]: !prev[layer] }));
-  };
+  }, []);
 
-  const setLayer = (layer: keyof LayerState, visible: boolean) => {
+  const setLayer = useCallback((layer: keyof LayerState, visible: boolean) => {
     setLayers((prev) => ({ ...prev, [layer]: visible }));
-  };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ ...layers, toggleLayer, setLayer }),
+    [layers, toggleLayer, setLayer]
+  );
 
   return (
-    <LayerVisibilityContext.Provider value={{ ...layers, toggleLayer, setLayer }}>
+    <LayerVisibilityContext.Provider value={contextValue}>
       {children}
     </LayerVisibilityContext.Provider>
   );

--- a/software/viewer/src/lib/icViewMode.d.ts
+++ b/software/viewer/src/lib/icViewMode.d.ts
@@ -1,0 +1,2 @@
+export function isIcViewModeQueryValue(value: string | null | undefined): boolean;
+

--- a/software/viewer/src/lib/icViewMode.js
+++ b/software/viewer/src/lib/icViewMode.js
@@ -1,0 +1,9 @@
+export function isIcViewModeQueryValue(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "ic";
+}
+

--- a/software/viewer/src/lib/icViewMode.test.mjs
+++ b/software/viewer/src/lib/icViewMode.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isIcViewModeQueryValue } from "./icViewMode.js";
+
+test("isIcViewModeQueryValue accepts the supported URL activation values", () => {
+  assert.equal(isIcViewModeQueryValue("1"), true);
+  assert.equal(isIcViewModeQueryValue("true"), true);
+  assert.equal(isIcViewModeQueryValue("IC"), true);
+});
+
+test("isIcViewModeQueryValue rejects operator-mode and missing values", () => {
+  assert.equal(isIcViewModeQueryValue(null), false);
+  assert.equal(isIcViewModeQueryValue("0"), false);
+  assert.equal(isIcViewModeQueryValue("operator"), false);
+});
+


### PR DESCRIPTION
## Summary
- Add a read-only incident commander mode for the live tactical display, activated by `?ic=1`, the IC View toggle, or the `I` keyboard shortcut.
- Recompose the viewer so the shared map, route overlays, detections, fleet status, gas overlays, and degraded-state cues remain visible while operator command surfaces are removed.
- Guard mission, zone editing, detection triage, and vehicle command actions in IC mode while retaining read-only map/navigation affordances.

## Validation
- `find src -name '*.test.mjs' -print0 | xargs -0 node --test`
- `npm run lint`
- `npm run build`
- Browser smoke: verified `http://localhost:60420/?ic=1` renders the map canvas, route overlays, IC summaries, and no mission/zone/triage controls. Local rosbridge was not running, so the viewer reported the expected disconnected ROS state.

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IC VIEW toggle (URL + I key + UI switch) that enables a read-only IC mode: operator controls disabled, map/zone edits blocked, layers forced for IC, and mode-specific layouts shown.
  * Fleet emergency controls are now conditional and only shown when actions exist.

* **UI Changes**
  * Cards, status pill, and sheets adopt larger IC typography/spacing; detection triage actions are hidden in IC mode while Locate remains available.

* **Tests**
  * Added tests for IC query parsing, keyboard toggle, and read-only UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only IC (Incident Commander) view mode to the live tactical display, accessible via `?ic=1`, an on-screen toggle, or the `I` keyboard shortcut. The implementation is thorough: write-capable callbacks are guarded at both the handler level and the UI layer, map interaction handlers are replaced with locate-only equivalents, and IC-specific typography scaling is applied consistently across `StatusPill`, `FleetCard`, and `DetectionsCard`.

- **IC mode activation** is URL-synced via `useSearchParams` + a `useEffect`, with state initialised from the URL on first render and kept in sync on navigation; a `<Suspense>` boundary is correctly added around the consuming component to satisfy Next.js App Router requirements.
- **Write guards** cover detection triage, drone RTH, zone drawing, mission pause/resume (Space bar), and fleet recall/hold — all confirmed by the accompanying AST-based surface tests.
- **`FleetSheet`** makes `onRTH`, `onRecallAll`, and `onHoldPositions` optional and gates their rendering on presence, which also fixes a pre-existing issue where those buttons rendered with `undefined` `onClick` handlers in operator mode.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all write-capable callbacks and mission-control actions are consistently guarded in IC mode at both the handler and UI layer.

The IC mode gate is applied uniformly: detection triage, vehicle RTH, zone drawing, fleet recall, and mission pause/resume are all blocked in handlers and/or removed from the UI. The URL-sync pattern is correct and tested. No regressions were found in operator mode — the changes are purely additive for existing users.

No files require special attention. The only omission is that the new `I` shortcut is not listed in the keyboard shortcuts help overlay, which does not affect runtime behaviour.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/viewer/src/lib/icViewMode.js | New utility that normalises IC mode URL query values ("1", "true", "ic"); logic is correct and well-tested. |
| software/viewer/src/app/page.tsx | Main page shell — adds URL-synced IC mode state, layer-forcing effect, keyboard shortcut, and conditionally passes undefined to all write-capable callbacks/props. Guards are comprehensive and applied at both the UI and handler level. |
| software/viewer/src/components/layout/CommandDock.tsx | IC mode renders a two-card layout without the controls card; the hidden-div fallback for a missing controlsCard in operator mode is safe (IC path returns early). |
| software/viewer/src/components/layout/GCSLayout.tsx | Adds viewMode and statusToggle slots; IC mode adjusts PiP positioning and command-dock backdrop gradient. Straightforward composition changes with no logic issues. |
| software/viewer/src/components/sheets/FleetSheet.tsx | Makes onRTH optional and guards recall/hold-position buttons behind hasFleetCommandActions; fixes a pre-existing issue where those buttons rendered but had undefined onClick handlers. |
| software/viewer/src/app/icViewModeSurface.test.mjs | AST-based surface tests verify IC mode prop threading and guard assertions against page.tsx; good coverage of the integration contract. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["URL / ?ic=1\nor Toggle / I key"] --> B["setIcModeFromUi(enabled)\n+ router.replace()"]
    B --> C["searchParams effect\n→ setIcViewModeEnabled"]
    C --> D{icViewModeEnabled?}

    D -- yes --> E["Layer-forcing effect\nensure all 6 layers visible"]
    D -- yes --> F["IC layout branch\nCommandDock: fleet + detections only\nLayersPanel → IC tactical summary\nZoneToolbar removed"]
    D -- yes --> G["Callback guards\nonRTH / onDroneSelect /\nonZoneSelect / Space bar\n→ undefined or early return"]

    D -- no --> H["Operator layout\nFull CommandDock incl. ControlsCard\nLayersPanel, ZoneToolbar, all callbacks"]

    F --> I["GCSLayout + StatusPill\nIC typography & contrast scaling"]
    G --> I
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/viewer/src/components/ui/KeyboardShortcuts.tsx:24-57
**`I` shortcut missing from in-app help registry**

The `SHORTCUTS` constant is the authoritative source for the keyboard shortcuts overlay (opened with `?`). The new `I` / IC VIEW mode toggle is handled in `page.tsx` but not added here, so any operator who presses `?` during a live mission will not discover the shortcut. In a field-deployed GCS, the help overlay is often the only reference available.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["viewer: stabilize layer visibility conte..."](https://github.com/aeris-drones/aeris/commit/736bead0367a39bb9871e02a8c557649bbb0e858) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32481744)</sub>

<!-- /greptile_comment -->