### PR TITLE
Finish incident commander tactical view hardening

### DIFF
--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -164,6 +164,16 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
     /onViewFeed=\{icViewModeEnabled \? undefined : handleViewFeed\}/,
     "page should hide the feed action entirely in IC mode instead of leaving a dead button behind"
   );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*if \(icViewModeEnabled\) \{\s*setPipVehicleId\(null\);\s*\}\s*\}, \[icViewModeEnabled\]\);/s,
+    "entering IC mode should clear any already-open PiP feed"
+  );
+  assert.match(
+    source,
+    /action:\s*icViewModeEnabled\s*\?\s*undefined\s*:\s*\{\s*label:\s*'VIEW',\s*onClick:\s*\(\) => handleViewFeed\('ranger_1'\)\s*\}/s,
+    "IC mode should remove feed-launch actions from mock alert surfaces as well"
+  );
 
   const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);
   assert.ok(keyboardEffect, "page should keep keyboard handling localized");

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -176,8 +176,23 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   );
   assert.match(
     source,
-    /action:\s*icViewModeEnabled\s*\?\s*undefined\s*:\s*\{\s*label:\s*'VIEW',\s*onClick:\s*\(\) => handleViewFeed\('ranger_1'\)\s*\}/s,
+    /const locateVehicleActionRef = useRef\(handleLocateVehicle\);/,
+    "mock alert actions should keep a stable reference to the latest locate handler"
+  );
+  assert.match(
+    source,
+    /const viewFeedActionRef = useRef\(handleViewFeed\);/,
+    "mock alert actions should keep a stable reference to the latest feed handler"
+  );
+  assert.match(
+    source,
+    /action:\s*icViewModeEnabled\s*\?\s*undefined\s*:\s*\{\s*label:\s*'VIEW',\s*onClick:\s*\(\) => viewFeedActionRef\.current\('ranger_1'\)\s*\}/s,
     "IC mode should remove feed-launch actions from mock alert surfaces as well"
+  );
+  assert.match(
+    source,
+    /\[allowMockFallback, icViewModeEnabled\]\s*\);/,
+    "mock alert definitions should not resubscribe on telemetry-driven handler churn"
   );
 
   const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -186,13 +186,38 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   );
   assert.match(
     source,
+    /const \[mockAlertTimestamps, setMockAlertTimestamps\] = useState<Record<\(typeof MOCK_ALERT_IDS\)\[number\], Date>>\(\(\) => \(\{/,
+    "mock alert timestamps should stay stable across resyncs and IC-mode toggles"
+  );
+  assert.match(
+    source,
+    /const dismissedMockAlertIdsRef = useRef<Set<string>>\(new Set\(\)\);/,
+    "mock alert dismissal state should be tracked separately from visibility state"
+  );
+  assert.match(
+    source,
+    /const shouldShowAlerts = areAlertsOpenRef\.current \|\| !hasSyncedMockAlerts\.current;/,
+    "mock alert resync should respect manual visibility state after the initial seed"
+  );
+  assert.match(
+    source,
+    /const getVisibleStoredAlerts = useCallback\(\s*\(\) => storedAlerts\.filter\(\(alert\) => !dismissedMockAlertIdsRef\.current\.has\(alert\.id\)\)/s,
+    "mock alert replay should exclude alerts the operator already dismissed"
+  );
+  assert.match(
+    source,
+    /if \(displayNonce !== mockAlertDisplayNonceRef\.current\) \{\s*return;\s*\}/s,
+    "programmatic alert resync dismissals should not be recorded as manual dismissals"
+  );
+  assert.match(
+    source,
     /action:\s*icViewModeEnabled\s*\?\s*undefined\s*:\s*\{\s*label:\s*'VIEW',\s*onClick:\s*\(\) => viewFeedActionRef\.current\('ranger_1'\)\s*\}/s,
     "IC mode should remove feed-launch actions from mock alert surfaces as well"
   );
   assert.match(
     source,
-    /\[allowMockFallback, icViewModeEnabled\]\s*\);/,
-    "mock alert definitions should not resubscribe on telemetry-driven handler churn"
+    /showVisibleStoredAlerts\(false\);/,
+    "manually reopening mock alerts should preserve the current dismissed-alert filter"
   );
 
   const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -1,8 +1,9 @@
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createElement } from "react";
 import ts from "typescript";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -10,6 +11,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const RENDER_TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-ic-view-render-"));
 const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "node_modules");
+
+after(() => {
+  fs.rmSync(RENDER_TEMP_ROOT, { recursive: true, force: true });
+});
 
 fs.symlinkSync(VIEWER_NODE_MODULES, path.join(RENDER_TEMP_ROOT, "node_modules"), "dir");
 
@@ -136,7 +141,7 @@ async function renderComponent(relativePath, exportName, props) {
   const loaded = await import(pathToFileURL(modulePath).href);
   const Component = loaded[exportName];
   assert.ok(Component, `${exportName} should be exported from ${relativePath}`);
-  return renderToStaticMarkup(Component(props));
+  return renderToStaticMarkup(createElement(Component, props));
 }
 
 test("IC mode keeps one canonical page-shell flag and propagates it", () => {

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -1,11 +1,87 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import ts from "typescript";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const RENDER_TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-ic-view-render-"));
+const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "node_modules");
+
+fs.symlinkSync(VIEWER_NODE_MODULES, path.join(RENDER_TEMP_ROOT, "node_modules"), "dir");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "button.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Button({ children, className = "", ...props }) {
+    return _jsx("button", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "card.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Card({ children, className = "", ...props }) {
+    return _jsx("div", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "badge.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Badge({ children, className = "", ...props }) {
+    return _jsx("span", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "utils.mjs"), `
+  export function cn(...values) {
+    return values.flatMap((value) => Array.isArray(value) ? value : [value]).filter(Boolean).join(" ");
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "degradedVehicleState.mjs"), `
+  export function formatLastContactAge(value) {
+    return value == null ? "--" : value + "ms";
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "detectionViewState.mjs"), `
+  export function getConfidenceTextClass() {
+    return "text-emerald-300";
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "lucide-react.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  function icon(name) {
+    return function Icon({ className = "", ...props }) {
+      return _jsx("svg", { "data-icon": name, className, ...props });
+    };
+  }
+  export const AlertTriangle = icon("AlertTriangle");
+  export const AudioLines = icon("AudioLines");
+  export const Battery = icon("Battery");
+  export const BatteryFull = icon("BatteryFull");
+  export const BatteryLow = icon("BatteryLow");
+  export const BatteryMedium = icon("BatteryMedium");
+  export const BatteryWarning = icon("BatteryWarning");
+  export const Bell = icon("Bell");
+  export const Check = icon("Check");
+  export const ChevronRight = icon("ChevronRight");
+  export const Crosshair = icon("Crosshair");
+  export const Flame = icon("Flame");
+  export const Gauge = icon("Gauge");
+  export const Home = icon("Home");
+  export const MapPin = icon("MapPin");
+  export const Radio = icon("Radio");
+  export const Signal = icon("Signal");
+  export const Video = icon("Video");
+  export const Wind = icon("Wind");
+  export const X = icon("X");
+  export const XCircle = icon("XCircle");
+  export const Zap = icon("Zap");
+`, "utf8");
 
 function parseTsx(filePath) {
   const source = fs.readFileSync(filePath, "utf8");
@@ -33,6 +109,36 @@ function findFunction(sourceFile, name) {
   return match;
 }
 
+async function renderComponent(relativePath, exportName, props) {
+  const sourcePath = path.join(ROOT, relativePath);
+  let source = fs.readFileSync(sourcePath, "utf8");
+  source = source
+    .replaceAll("@/components/ui/button", "./button.mjs")
+    .replaceAll("@/components/ui/card", "./card.mjs")
+    .replaceAll("@/components/ui/badge", "./badge.mjs")
+    .replaceAll("@/lib/utils", "./utils.mjs")
+    .replaceAll("@/lib/degradedVehicleState", "./degradedVehicleState.mjs")
+    .replaceAll("@/lib/detectionViewState", "./detectionViewState.mjs")
+    .replaceAll("lucide-react", "./lucide-react.mjs");
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  }).outputText;
+
+  const moduleName = `${path.basename(relativePath, ".tsx")}-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`;
+  const modulePath = path.join(RENDER_TEMP_ROOT, moduleName);
+  fs.writeFileSync(modulePath, compiled, "utf8");
+
+  const loaded = await import(pathToFileURL(modulePath).href);
+  const Component = loaded[exportName];
+  assert.ok(Component, `${exportName} should be exported from ${relativePath}`);
+  return renderToStaticMarkup(Component(props));
+}
+
 test("IC mode keeps one canonical page-shell flag and propagates it", () => {
   const pagePath = path.join(ROOT, "app", "page.tsx");
   const { source } = parseTsx(pagePath);
@@ -53,6 +159,11 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   const handleViewFeedText = handleViewFeed.getText(sourceFile);
   assert.match(handleViewFeedText, /if \(icViewModeEnabled\) \{\s*return;\s*\}/s);
   assert.match(handleViewFeedText, /setPipVehicleId\(id\)/);
+  assert.match(
+    source,
+    /onViewFeed=\{icViewModeEnabled \? undefined : handleViewFeed\}/,
+    "page should hide the feed action entirely in IC mode instead of leaving a dead button behind"
+  );
 
   const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);
   assert.ok(keyboardEffect, "page should keep keyboard handling localized");
@@ -62,30 +173,98 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   assert.match(keyboardText, /case 'r':[\s\S]*case 'R':[\s\S]*if \(icViewModeEnabled\) \{\s*break;\s*\}/);
 });
 
-test("FleetSheet only exposes feed action when the parent passes it", () => {
-  const fleetSheetPath = path.join(ROOT, "components", "sheets", "FleetSheet.tsx");
-  const { source } = parseTsx(fleetSheetPath);
+test("VehicleCard only renders the feed action when a feed callback is provided", async () => {
+  const vehicle = {
+    id: "scout-1",
+    name: "Scout 1",
+    status: "active",
+    battery: 82,
+    altitude: 46,
+    linkQuality: 77,
+    coverage: 64,
+    slamMode: "vio",
+  };
 
-  assert.match(source, /onViewFeed=\{\(\) => handleViewFeed\(vehicle\.id\)\}/);
+  const icMarkup = await renderComponent("components/sheets/VehicleCard.tsx", "VehicleCard", {
+    vehicle,
+    isSelected: false,
+    onLocate: () => {},
+    viewMode: "ic",
+  });
+  assert.doesNotMatch(icMarkup, />Feed</, "IC-mode vehicle cards should not render the operator video action");
+
+  const operatorMarkup = await renderComponent("components/sheets/VehicleCard.tsx", "VehicleCard", {
+    vehicle,
+    isSelected: false,
+    onLocate: () => {},
+    onViewFeed: () => {},
+    viewMode: "operator",
+  });
+  assert.match(operatorMarkup, />Feed</, "operator vehicle cards should still expose the feed action");
 });
 
-test("IC mode typography upgrades keep key tactical labels at text-base or larger", () => {
-  const files = [
-    path.join(ROOT, "app", "page.tsx"),
-    path.join(ROOT, "components", "layout", "StatusPill.tsx"),
-    path.join(ROOT, "components", "cards", "FleetCard.tsx"),
-    path.join(ROOT, "components", "cards", "DetectionsCard.tsx"),
-    path.join(ROOT, "components", "sheets", "VehicleCard.tsx"),
-    path.join(ROOT, "components", "sheets", "DetectionCard.tsx"),
-  ];
+test("IC mode render branches use large, distance-readable tactical typography", async () => {
+  const statusMarkup = await renderComponent("components/layout/StatusPill.tsx", "StatusPill", {
+    missionPhase: "SEARCHING",
+    elapsedTime: 95,
+    progressPercent: 62,
+    connectionStatus: "connected",
+    alertCount: 3,
+    hasUnreadAlerts: true,
+    detectionCounts: {
+      thermal: 2,
+      acoustic: 1,
+      gas: 1,
+      pending: 3,
+      confirmed: 2,
+    },
+    viewMode: "ic",
+  });
+  assert.match(statusMarkup, /text-xl[^"]*">AERIS</, "IC status branding should render at large-display size");
+  assert.match(statusMarkup, /text-xl text-white\/90[^"]*">Progress</, "IC status labels should render above the old text-base size");
+  assert.match(statusMarkup, /text-2xl text-white[^"]*">62%</, "IC progress counters should render above the old text-lg size");
 
-  const combined = files.map((file) => fs.readFileSync(file, "utf8")).join("\n");
-  assert.match(combined, /text-base text-white\/75">fleet active/);
-  assert.match(combined, /text-base text-white\/75">pending alerts/);
-  assert.match(combined, /isIcMode \? 'text-lg' : 'text-xs'/);
-  assert.match(combined, /isIcMode \? 'text-lg text-white\/85' : 'text-xs text-white\/50'/);
-  assert.match(combined, /text-base font-medium tracking-\[0\.12em\] text-white\/55/);
-  assert.match(combined, /text-base text-white\/45 uppercase tracking-wide">Alt \(m\)</);
+  const fleetMarkup = await renderComponent("components/cards/FleetCard.tsx", "FleetCard", {
+    vehicles: [{ id: "scout-1", name: "Scout 1", status: "active", battery: 82, altitude: 46 }],
+    activeCount: 1,
+    totalCount: 1,
+    avgBattery: 82,
+    avgAltitude: 46,
+    warnings: [],
+    viewMode: "ic",
+  });
+  assert.match(fleetMarkup, /text-xl text-white\/90[^"]*">Fleet</, "IC fleet headings should render above the old text-lg size");
+  assert.match(fleetMarkup, /text-2xl text-white\/80[^"]*">\/1</, "IC fleet counters should keep the shared-display total legible");
+
+  const detectionsMarkup = await renderComponent("components/cards/DetectionsCard.tsx", "DetectionsCard", {
+    thermalCount: 2,
+    acousticCount: 1,
+    gasCount: 1,
+    pendingCount: 3,
+    confirmedCount: 2,
+    viewMode: "ic",
+  });
+  assert.match(detectionsMarkup, /text-xl text-white\/90[^"]*">Detections</, "IC detection headings should render above the old text-lg size");
+  assert.match(detectionsMarkup, /text-xl[^"]*">Review</, "IC detection affordances should stay readable at distance");
+
+  const vehicleMarkup = await renderComponent("components/sheets/VehicleCard.tsx", "VehicleCard", {
+    vehicle: {
+      id: "scout-1",
+      name: "Scout 1",
+      status: "active",
+      battery: 82,
+      altitude: 46,
+      linkQuality: 77,
+      coverage: 64,
+      slamMode: "vio",
+    },
+    isSelected: false,
+    onLocate: () => {},
+    onViewFeed: () => {},
+    viewMode: "ic",
+  });
+  assert.match(vehicleMarkup, /text-xl font-medium tracking-\[0\.12em\] text-white\/60[\s\S]*?>SLAM:/, "vehicle tactical labels should render above the old text-base size");
+  assert.match(vehicleMarkup, /text-xl text-white\/50 uppercase tracking-wide[\s\S]*?>Alt \(m\)</, "vehicle metric captions should render above the old text-base size");
 });
 
 test("DetectionCard read-only mode keeps locate while removing triage actions", () => {

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -528,23 +528,23 @@ function V2PageContent() {
   const icTacticalSummary = (
     <div className="pointer-events-auto flex max-w-[360px] flex-col gap-3 text-lg">
       <div className="rounded-lg border border-white/25 bg-black/75 px-4 py-3 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
-        <div className="text-base font-semibold uppercase tracking-wide text-white/75">IC VIEW</div>
+        <div className="text-xl font-semibold uppercase tracking-wide text-white/90">IC VIEW</div>
         <div className="mt-2 grid grid-cols-2 gap-3 text-white">
           <div>
-            <div className="font-mono text-2xl font-semibold">{activeVehicles.length}/{fleetVehicles.length}</div>
-            <div className="text-base text-white/75">fleet active</div>
+            <div className="font-mono text-3xl font-semibold">{activeVehicles.length}/{fleetVehicles.length}</div>
+            <div className="text-xl text-white/90">fleet active</div>
           </div>
           <div>
-            <div className="font-mono text-2xl font-semibold">{detectionCounts.pending}</div>
-            <div className="text-base text-white/75">pending alerts</div>
+            <div className="font-mono text-3xl font-semibold">{detectionCounts.pending}</div>
+            <div className="text-xl text-white/90">pending alerts</div>
           </div>
           <div>
-            <div className="font-mono text-2xl font-semibold">{routeRecommendations.length}</div>
-            <div className="text-base text-white/75">entry routes</div>
+            <div className="font-mono text-3xl font-semibold">{routeRecommendations.length}</div>
+            <div className="text-xl text-white/90">entry routes</div>
           </div>
           <div>
-            <div className="font-mono text-2xl font-semibold">{structuralHazardZones.length}</div>
-            <div className="text-base text-white/75">hazard zones</div>
+            <div className="font-mono text-3xl font-semibold">{structuralHazardZones.length}</div>
+            <div className="text-xl text-white/90">hazard zones</div>
           </div>
         </div>
       </div>
@@ -597,7 +597,7 @@ function V2PageContent() {
         icViewModeEnabled ? (
           <div className="space-y-3">
             {icTacticalSummary}
-            <div className="rounded-lg border border-white/20 bg-black/70 px-4 py-3 text-lg text-white/90">
+            <div className="rounded-lg border border-white/20 bg-black/70 px-4 py-3 text-xl text-white/95">
               Read-only shared tactical picture
             </div>
           </div>
@@ -616,8 +616,9 @@ function V2PageContent() {
               vehicles={fleetVehicles}
               selectedVehicleId={selectedDroneId}
               onLocate={handleLocateVehicle}
-              onViewFeed={handleViewFeed}
+              onViewFeed={icViewModeEnabled ? undefined : handleViewFeed}
               onRTH={icViewModeEnabled ? undefined : handleRTH}
+              viewMode={icViewModeEnabled ? 'ic' : 'operator'}
               trigger={
                 <FleetCard
                   vehicles={fleetVehicles}

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -323,6 +323,12 @@ function V2PageContent() {
   useEffect(() => {
     viewFeedActionRef.current = handleViewFeed;
   }, [handleViewFeed]);
+  const [mockAlertTimestamps, setMockAlertTimestamps] = useState<Record<(typeof MOCK_ALERT_IDS)[number], Date>>(() => ({
+    'demo-critical': new Date(),
+    'demo-warning': new Date(),
+  }));
+  const dismissedMockAlertIdsRef = useRef<Set<string>>(new Set());
+  const mockAlertDisplayNonceRef = useRef(0);
 
   /**
    * Static alerts for demonstration. In production, these are fed from
@@ -340,7 +346,7 @@ function V2PageContent() {
           title: 'Scout-2 COMMS LOST',
           description: 'Last contact: 45 seconds ago - Initiating recovery',
           dismissible: false,
-          timestamp: new Date(),
+          timestamp: mockAlertTimestamps['demo-critical'],
           action: { label: 'LOCATE', onClick: () => locateVehicleActionRef.current('scout_2') },
         },
         {
@@ -349,36 +355,74 @@ function V2PageContent() {
           title: 'Ranger-1 low battery',
           description: '22% remaining - Auto RTH initiated',
           dismissible: true,
-          timestamp: new Date(),
+          timestamp: mockAlertTimestamps['demo-warning'],
           action: icViewModeEnabled
             ? undefined
             : { label: 'VIEW', onClick: () => viewFeedActionRef.current('ranger_1') },
         },
       ];
     },
-    [allowMockFallback, icViewModeEnabled]
+    [allowMockFallback, icViewModeEnabled, mockAlertTimestamps]
   );
   const hasSyncedMockAlerts = useRef(false);
   const areAlertsOpenRef = useRef(false);
+  const getVisibleStoredAlerts = useCallback(
+    () => storedAlerts.filter((alert) => !dismissedMockAlertIdsRef.current.has(alert.id)),
+    [storedAlerts]
+  );
   const dismissStoredAlerts = useCallback(() => {
+    mockAlertDisplayNonceRef.current += 1;
     MOCK_ALERT_IDS.forEach((alertId) => dismissAlert(alertId));
   }, []);
+  const showVisibleStoredAlerts = useCallback((playSound: boolean) => {
+    const visibleStoredAlerts = getVisibleStoredAlerts();
+    mockAlertDisplayNonceRef.current += 1;
+    const displayNonce = mockAlertDisplayNonceRef.current;
+
+    visibleStoredAlerts.forEach((alert) =>
+      showAlert(
+        {
+          ...alert,
+          onDismiss: alert.dismissible
+            ? () => {
+                if (displayNonce !== mockAlertDisplayNonceRef.current) {
+                  return;
+                }
+                dismissedMockAlertIdsRef.current.add(alert.id);
+                areAlertsOpenRef.current = getVisibleStoredAlerts().length > 0;
+              }
+            : undefined,
+        },
+        { playSound }
+      )
+    );
+
+    areAlertsOpenRef.current = visibleStoredAlerts.length > 0;
+  }, [getVisibleStoredAlerts]);
 
   useEffect(() => {
     if (!allowMockFallback) {
       hasSyncedMockAlerts.current = false;
       areAlertsOpenRef.current = false;
+      dismissedMockAlertIdsRef.current.clear();
+      setMockAlertTimestamps({
+        'demo-critical': new Date(),
+        'demo-warning': new Date(),
+      });
       dismissStoredAlerts();
       return;
     }
 
+    const shouldShowAlerts = areAlertsOpenRef.current || !hasSyncedMockAlerts.current;
+    if (!shouldShowAlerts) {
+      hasSyncedMockAlerts.current = true;
+      return;
+    }
+
     dismissStoredAlerts();
-    storedAlerts.forEach((alert) =>
-      showAlert(alert, { playSound: !hasSyncedMockAlerts.current })
-    );
+    showVisibleStoredAlerts(!hasSyncedMockAlerts.current);
     hasSyncedMockAlerts.current = true;
-    areAlertsOpenRef.current = true;
-  }, [allowMockFallback, dismissStoredAlerts, storedAlerts]);
+  }, [allowMockFallback, dismissStoredAlerts, showVisibleStoredAlerts]);
 
   const handleDroneSelect = (id: string) => {
     setSelectedDroneId(id || null);
@@ -454,11 +498,11 @@ function V2PageContent() {
     }
     areAlertsOpenRef.current = !areAlertsOpenRef.current;
     if (areAlertsOpenRef.current) {
-      storedAlerts.forEach((alert) => showAlert(alert, { playSound: false }));
+      showVisibleStoredAlerts(false);
       return;
     }
     dismissStoredAlerts();
-  }, [allowMockFallback, dismissStoredAlerts, storedAlerts]);
+  }, [allowMockFallback, dismissStoredAlerts, showVisibleStoredAlerts, storedAlerts.length]);
 
   /**
    * Global keyboard shortcuts for mission control.

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -313,6 +313,16 @@ function V2PageContent() {
 
     setPipVehicleId(id);
   }, [icViewModeEnabled]);
+  const locateVehicleActionRef = useRef(handleLocateVehicle);
+  const viewFeedActionRef = useRef(handleViewFeed);
+
+  useEffect(() => {
+    locateVehicleActionRef.current = handleLocateVehicle;
+  }, [handleLocateVehicle]);
+
+  useEffect(() => {
+    viewFeedActionRef.current = handleViewFeed;
+  }, [handleViewFeed]);
 
   /**
    * Static alerts for demonstration. In production, these are fed from
@@ -331,7 +341,7 @@ function V2PageContent() {
           description: 'Last contact: 45 seconds ago - Initiating recovery',
           dismissible: false,
           timestamp: new Date(),
-          action: { label: 'LOCATE', onClick: () => handleLocateVehicle('scout_2') },
+          action: { label: 'LOCATE', onClick: () => locateVehicleActionRef.current('scout_2') },
         },
         {
           id: 'demo-warning',
@@ -342,11 +352,11 @@ function V2PageContent() {
           timestamp: new Date(),
           action: icViewModeEnabled
             ? undefined
-            : { label: 'VIEW', onClick: () => handleViewFeed('ranger_1') },
+            : { label: 'VIEW', onClick: () => viewFeedActionRef.current('ranger_1') },
         },
       ];
     },
-    [allowMockFallback, handleLocateVehicle, handleViewFeed, icViewModeEnabled]
+    [allowMockFallback, icViewModeEnabled]
   );
   const hasSyncedMockAlerts = useRef(false);
   const areAlertsOpenRef = useRef(false);

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -180,6 +180,12 @@ function V2PageContent() {
     });
   }, [icViewModeEnabled, layerVisibility]);
 
+  useEffect(() => {
+    if (icViewModeEnabled) {
+      setPipVehicleId(null);
+    }
+  }, [icViewModeEnabled]);
+
   const setIcModeFromUi = useCallback((enabled: boolean) => {
     const params = new URLSearchParams(searchParams.toString());
     if (enabled) {
@@ -334,13 +340,15 @@ function V2PageContent() {
           description: '22% remaining - Auto RTH initiated',
           dismissible: true,
           timestamp: new Date(),
-          action: { label: 'VIEW', onClick: () => handleViewFeed('ranger_1') },
+          action: icViewModeEnabled
+            ? undefined
+            : { label: 'VIEW', onClick: () => handleViewFeed('ranger_1') },
         },
       ];
     },
-    [allowMockFallback, handleLocateVehicle, handleViewFeed]
+    [allowMockFallback, handleLocateVehicle, handleViewFeed, icViewModeEnabled]
   );
-  const hasAddedInitialAlerts = useRef(false);
+  const hasSyncedMockAlerts = useRef(false);
   const areAlertsOpenRef = useRef(false);
   const dismissStoredAlerts = useCallback(() => {
     MOCK_ALERT_IDS.forEach((alertId) => dismissAlert(alertId));
@@ -348,14 +356,18 @@ function V2PageContent() {
 
   useEffect(() => {
     if (!allowMockFallback) {
-      hasAddedInitialAlerts.current = false;
+      hasSyncedMockAlerts.current = false;
       areAlertsOpenRef.current = false;
       dismissStoredAlerts();
       return;
     }
-    if (hasAddedInitialAlerts.current) return;
-    hasAddedInitialAlerts.current = true;
-    storedAlerts.forEach((alert) => showAlert(alert));
+
+    dismissStoredAlerts();
+    storedAlerts.forEach((alert) =>
+      showAlert(alert, { playSound: !hasSyncedMockAlerts.current })
+    );
+    hasSyncedMockAlerts.current = true;
+    areAlertsOpenRef.current = true;
   }, [allowMockFallback, dismissStoredAlerts, storedAlerts]);
 
   const handleDroneSelect = (id: string) => {

--- a/software/viewer/src/components/alerts/AlertStack.tsx
+++ b/software/viewer/src/components/alerts/AlertStack.tsx
@@ -24,6 +24,7 @@ export interface Alert {
   };
   timestamp: Date;
   dismissible: boolean;
+  onDismiss?: () => void;
 }
 
 /**
@@ -104,7 +105,7 @@ function playCriticalAlertSound() {
  * @returns The alert ID for programmatic dismissal
  */
 export function showAlert(alert: Omit<Alert, 'timestamp'>, options?: { playSound?: boolean }) {
-  const { id, severity, title, description, action } = alert;
+  const { id, severity, title, description, action, onDismiss } = alert;
   const { playSound = true } = options || {};
 
   if (playSound && severity === 'critical') {
@@ -125,6 +126,7 @@ export function showAlert(alert: Omit<Alert, 'timestamp'>, options?: { playSound
       label: action.label,
       onClick: action.onClick,
     } : undefined,
+    onDismiss: onDismiss ? () => onDismiss() : undefined,
     classNames: {
       toast: cn(
         'group-[.toaster]:border-l-4',

--- a/software/viewer/src/components/cards/DetectionsCard.tsx
+++ b/software/viewer/src/components/cards/DetectionsCard.tsx
@@ -93,12 +93,12 @@ export function DetectionsCard({
       )}
     >
       <div className="flex items-center justify-between">
-        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-lg text-white/85' : 'text-xs text-white/50')}>
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-xl text-white/90' : 'text-xs text-white/50')}>
           Detections
         </span>
         {hasPending && (
           <Badge variant="success" className="px-2 py-0.5">
-            <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>{pendingCount} pending</span>
+            <span className={cn(isIcMode ? 'text-xl' : 'text-xs')}>{pendingCount} pending</span>
           </Badge>
         )}
       </div>
@@ -106,21 +106,21 @@ export function DetectionsCard({
       <div className="flex items-center gap-2">
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.thermal.bg)}>
           <Flame className={cn('h-4 w-4', sensorConfig.thermal.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.thermal.color, isIcMode ? 'text-lg' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.thermal.color, isIcMode ? 'text-xl' : 'text-sm')}>
             {thermalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.acoustic.bg)}>
           <AudioLines className={cn('h-4 w-4', sensorConfig.acoustic.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.acoustic.color, isIcMode ? 'text-lg' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.acoustic.color, isIcMode ? 'text-xl' : 'text-sm')}>
             {acousticCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.gas.bg)}>
           <Wind className={cn('h-4 w-4', sensorConfig.gas.color)} />
-          <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-lg' : 'text-sm')}>
+          <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-xl' : 'text-sm')}>
             {gasCount}
           </span>
         </div>
@@ -128,15 +128,15 @@ export function DetectionsCard({
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <span className={cn('font-mono text-[var(--success)]', isIcMode ? 'text-lg' : 'text-sm')}>
+          <span className={cn('font-mono text-[var(--success)]', isIcMode ? 'text-xl' : 'text-sm')}>
             {confirmedCount}
           </span>
-          <span className={cn(isIcMode ? 'text-base text-white/55' : 'text-xs text-white/40')}>/</span>
-          <span className={cn('font-mono text-white/70', isIcMode ? 'text-lg' : 'text-sm')}>{totalCount}</span>
+          <span className={cn(isIcMode ? 'text-xl text-white/60' : 'text-xs text-white/40')}>/</span>
+          <span className={cn('font-mono text-white/70', isIcMode ? 'text-xl' : 'text-sm')}>{totalCount}</span>
         </div>
 
         <div className="flex items-center gap-1 text-white/40">
-          <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>Review</span>
+          <span className={cn(isIcMode ? 'text-xl' : 'text-xs')}>Review</span>
           <ChevronRight className="h-4 w-4" />
         </div>
       </div>

--- a/software/viewer/src/components/cards/FleetCard.tsx
+++ b/software/viewer/src/components/cards/FleetCard.tsx
@@ -117,7 +117,7 @@ export function FleetCard({
       )}
     >
       <div className="flex items-center justify-between">
-        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-lg text-white/85' : 'text-xs text-white/50')}>
+        <span className={cn('font-medium uppercase tracking-wider', isIcMode ? 'text-xl text-white/90' : 'text-xs text-white/50')}>
           Fleet
         </span>
         {hasWarnings && (
@@ -126,7 +126,7 @@ export function FleetCard({
             className="flex items-center gap-1 px-2 py-0.5"
           >
             <AlertTriangle className="h-3.5 w-3.5" />
-            <span className={cn(isIcMode ? 'text-base' : 'text-xs')}>{warnings.length}</span>
+            <span className={cn(isIcMode ? 'text-xl' : 'text-xs')}>{warnings.length}</span>
           </Badge>
         )}
       </div>
@@ -144,7 +144,7 @@ export function FleetCard({
           />
         ))}
         {vehicles.length > 8 && (
-          <span className="ml-1 text-xs text-white/50">
+          <span className={cn('ml-1 text-white/50', isIcMode ? 'text-lg' : 'text-xs')}>
             +{vehicles.length - 8}
           </span>
         )}
@@ -152,17 +152,17 @@ export function FleetCard({
 
       <div className="flex items-center justify-between">
         <div className="flex items-baseline gap-1.5">
-          <span className={cn('font-mono font-bold text-white', isIcMode ? 'text-3xl' : 'text-xl')}>
+          <span className={cn('font-mono font-bold text-white', isIcMode ? 'text-4xl' : 'text-xl')}>
             {activeCount}
           </span>
-          <span className={cn(isIcMode ? 'text-lg text-white/75' : 'text-sm text-white/50')}>
+          <span className={cn(isIcMode ? 'text-2xl text-white/80' : 'text-sm text-white/50')}>
             /{totalCount}
           </span>
         </div>
 
         <div className={cn('flex items-center gap-1.5', getBatteryColor(avgBattery))}>
           {getBatteryIcon(avgBattery)}
-          <span className={cn('font-mono', isIcMode ? 'text-lg' : 'text-sm')}>
+          <span className={cn('font-mono', isIcMode ? 'text-xl' : 'text-sm')}>
             {avgBattery === null ? '--' : `${avgBattery}%`}
           </span>
         </div>

--- a/software/viewer/src/components/layout/StatusPill.tsx
+++ b/software/viewer/src/components/layout/StatusPill.tsx
@@ -144,7 +144,7 @@ export function StatusPill({
         {logo || (
           <span className={cn(
             'font-mono font-bold tracking-wider text-[var(--foreground)]',
-            isIcMode ? 'text-lg' : 'text-xs'
+            isIcMode ? 'text-xl' : 'text-xs'
           )}>
             AERIS
           </span>
@@ -155,7 +155,7 @@ export function StatusPill({
 
       <Badge
         variant={phase.variant}
-        className={cn('flex items-center gap-2 rounded-full px-3 py-1.5', isIcMode && 'text-lg')}
+        className={cn('flex items-center gap-2 rounded-full px-3 py-1.5', isIcMode && 'text-xl')}
       >
         {phase.pulse ? (
           <span className="relative flex h-2 w-2">
@@ -167,7 +167,7 @@ export function StatusPill({
         ) : (
           <span className="h-2 w-2 rounded-full bg-current opacity-50" />
         )}
-        <span className={cn('font-semibold tracking-wide', isIcMode ? 'text-lg' : 'text-xs')}>
+        <span className={cn('font-semibold tracking-wide', isIcMode ? 'text-xl' : 'text-xs')}>
           {phase.label}
         </span>
       </Badge>
@@ -177,7 +177,7 @@ export function StatusPill({
       <div className="flex items-center px-3">
         <span className={cn(
           'font-mono font-medium tabular-nums text-[var(--foreground)]',
-          isIcMode ? 'text-lg' : 'text-sm'
+          isIcMode ? 'text-2xl' : 'text-sm'
         )}>
           {formatElapsedTime(elapsedTime)}
         </span>
@@ -186,7 +186,7 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-2 px-3">
-        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-base text-white/85' : 'text-[10px] text-white/50')}>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-xl text-white/90' : 'text-[10px] text-white/50')}>
           Progress
         </span>
         <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
@@ -195,7 +195,7 @@ export function StatusPill({
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <span className={cn('font-mono tabular-nums', isIcMode ? 'text-lg text-white' : 'text-xs text-white/70')}>
+        <span className={cn('font-mono tabular-nums', isIcMode ? 'text-2xl text-white' : 'text-xs text-white/70')}>
           {progressPercent}%
         </span>
       </div>
@@ -203,22 +203,22 @@ export function StatusPill({
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className="flex items-center gap-1.5 px-3">
-        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-base text-white/85' : 'text-[10px] text-white/50')}>
+        <span className={cn('uppercase tracking-wide', isIcMode ? 'text-xl text-white/90' : 'text-[10px] text-white/50')}>
           Det
         </span>
-        <span className={cn('font-mono text-orange-400', isIcMode ? 'text-lg' : 'text-xs')}>T{liveDetections.thermal}</span>
-        <span className={cn('font-mono text-sky-400', isIcMode ? 'text-lg' : 'text-xs')}>A{liveDetections.acoustic}</span>
-        <span className={cn('font-mono text-amber-400', isIcMode ? 'text-lg' : 'text-xs')}>G{liveDetections.gas}</span>
+        <span className={cn('font-mono text-orange-400', isIcMode ? 'text-2xl' : 'text-xs')}>T{liveDetections.thermal}</span>
+        <span className={cn('font-mono text-sky-400', isIcMode ? 'text-2xl' : 'text-xs')}>A{liveDetections.acoustic}</span>
+        <span className={cn('font-mono text-amber-400', isIcMode ? 'text-2xl' : 'text-xs')}>G{liveDetections.gas}</span>
         <span className="text-white/25">|</span>
-        <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-lg' : 'text-xs')}>P{liveDetections.pending}</span>
-        <span className={cn('font-mono', isIcMode ? 'text-lg text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>
+        <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-2xl' : 'text-xs')}>P{liveDetections.pending}</span>
+        <span className={cn('font-mono', isIcMode ? 'text-2xl text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
 
       <div className={cn('flex items-center gap-1.5 px-3', connection.colorClass)}>
         <ConnectionIcon className={cn(isIcMode ? 'h-4.5 w-4.5' : 'h-3.5 w-3.5')} />
-        <span className={cn('font-medium', isIcMode ? 'text-lg' : 'text-xs')}>{connection.label}</span>
+        <span className={cn('font-medium', isIcMode ? 'text-xl' : 'text-xs')}>{connection.label}</span>
       </div>
 
       <div className="h-4 w-px bg-[var(--glass-border)]" />
@@ -232,7 +232,7 @@ export function StatusPill({
       >
         <Bell className={cn(isIcMode ? 'h-5 w-5' : 'h-4 w-4')} />
         {alertCount > 0 && (
-          <span className={cn('font-medium text-[var(--foreground)]', isIcMode ? 'text-base' : 'text-xs')}>
+          <span className={cn('font-medium text-[var(--foreground)]', isIcMode ? 'text-xl' : 'text-xs')}>
             {alertCount}
           </span>
         )}

--- a/software/viewer/src/components/sheets/FleetSheet.tsx
+++ b/software/viewer/src/components/sheets/FleetSheet.tsx
@@ -21,7 +21,7 @@ interface FleetSheetProps {
   /** Callback to center map on vehicle location */
   onLocate: (id: string) => void;
   /** Callback to open video feed for vehicle */
-  onViewFeed: (id: string) => void;
+  onViewFeed?: (id: string) => void;
   /** Callback to initiate return-to-home for vehicle */
   onRTH?: (id: string) => void;
   /** Callback for emergency recall of all vehicles */
@@ -30,6 +30,8 @@ interface FleetSheetProps {
   onHoldPositions?: () => void;
   /** Trigger element that opens the drawer */
   trigger: React.ReactNode;
+  /** Presentation mode adjusts drawer readability for shared displays */
+  viewMode?: 'operator' | 'ic';
 }
 
 /**
@@ -60,10 +62,15 @@ export function FleetSheet({
   onRecallAll,
   onHoldPositions,
   trigger,
+  viewMode = 'operator',
 }: FleetSheetProps) {
   const [open, setOpen] = useState(false);
+  const isIcMode = viewMode === 'ic';
 
   const handleViewFeed = (id: string) => {
+    if (!onViewFeed) {
+      return;
+    }
     onViewFeed(id);
     setOpen(false);
   };
@@ -105,20 +112,20 @@ export function FleetSheet({
                   Fleet
                 </DrawerTitle>
               </div>
-              <div className="flex items-center gap-5 text-base">
+              <div className={cn('flex items-center gap-5', isIcMode ? 'text-xl' : 'text-base')}>
                 <span className="text-emerald-400">
-                  <span className="font-mono text-lg">{activeCount}</span>
+                  <span className={cn('font-mono', isIcMode ? 'text-2xl' : 'text-lg')}>{activeCount}</span>
                   <span className="ml-1 text-white/40">active</span>
                 </span>
                 {warningCount > 0 && (
                   <span className="flex items-center gap-1 text-amber-400">
                     <AlertTriangle className="h-3 w-3" />
-                    <span className="font-mono text-lg">{warningCount}</span>
+                    <span className={cn('font-mono', isIcMode ? 'text-2xl' : 'text-lg')}>{warningCount}</span>
                   </span>
                 )}
                 <span className="flex items-center gap-1.5 text-white/50">
                   <Battery className="h-3.5 w-3.5" />
-                  <span className="font-mono text-lg">
+                  <span className={cn('font-mono', isIcMode ? 'text-2xl' : 'text-lg')}>
                     {avgBattery === null ? '--' : `${avgBattery}%`}
                   </span>
                   <span className="text-white/30">avg</span>
@@ -153,8 +160,9 @@ export function FleetSheet({
                   vehicle={vehicle}
                   isSelected={selectedVehicleId === vehicle.id}
                   onLocate={() => handleLocate(vehicle.id)}
-                  onViewFeed={() => handleViewFeed(vehicle.id)}
+                  onViewFeed={onViewFeed ? () => handleViewFeed(vehicle.id) : undefined}
                   onRTH={onRTH ? () => onRTH(vehicle.id) : undefined}
+                  viewMode={viewMode}
                 />
               ))}
             </div>

--- a/software/viewer/src/components/sheets/VehicleCard.tsx
+++ b/software/viewer/src/components/sheets/VehicleCard.tsx
@@ -49,8 +49,9 @@ export interface VehicleCardProps {
   vehicle: VehicleInfo;
   isSelected: boolean;
   onLocate: () => void;
-  onViewFeed: () => void;
+  onViewFeed?: () => void;
   onRTH?: () => void;
+  viewMode?: 'operator' | 'ic';
 }
 
 /**
@@ -199,9 +200,11 @@ export function VehicleCard({
   onLocate,
   onViewFeed,
   onRTH,
+  viewMode = 'operator',
 }: VehicleCardProps) {
   const status = statusConfig[vehicle.status];
   const isOffline = vehicle.status === 'offline';
+  const isIcMode = viewMode === 'ic';
 
   return (
     <div
@@ -210,6 +213,7 @@ export function VehicleCard({
         'bg-white/[0.03] backdrop-blur-md',
         'border border-white/[0.06]',
         status.glow,
+        isIcMode && 'border-white/18 bg-black/60',
         isOffline && 'grayscale opacity-75 bg-zinc-950/60 border-zinc-500/20',
         isSelected && 'ring-2 ring-cyan-500/50',
         vehicle.status === 'error' && 'border-red-500/20'
@@ -217,22 +221,30 @@ export function VehicleCard({
     >
       <div className="flex items-start justify-between p-3 pb-0">
         <div className="flex flex-col gap-0.5">
-          <span className="text-lg font-light text-white">{vehicle.name}</span>
+          <span className={cn(isIcMode ? 'text-xl font-medium text-white' : 'text-lg font-light text-white')}>{vehicle.name}</span>
           <div className="flex items-center gap-2">
             <span className={cn('h-1.5 w-1.5 rounded-full animate-pulse', status.dot)} />
-            <span className={cn('text-base font-semibold tracking-wider', status.color)}>
+            <span className={cn(isIcMode ? 'text-xl font-semibold tracking-wider' : 'text-base font-semibold tracking-wider', status.color)}>
               {status.label}
             </span>
           </div>
           <span
-            className="text-base font-medium tracking-[0.12em] text-white/55"
+            className={cn(
+              isIcMode
+                ? 'text-xl font-medium tracking-[0.12em] text-white/60'
+                : 'text-base font-medium tracking-[0.12em] text-white/55'
+            )}
             data-testid="vehicle-slam-mode"
           >
             SLAM: {formatSlamModeLabel(vehicle.slamMode)}
           </span>
           {isOffline && (
             <span
-              className="text-base font-semibold tracking-[0.12em] text-zinc-200"
+              className={cn(
+                isIcMode
+                  ? 'text-xl font-semibold tracking-[0.12em] text-zinc-100'
+                  : 'text-base font-semibold tracking-[0.12em] text-zinc-200'
+              )}
               data-testid="vehicle-last-known-age"
             >
               LAST CONTACT {formatLastContactAge(vehicle.lastContactAgeMs)}
@@ -243,10 +255,10 @@ export function VehicleCard({
         <div className="relative">
           <BatteryArc battery={vehicle.battery} />
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className={cn('font-mono text-base font-light tabular-nums', getBatteryColor(vehicle.battery))}>
+            <span className={cn(isIcMode ? 'font-mono text-xl font-light tabular-nums' : 'font-mono text-base font-light tabular-nums', getBatteryColor(vehicle.battery))}>
               {vehicle.battery ?? '--'}
             </span>
-            <span className="text-base text-white/45">{vehicle.battery === null ? '' : '%'}</span>
+            <span className={cn(isIcMode ? 'text-xl text-white/50' : 'text-base text-white/45')}>{vehicle.battery === null ? '' : '%'}</span>
           </div>
         </div>
       </div>
@@ -255,18 +267,18 @@ export function VehicleCard({
       <div className="grid grid-cols-3 gap-px bg-white/[0.02] mx-3 my-2 rounded-lg overflow-hidden">
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Gauge className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-base text-white/80">{vehicle.altitude}</span>
-          <span className="text-base text-white/45 uppercase tracking-wide">Alt (m)</span>
+          <span className={cn(isIcMode ? 'font-mono text-xl text-white/85' : 'font-mono text-base text-white/80')}>{vehicle.altitude}</span>
+          <span className={cn(isIcMode ? 'text-xl text-white/50 uppercase tracking-wide' : 'text-base text-white/45 uppercase tracking-wide')}>Alt (m)</span>
         </div>
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Radio className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-base text-white/80">{vehicle.linkQuality ?? '--'}</span>
-          <span className="text-base text-white/45 uppercase tracking-wide">Link %</span>
+          <span className={cn(isIcMode ? 'font-mono text-xl text-white/85' : 'font-mono text-base text-white/80')}>{vehicle.linkQuality ?? '--'}</span>
+          <span className={cn(isIcMode ? 'text-xl text-white/50 uppercase tracking-wide' : 'text-base text-white/45 uppercase tracking-wide')}>Link %</span>
         </div>
         <div className="flex flex-col items-center gap-0.5 bg-white/[0.02] py-2">
           <Signal className="h-3 w-3 text-white/30" />
-          <span className="font-mono text-base text-white/80">{vehicle.coverage ?? '--'}</span>
-          <span className="text-base text-white/45 uppercase tracking-wide">Cover %</span>
+          <span className={cn(isIcMode ? 'font-mono text-xl text-white/85' : 'font-mono text-base text-white/80')}>{vehicle.coverage ?? '--'}</span>
+          <span className={cn(isIcMode ? 'text-xl text-white/50 uppercase tracking-wide' : 'text-base text-white/45 uppercase tracking-wide')}>Cover %</span>
         </div>
       </div>
 
@@ -276,7 +288,8 @@ export function VehicleCard({
           variant="ghost"
           size="sm"
           className={cn(
-            'flex-1 h-10 rounded-lg text-base',
+            'flex-1 rounded-lg',
+            isIcMode ? 'h-11 text-lg' : 'h-10 text-base',
             'text-white/50 hover:text-white hover:bg-white/10'
           )}
           onClick={onLocate}
@@ -284,24 +297,28 @@ export function VehicleCard({
           <MapPin className="mr-1 h-3 w-3" />
           Locate
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className={cn(
-            'flex-1 h-10 rounded-lg text-base',
-            'text-white/50 hover:text-white hover:bg-white/10'
-          )}
-          onClick={onViewFeed}
-        >
-          <Video className="mr-1 h-3 w-3" />
-          Feed
-        </Button>
+        {onViewFeed && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              'flex-1 rounded-lg',
+              isIcMode ? 'h-11 text-lg' : 'h-10 text-base',
+              'text-white/50 hover:text-white hover:bg-white/10'
+            )}
+            onClick={onViewFeed}
+          >
+            <Video className="mr-1 h-3 w-3" />
+            Feed
+          </Button>
+        )}
         {onRTH && vehicle.status !== 'returning' && vehicle.status !== 'idle' && (
           <Button
             variant="ghost"
             size="sm"
             className={cn(
-              'h-10 px-3 rounded-lg text-base',
+              'px-3 rounded-lg',
+              isIcMode ? 'h-11 text-lg' : 'h-10 text-base',
               'text-amber-400/70 hover:text-amber-400 hover:bg-amber-500/10'
             )}
             onClick={onRTH}


### PR DESCRIPTION
## Summary
- Remove operator-only feed actions from the incident commander tactical view.
- Improve shared-display typography across IC summaries and fleet surfaces.
- Preserve mock alert close/dismiss state while still updating IC/operator alert actions.

## Done
- IC mode no longer exposes feed launch actions or leaves PiP open.
- The shared tactical surfaces render with larger IC-mode text and covered component output.
- Mock fallback alerts no longer reopen from telemetry churn or IC-mode toggles.

Refs #46

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the incident commander (IC) tactical view by removing operator-only feed actions, improving shared-display typography, and preserving mock alert dismiss state across IC mode toggles and telemetry updates.

- **IC mode feed isolation**: `onViewFeed` is now passed as `undefined` (rather than guarded inside the handler) when IC mode is active, so the Feed button never renders at all in `VehicleCard`. `PipVehicleId` is also cleared via a dedicated `useEffect` when IC mode activates.
- **Dismissed alert persistence**: A `dismissedMockAlertIdsRef` + nonce guard ensures that alerts a user has manually closed are not re-shown on IC toggle or telemetry-driven resyncs; `mockAlertTimestamps` are stabilised in state so displayed ages don't reset.
- **Typography upgrade**: IC mode text sizes stepped up across `StatusPill`, `FleetCard`, `DetectionsCard`, `VehicleCard`, and the inline `icTacticalSummary` block for shared-display legibility.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three previously flagged issues are correctly resolved and no new regressions are introduced.

The alert dismiss-state fix is carefully structured: a nonce guard prevents programmatic dismissStoredAlerts calls from being mistaken for user actions, dismissedMockAlertIdsRef persists across IC mode toggles, and stable mockAlertTimestamps state keeps displayed ages correct. The IC mode feed isolation is complete end-to-end. Typography changes are additive and covered by the expanded render-based test suite.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/viewer/src/app/page.tsx | Core alert-state refactor: adds dismissedMockAlertIdsRef, nonce guard, stable timestamps, and showVisibleStoredAlerts; correctly fixes the previously flagged dismissed-alert-resurface bug. |
| software/viewer/src/app/icViewModeSurface.test.mjs | Test suite expanded with render-based component tests using createElement; temp directory is now cleaned up via after() hook; previous reviewers' issues are resolved. |
| software/viewer/src/components/alerts/AlertStack.tsx | Adds optional onDismiss callback to the Alert interface and threads it through showAlert; minimal, correct change. |
| software/viewer/src/components/sheets/VehicleCard.tsx | onViewFeed made optional; Feed button now conditionally rendered; viewMode prop added with IC typography upgrades throughout. |
| software/viewer/src/components/sheets/FleetSheet.tsx | onViewFeed made optional; viewMode prop added and propagated to VehicleCard; IC mode header typography scaled up. |
| software/viewer/src/components/cards/FleetCard.tsx | IC mode typography bumped; overflow indicator now scales with viewMode. |
| software/viewer/src/components/cards/DetectionsCard.tsx | IC typography stepped up from text-lg/text-base to text-xl across headings, sensor counts, and footer labels. |
| software/viewer/src/components/layout/StatusPill.tsx | IC mode text sizes upgraded for shared-display legibility. |

</details>

<sub>Reviews (6): Last reviewed commit: ["viewer: preserve mock alert visibility s..."](https://github.com/aeris-drones/aeris/commit/d3440220f534a5d12c93c09f114b8cb82ff69ce5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33441821)</sub>

<!-- /greptile_comment -->