### PR TITLE
Add persistent emergency stop hold control

### DIFF
--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -164,6 +164,11 @@ test("IC mode keeps one canonical page-shell flag and propagates it", () => {
     /<EmergencyStopControl[\s\S]*onAbort=\{abortMission\}/,
     "page should route the persistent control through the existing abortMission callback"
   );
+  assert.match(
+    source,
+    /<EmergencyStopControl[\s\S]*key=\{missionPhase\}/,
+    "mission-phase changes should reset the emergency-stop hold and pending state"
+  );
 });
 
 test("IC mode blocks feed launch and operator keyboard shortcuts", () => {

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -202,13 +202,38 @@ test("IC mode blocks feed launch and operator keyboard shortcuts", () => {
   );
   assert.match(
     source,
+    /const \[mockAlertTimestamps, setMockAlertTimestamps\] = useState<Record<\(typeof MOCK_ALERT_IDS\)\[number\], Date>>\(\(\) => \(\{/,
+    "mock alert timestamps should stay stable across resyncs and IC-mode toggles"
+  );
+  assert.match(
+    source,
+    /const dismissedMockAlertIdsRef = useRef<Set<string>>\(new Set\(\)\);/,
+    "mock alert dismissal state should be tracked separately from visibility state"
+  );
+  assert.match(
+    source,
+    /const shouldShowAlerts = areAlertsOpenRef\.current \|\| !hasSyncedMockAlerts\.current;/,
+    "mock alert resync should respect manual visibility state after the initial seed"
+  );
+  assert.match(
+    source,
+    /const getVisibleStoredAlerts = useCallback\(\s*\(\) => storedAlerts\.filter\(\(alert\) => !dismissedMockAlertIdsRef\.current\.has\(alert\.id\)\)/s,
+    "mock alert replay should exclude alerts the operator already dismissed"
+  );
+  assert.match(
+    source,
+    /if \(displayNonce !== mockAlertDisplayNonceRef\.current\) \{\s*return;\s*\}/s,
+    "programmatic alert resync dismissals should not be recorded as manual dismissals"
+  );
+  assert.match(
+    source,
     /action:\s*icViewModeEnabled\s*\?\s*undefined\s*:\s*\{\s*label:\s*'VIEW',\s*onClick:\s*\(\) => viewFeedActionRef\.current\('ranger_1'\)\s*\}/s,
     "IC mode should remove feed-launch actions from mock alert surfaces as well"
   );
   assert.match(
     source,
-    /\[allowMockFallback, icViewModeEnabled\]\s*\);/,
-    "mock alert definitions should not resubscribe on telemetry-driven handler churn"
+    /showVisibleStoredAlerts\(false\);/,
+    "manually reopening mock alerts should preserve the current dismissed-alert filter"
   );
 
   const keyboardEffect = source.match(/const handleKeyDown = \(e: KeyboardEvent\) => \{([\s\S]*?)\n    \};/);

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -149,10 +149,21 @@ test("IC mode keeps one canonical page-shell flag and propagates it", () => {
   const { source } = parseTsx(pagePath);
 
   assert.match(source, /useSearchParams/);
+  assert.match(source, /EmergencyStopControl/);
   assert.match(source, /isIcViewModeQueryValue/);
   assert.match(source, /setIcViewModeEnabled/);
   assert.match(source, /viewMode=\{icViewModeEnabled \? 'ic' : 'operator'\}/);
   assert.match(source, /mode=\{icViewModeEnabled \? 'ic' : 'operator'\}/);
+  assert.match(
+    source,
+    /topRightOverlay=\{icViewModeEnabled \? undefined : \(/,
+    "operator mode should own the persistent emergency-stop surface while IC mode keeps the shell read-only"
+  );
+  assert.match(
+    source,
+    /<EmergencyStopControl[\s\S]*onAbort=\{abortMission\}/,
+    "page should route the persistent control through the existing abortMission callback"
+  );
 });
 
 test("IC mode blocks feed launch and operator keyboard shortcuts", () => {

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -623,6 +623,7 @@ function V2PageContent() {
 
       topRightOverlay={icViewModeEnabled ? undefined : (
         <EmergencyStopControl
+          key={missionPhase}
           missionPhase={missionPhase}
           canAbort={canAbort}
           abortUnavailableReason={abortUnavailableReason}

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -326,6 +326,12 @@ function V2PageContent() {
   useEffect(() => {
     viewFeedActionRef.current = handleViewFeed;
   }, [handleViewFeed]);
+  const [mockAlertTimestamps, setMockAlertTimestamps] = useState<Record<(typeof MOCK_ALERT_IDS)[number], Date>>(() => ({
+    'demo-critical': new Date(),
+    'demo-warning': new Date(),
+  }));
+  const dismissedMockAlertIdsRef = useRef<Set<string>>(new Set());
+  const mockAlertDisplayNonceRef = useRef(0);
 
   /**
    * Static alerts for demonstration. In production, these are fed from
@@ -343,7 +349,7 @@ function V2PageContent() {
           title: 'Scout-2 COMMS LOST',
           description: 'Last contact: 45 seconds ago - Initiating recovery',
           dismissible: false,
-          timestamp: new Date(),
+          timestamp: mockAlertTimestamps['demo-critical'],
           action: { label: 'LOCATE', onClick: () => locateVehicleActionRef.current('scout_2') },
         },
         {
@@ -352,36 +358,74 @@ function V2PageContent() {
           title: 'Ranger-1 low battery',
           description: '22% remaining - Auto RTH initiated',
           dismissible: true,
-          timestamp: new Date(),
+          timestamp: mockAlertTimestamps['demo-warning'],
           action: icViewModeEnabled
             ? undefined
             : { label: 'VIEW', onClick: () => viewFeedActionRef.current('ranger_1') },
         },
       ];
     },
-    [allowMockFallback, icViewModeEnabled]
+    [allowMockFallback, icViewModeEnabled, mockAlertTimestamps]
   );
   const hasSyncedMockAlerts = useRef(false);
   const areAlertsOpenRef = useRef(false);
+  const getVisibleStoredAlerts = useCallback(
+    () => storedAlerts.filter((alert) => !dismissedMockAlertIdsRef.current.has(alert.id)),
+    [storedAlerts]
+  );
   const dismissStoredAlerts = useCallback(() => {
+    mockAlertDisplayNonceRef.current += 1;
     MOCK_ALERT_IDS.forEach((alertId) => dismissAlert(alertId));
   }, []);
+  const showVisibleStoredAlerts = useCallback((playSound: boolean) => {
+    const visibleStoredAlerts = getVisibleStoredAlerts();
+    mockAlertDisplayNonceRef.current += 1;
+    const displayNonce = mockAlertDisplayNonceRef.current;
+
+    visibleStoredAlerts.forEach((alert) =>
+      showAlert(
+        {
+          ...alert,
+          onDismiss: alert.dismissible
+            ? () => {
+                if (displayNonce !== mockAlertDisplayNonceRef.current) {
+                  return;
+                }
+                dismissedMockAlertIdsRef.current.add(alert.id);
+                areAlertsOpenRef.current = getVisibleStoredAlerts().length > 0;
+              }
+            : undefined,
+        },
+        { playSound }
+      )
+    );
+
+    areAlertsOpenRef.current = visibleStoredAlerts.length > 0;
+  }, [getVisibleStoredAlerts]);
 
   useEffect(() => {
     if (!allowMockFallback) {
       hasSyncedMockAlerts.current = false;
       areAlertsOpenRef.current = false;
+      dismissedMockAlertIdsRef.current.clear();
+      setMockAlertTimestamps({
+        'demo-critical': new Date(),
+        'demo-warning': new Date(),
+      });
       dismissStoredAlerts();
       return;
     }
 
+    const shouldShowAlerts = areAlertsOpenRef.current || !hasSyncedMockAlerts.current;
+    if (!shouldShowAlerts) {
+      hasSyncedMockAlerts.current = true;
+      return;
+    }
+
     dismissStoredAlerts();
-    storedAlerts.forEach((alert) =>
-      showAlert(alert, { playSound: !hasSyncedMockAlerts.current })
-    );
+    showVisibleStoredAlerts(!hasSyncedMockAlerts.current);
     hasSyncedMockAlerts.current = true;
-    areAlertsOpenRef.current = true;
-  }, [allowMockFallback, dismissStoredAlerts, storedAlerts]);
+  }, [allowMockFallback, dismissStoredAlerts, showVisibleStoredAlerts]);
 
   const handleDroneSelect = (id: string) => {
     setSelectedDroneId(id || null);
@@ -457,11 +501,11 @@ function V2PageContent() {
     }
     areAlertsOpenRef.current = !areAlertsOpenRef.current;
     if (areAlertsOpenRef.current) {
-      storedAlerts.forEach((alert) => showAlert(alert, { playSound: false }));
+      showVisibleStoredAlerts(false);
       return;
     }
     dismissStoredAlerts();
-  }, [allowMockFallback, dismissStoredAlerts, storedAlerts]);
+  }, [allowMockFallback, dismissStoredAlerts, showVisibleStoredAlerts, storedAlerts.length]);
 
   /**
    * Global keyboard shortcuts for mission control.

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -8,6 +8,7 @@ import { CommandDock } from '@/components/layout/CommandDock';
 import { FleetCard, VehicleWarning } from '@/components/cards/FleetCard';
 import { DetectionsCard } from '@/components/cards/DetectionsCard';
 import { ControlsCard } from '@/components/cards/ControlsCard';
+import { EmergencyStopControl } from '@/components/mission/EmergencyStopControl';
 import { MapScene3D, MapScene3DHandle } from '@/components/map/MapScene3D';
 import { FleetSheet } from '@/components/sheets/FleetSheet';
 import { DetectionSheet } from '@/components/sheets/DetectionSheet';
@@ -137,10 +138,12 @@ function V2PageContent() {
     canStart,
     canPause,
     canAbort,
+    abortUnavailableReason,
     hasValidStartZone,
     selectedPattern,
     setSelectedPattern,
     startMissionError,
+    abortMissionError,
     startMission,
     pauseMission,
     resumeMission,
@@ -618,6 +621,16 @@ function V2PageContent() {
         )
       }
 
+      topRightOverlay={icViewModeEnabled ? undefined : (
+        <EmergencyStopControl
+          missionPhase={missionPhase}
+          canAbort={canAbort}
+          abortUnavailableReason={abortUnavailableReason}
+          abortError={abortMissionError}
+          onAbort={abortMission}
+        />
+      )}
+
       zoneToolbar={icViewModeEnabled ? undefined : <ZoneToolbar />}
 
       commandDock={
@@ -669,7 +682,6 @@ function V2PageContent() {
               isPaused={isPaused}
               canStart={canStart}
               canPause={canPause}
-              canAbort={canAbort}
               hasValidStartZone={hasValidStartZone}
               selectedPattern={selectedPattern}
               setSelectedPattern={setSelectedPattern}
@@ -677,7 +689,6 @@ function V2PageContent() {
               onStart={startMission}
               onPause={pauseMission}
               onResume={resumeMission}
-              onAbort={abortMission}
             />
           )}
         />

--- a/software/viewer/src/components/alerts/AlertStack.tsx
+++ b/software/viewer/src/components/alerts/AlertStack.tsx
@@ -24,6 +24,7 @@ export interface Alert {
   };
   timestamp: Date;
   dismissible: boolean;
+  onDismiss?: () => void;
 }
 
 /**
@@ -104,7 +105,7 @@ function playCriticalAlertSound() {
  * @returns The alert ID for programmatic dismissal
  */
 export function showAlert(alert: Omit<Alert, 'timestamp'>, options?: { playSound?: boolean }) {
-  const { id, severity, title, description, action } = alert;
+  const { id, severity, title, description, action, onDismiss } = alert;
   const { playSound = true } = options || {};
 
   if (playSound && severity === 'critical') {
@@ -125,6 +126,7 @@ export function showAlert(alert: Omit<Alert, 'timestamp'>, options?: { playSound
       label: action.label,
       onClick: action.onClick,
     } : undefined,
+    onDismiss: onDismiss ? () => onDismiss() : undefined,
     classNames: {
       toast: cn(
         'group-[.toaster]:border-l-4',

--- a/software/viewer/src/components/cards/ControlsCard.tsx
+++ b/software/viewer/src/components/cards/ControlsCard.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ShimmerButton } from '@/components/ui/shimmer-button';
-import { Play, Pause, Square } from 'lucide-react';
+import { Play, Pause } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -27,7 +26,6 @@ export interface ControlsCardProps {
   isPaused: boolean;
   canStart: boolean;
   canPause: boolean;
-  canAbort: boolean;
   hasValidStartZone?: boolean;
   selectedPattern?: SearchPattern;
   setSelectedPattern?: (pattern: SearchPattern) => void;
@@ -35,7 +33,6 @@ export interface ControlsCardProps {
   onStart: () => void;
   onPause: () => void;
   onResume: () => void;
-  onAbort: () => void;
 }
 
 /**
@@ -43,15 +40,14 @@ export interface ControlsCardProps {
  *
  * UI/UX Decisions:
  * - ShimmerButton for START/NEW creates visual prominence for primary actions
- * - Two-step abort with countdown prevents accidental mission termination
+ * - Mission abort lives in the persistent shell emergency stop surface
  * - Pattern selector only visible in IDLE phase to prevent mid-mission changes
  * - Status message area provides contextual feedback on current state
  * - Warning/error messages appear inline to guide user corrections
  *
  * Safety Features:
- * - Abort requires confirmation (5-second countdown with cancel option)
  * - Disabled states prevent invalid actions for current phase
- * - Visual distinction between destructive (abort) and constructive (start) actions
+ * - Visual distinction between paused vs running mission states
  *
  * Accessibility:
  * - Buttons have clear labels with icons
@@ -63,7 +59,6 @@ export function ControlsCard({
   isPaused,
   canStart,
   canPause,
-  canAbort,
   hasValidStartZone = true,
   selectedPattern = 'lawnmower',
   setSelectedPattern,
@@ -71,45 +66,12 @@ export function ControlsCard({
   onStart,
   onPause,
   onResume,
-  onAbort,
 }: ControlsCardProps) {
-  const [abortCountdown, setAbortCountdown] = useState<number | null>(null);
-
   const isIdle = missionPhase === 'IDLE';
   const isActive =
     missionPhase === 'PLANNING' ||
     missionPhase === 'SEARCHING' ||
     missionPhase === 'TRACKING';
-
-  /**
-   * Abort countdown timer effect. Automatically triggers abort when countdown
-   * reaches zero. The 5-second window provides operators time to cancel
-   * accidental abort clicks while maintaining mission safety.
-   */
-  useEffect(() => {
-    if (abortCountdown === null) return;
-
-    const timer = setTimeout(() => {
-      setAbortCountdown((prev) => {
-        if (prev === null) return prev;
-        if (prev <= 1) {
-          onAbort();
-          return null;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearTimeout(timer);
-  }, [abortCountdown, onAbort]);
-
-  const handleAbortClick = useCallback(() => {
-    if (abortCountdown !== null) {
-      setAbortCountdown(null);
-    } else {
-      setAbortCountdown(5);
-    }
-  }, [abortCountdown]);
 
   return (
     <Card className="flex h-full flex-col justify-between p-4">
@@ -189,29 +151,6 @@ export function ControlsCard({
           </Button>
         )}
 
-        {/* ABORT button - Two-step confirmation prevents accidental mission termination */}
-        {isActive && (
-          <Button
-            variant="outline"
-            className={cn(
-              'flex-1 h-auto py-2.5 transition-all',
-              abortCountdown !== null
-                ? 'border-[var(--danger)] bg-[var(--danger)]/20 text-[var(--danger)]'
-                : 'border-[var(--danger)]/50 text-[var(--danger)] hover:bg-[var(--danger)]/10 hover:text-[var(--danger)]',
-              !canAbort && 'opacity-50'
-            )}
-            disabled={!canAbort}
-            onClick={handleAbortClick}
-          >
-            <Square className="mr-2 h-4 w-4 fill-current" />
-            {abortCountdown !== null ? (
-              <span className="font-mono">{abortCountdown}s</span>
-            ) : (
-              'ABORT'
-            )}
-          </Button>
-        )}
-
         {/* NEW button - Reset for next mission after completion or abort */}
         {(missionPhase === 'COMPLETE' || missionPhase === 'ABORTED') && (
           <ShimmerButton
@@ -233,9 +172,8 @@ export function ControlsCard({
       <div className="text-center">
         <span className="text-[10px] text-white/40">
           {isIdle && 'Ready to start mission'}
-          {isActive && !isPaused && abortCountdown === null && 'Mission in progress'}
+          {isActive && !isPaused && 'Mission in progress'}
           {isActive && isPaused && 'Mission paused'}
-          {isActive && abortCountdown !== null && 'Click again to cancel abort'}
           {missionPhase === 'COMPLETE' && 'Mission completed'}
           {missionPhase === 'ABORTED' && 'Mission aborted'}
         </span>

--- a/software/viewer/src/components/layout/GCSLayout.tsx
+++ b/software/viewer/src/components/layout/GCSLayout.tsx
@@ -22,6 +22,8 @@ interface GCSLayoutProps {
   pipFeed?: ReactNode;
   /** Optional alerts panel - top-right notification area */
   alerts?: ReactNode;
+  /** Optional top-right overlay for operator-only shell controls */
+  topRightOverlay?: ReactNode;
   /** Optional zone toolbar - top-center below status pill for zone drawing tools */
   zoneToolbar?: ReactNode;
   /** Presentation mode controls overlay spacing and read-only shell treatment */
@@ -57,6 +59,7 @@ export function GCSLayout({
   layersPanel,
   pipFeed,
   alerts,
+  topRightOverlay,
   zoneToolbar,
   viewMode = 'operator',
   statusToggle,
@@ -95,8 +98,9 @@ export function GCSLayout({
           </div>
         )}
 
-        {alerts && (
-          <div className="pointer-events-auto absolute right-4 top-20">
+        {(topRightOverlay || alerts) && (
+          <div className="pointer-events-auto absolute right-4 top-20 flex flex-col items-end gap-3">
+            {topRightOverlay}
             {alerts}
           </div>
         )}

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -9,7 +9,7 @@ import type { MissionPhase } from '@/components/layout/StatusPill';
 import {
   advanceEmergencyStopHold,
   beginEmergencyStopHold,
-  cancelEmergencyStopHold,
+  cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
 } from '@/lib/emergencyStopHold';
@@ -43,9 +43,9 @@ export function EmergencyStopControl({
     canAbort && !abortPending ? holdState : idleHoldState;
 
   const cancelHold = useCallback(() => {
-    setHoldState((current) =>
-      current.phase === 'holding' ? cancelEmergencyStopHold() : current
-    );
+    const nextState = cancelEmergencyStopHoldState(holdStateRef.current);
+    holdStateRef.current = nextState;
+    setHoldState(nextState);
   }, []);
 
   useEffect(() => {

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -10,6 +10,7 @@ import {
   beginEmergencyStopHold,
   cancelEmergencyStopHold,
   createIdleEmergencyStopHold,
+  isAbortRequestPending,
   tickEmergencyStopHold,
 } from '@/lib/emergencyStopHold';
 
@@ -31,10 +32,11 @@ export function EmergencyStopControl({
   const idleHoldState = useMemo(() => createIdleEmergencyStopHold(), []);
   const [holdState, setHoldState] = useState(createIdleEmergencyStopHold);
   const [abortRequested, setAbortRequested] = useState(false);
-  const abortPending =
-    abortRequested &&
-    !abortError &&
-    missionPhase !== 'ABORTED';
+  const abortPending = isAbortRequestPending({
+    abortRequested,
+    abortError,
+    missionPhase,
+  });
   const displayHoldState =
     canAbort && !abortPending ? holdState : idleHoldState;
 

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { MissionPhase } from '@/components/layout/StatusPill';
 import {
+  advanceEmergencyStopHold,
   beginEmergencyStopHold,
   cancelEmergencyStopHold,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
-  tickEmergencyStopHold,
 } from '@/lib/emergencyStopHold';
 
 interface EmergencyStopControlProps {
@@ -32,6 +32,8 @@ export function EmergencyStopControl({
   const idleHoldState = useMemo(() => createIdleEmergencyStopHold(), []);
   const [holdState, setHoldState] = useState(createIdleEmergencyStopHold);
   const [abortRequested, setAbortRequested] = useState(false);
+  const [abortDispatchNonce, setAbortDispatchNonce] = useState(0);
+  const holdStateRef = useRef(holdState);
   const abortPending = isAbortRequestPending({
     abortRequested,
     abortError,
@@ -47,40 +49,42 @@ export function EmergencyStopControl({
   }, []);
 
   useEffect(() => {
+    holdStateRef.current = holdState;
+  }, [holdState]);
+
+  useEffect(() => {
     if (holdState.phase !== 'holding') {
       return;
     }
 
     const tick = () => {
-      let shouldAbort = false;
-
-      setHoldState((current) => {
-        if (current.phase !== 'holding') {
-          return current;
-        }
-        if (!canAbort || abortPending) {
-          return idleHoldState;
-        }
-
-        const next = tickEmergencyStopHold(current, Date.now());
-        if (next.phase === 'completed') {
-          shouldAbort = true;
-          return idleHoldState;
-        }
-
-        return next;
+      const { nextState, shouldDispatchAbort } = advanceEmergencyStopHold({
+        state: holdStateRef.current,
+        now: Date.now(),
+        canAbort,
+        abortPending,
       });
+      holdStateRef.current = nextState;
+      setHoldState(nextState);
 
-      if (shouldAbort) {
+      if (shouldDispatchAbort) {
         setAbortRequested(true);
-        onAbort();
+        setAbortDispatchNonce((value) => value + 1);
       }
     };
 
     tick();
     const intervalId = window.setInterval(tick, 50);
     return () => window.clearInterval(intervalId);
-  }, [abortPending, canAbort, holdState.phase, idleHoldState, onAbort]);
+  }, [abortPending, canAbort, holdState.phase]);
+
+  useEffect(() => {
+    if (abortDispatchNonce === 0) {
+      return;
+    }
+
+    onAbort();
+  }, [abortDispatchNonce, onAbort]);
 
   useEffect(() => {
     if (holdState.phase !== 'holding') {

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { MissionPhase } from '@/components/layout/StatusPill';
+import {
+  beginEmergencyStopHold,
+  cancelEmergencyStopHold,
+  createIdleEmergencyStopHold,
+  tickEmergencyStopHold,
+} from '@/lib/emergencyStopHold';
+
+interface EmergencyStopControlProps {
+  missionPhase: MissionPhase;
+  canAbort: boolean;
+  abortUnavailableReason: string | null;
+  abortError?: string | null;
+  onAbort: () => void;
+}
+
+export function EmergencyStopControl({
+  missionPhase,
+  canAbort,
+  abortUnavailableReason,
+  abortError = null,
+  onAbort,
+}: EmergencyStopControlProps) {
+  const idleHoldState = useMemo(() => createIdleEmergencyStopHold(), []);
+  const [holdState, setHoldState] = useState(createIdleEmergencyStopHold);
+  const [abortRequested, setAbortRequested] = useState(false);
+  const abortPending =
+    abortRequested &&
+    !abortError &&
+    missionPhase !== 'ABORTED';
+  const displayHoldState =
+    canAbort && !abortPending ? holdState : idleHoldState;
+
+  const cancelHold = useCallback(() => {
+    setHoldState((current) =>
+      current.phase === 'holding' ? cancelEmergencyStopHold() : current
+    );
+  }, []);
+
+  useEffect(() => {
+    if (holdState.phase !== 'holding') {
+      return;
+    }
+
+    const tick = () => {
+      let shouldAbort = false;
+
+      setHoldState((current) => {
+        if (current.phase !== 'holding') {
+          return current;
+        }
+        if (!canAbort || abortPending) {
+          return idleHoldState;
+        }
+
+        const next = tickEmergencyStopHold(current, Date.now());
+        if (next.phase === 'completed') {
+          shouldAbort = true;
+          return idleHoldState;
+        }
+
+        return next;
+      });
+
+      if (shouldAbort) {
+        setAbortRequested(true);
+        onAbort();
+      }
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, 50);
+    return () => window.clearInterval(intervalId);
+  }, [abortPending, canAbort, holdState.phase, idleHoldState, onAbort]);
+
+  useEffect(() => {
+    if (holdState.phase !== 'holding') {
+      return;
+    }
+
+    const handleWindowBlur = () => cancelHold();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        cancelHold();
+      }
+    };
+
+    window.addEventListener('blur', handleWindowBlur);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('blur', handleWindowBlur);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [cancelHold, holdState.phase]);
+
+  const helperText = useMemo(() => {
+    if (abortPending) {
+      return 'Abort requested. Awaiting mission-state update.';
+    }
+    if (abortError) {
+      return abortError;
+    }
+    if (!canAbort) {
+      return abortUnavailableReason ?? 'Emergency stop is currently unavailable.';
+    }
+    if (displayHoldState.phase === 'holding') {
+      return 'Keep holding until the progress bar fills.';
+    }
+    return 'Press and hold to dispatch the fleet abort command.';
+  }, [abortError, abortPending, abortUnavailableReason, canAbort, displayHoldState.phase]);
+
+  const buttonLabel = abortPending
+    ? 'ABORT REQUESTED'
+    : displayHoldState.phase === 'holding'
+      ? 'KEEP HOLDING'
+      : 'EMERGENCY STOP';
+
+  return (
+    <div className="pointer-events-auto flex w-[248px] flex-col gap-2 rounded-lg border border-[var(--danger)]/60 bg-black/80 p-3 text-white shadow-[0_0_30px_rgba(0,0,0,0.45)]">
+      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--danger)]">
+        <AlertTriangle className="h-4 w-4" />
+        <span>Operator only</span>
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        className={cn(
+          'relative h-16 w-full overflow-hidden border-[var(--danger)] bg-[var(--danger)]/12 px-4 text-left text-white hover:bg-[var(--danger)]/18 hover:text-white',
+          'focus-visible:ring-[var(--danger)]/80',
+          (canAbort && !abortPending) || 'cursor-not-allowed opacity-70'
+        )}
+        disabled={!canAbort || abortPending}
+        aria-label="Press and hold emergency stop"
+        onPointerDown={(event) => {
+          if (event.pointerType === 'mouse' && event.button !== 0) {
+            return;
+          }
+          if (!canAbort || abortPending) {
+            return;
+          }
+          setAbortRequested(false);
+          setHoldState(beginEmergencyStopHold(Date.now()));
+        }}
+        onPointerUp={cancelHold}
+        onPointerLeave={cancelHold}
+        onPointerCancel={cancelHold}
+        onBlur={cancelHold}
+      >
+        <div className="absolute inset-x-0 bottom-0 px-4 pb-2">
+          <Progress
+            value={displayHoldState.progress * 100}
+            className="h-1.5 bg-white/10"
+            indicatorColor="danger"
+            aria-hidden="true"
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md border border-[var(--danger)]/50 bg-[var(--danger)]/18">
+            <AlertTriangle className="h-5 w-5" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-base font-semibold tracking-wide">{buttonLabel}</span>
+            <span className="text-xs uppercase tracking-[0.2em] text-white/70">
+              Press and hold
+            </span>
+          </div>
+        </div>
+      </Button>
+
+      <p className="min-h-[2.5rem] text-sm leading-5 text-white/85">{helperText}</p>
+    </div>
+  );
+}

--- a/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
+++ b/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
@@ -1,0 +1,119 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createElement } from "react";
+import ts from "typescript";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const RENDER_TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-emergency-stop-render-"));
+const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "..", "..", "node_modules");
+
+after(() => {
+  fs.rmSync(RENDER_TEMP_ROOT, { recursive: true, force: true });
+});
+
+fs.symlinkSync(VIEWER_NODE_MODULES, path.join(RENDER_TEMP_ROOT, "node_modules"), "dir");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "button.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Button({ children, className = "", disabled = false, ...props }) {
+    return _jsx("button", { className, disabled, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "progress.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Progress({ value = 0, className = "" }) {
+    return _jsx("div", { "data-progress": String(value), className });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "utils.mjs"), `
+  export function cn(...values) {
+    return values.flatMap((value) => Array.isArray(value) ? value : [value]).filter(Boolean).join(" ");
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "lucide-react.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function AlertTriangle({ className = "", ...props }) {
+    return _jsx("svg", { "data-icon": "AlertTriangle", className, ...props });
+  }
+`, "utf8");
+
+async function renderEmergencyStop(props) {
+  const sourcePath = path.join(ROOT, "EmergencyStopControl.tsx");
+  const holdModuleHref = pathToFileURL(path.resolve(ROOT, "..", "..", "lib", "emergencyStopHold.js")).href;
+  let source = fs.readFileSync(sourcePath, "utf8");
+  source = source
+    .replaceAll("@/components/ui/button", "./button.mjs")
+    .replaceAll("@/components/ui/progress", "./progress.mjs")
+    .replaceAll("@/lib/utils", "./utils.mjs")
+    .replaceAll("lucide-react", "./lucide-react.mjs")
+    .replaceAll("@/lib/emergencyStopHold", holdModuleHref);
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  }).outputText;
+
+  const modulePath = path.join(RENDER_TEMP_ROOT, `EmergencyStopControl-${Date.now()}.mjs`);
+  fs.writeFileSync(modulePath, compiled, "utf8");
+
+  const loaded = await import(pathToFileURL(modulePath).href);
+  return renderToStaticMarkup(createElement(loaded.EmergencyStopControl, props));
+}
+
+test("EmergencyStopControl renders the operator-only hold affordance", async () => {
+  const markup = await renderEmergencyStop({
+    missionPhase: "SEARCHING",
+    canAbort: true,
+    abortUnavailableReason: null,
+    abortError: null,
+    onAbort: () => {},
+  });
+
+  assert.match(markup, />Operator only</, "surface should stay clearly scoped to operators");
+  assert.match(markup, />EMERGENCY STOP</, "surface should render the persistent emergency stop button");
+  assert.match(
+    markup,
+    /Press and hold to dispatch the fleet abort command\./,
+    "surface should render the deliberate hold instructions in the default state"
+  );
+});
+
+test("EmergencyStopControl renders honest unavailable and error states", async () => {
+  const unavailableMarkup = await renderEmergencyStop({
+    missionPhase: "IDLE",
+    canAbort: false,
+    abortUnavailableReason: "Emergency stop is unavailable until a mission is active.",
+    abortError: null,
+    onAbort: () => {},
+  });
+  assert.match(
+    unavailableMarkup,
+    /Emergency stop is unavailable until a mission is active\./,
+    "surface should expose the supplied unavailable reason when abort is disabled"
+  );
+  assert.match(unavailableMarkup, /disabled/, "surface should disable the button when abort is unavailable");
+
+  const errorMarkup = await renderEmergencyStop({
+    missionPhase: "SEARCHING",
+    canAbort: true,
+    abortUnavailableReason: null,
+    abortError: "Mission abort was rejected by orchestrator.",
+    onAbort: () => {},
+  });
+  assert.match(
+    errorMarkup,
+    /Mission abort was rejected by orchestrator\./,
+    "surface should surface abort failures directly instead of masking them behind generic helper text"
+  );
+});

--- a/software/viewer/src/hooks/useMissionControl.ts
+++ b/software/viewer/src/hooks/useMissionControl.ts
@@ -12,6 +12,7 @@ import {
 } from '@/types/mission';
 import {
   computeMissionControlFlags,
+  getAbortMissionUnavailableReason,
   getAbortMissionValidationError,
   withServiceTimeout,
 } from '@/lib/missionControlBehavior';
@@ -49,6 +50,7 @@ export interface MissionControlState {
   canPause: boolean;
   canResume: boolean;
   canAbort: boolean;
+  abortUnavailableReason: string | null;
   hasValidStartZone: boolean;
   selectedPattern: SearchPattern;
   setSelectedPattern: (pattern: SearchPattern) => void;
@@ -122,6 +124,7 @@ export function useMissionControl(): MissionControlState {
     hasValidStartZone && startMissionError === INVALID_START_ZONE_ERROR
       ? null
       : startMissionError;
+  const missionId = state.missionId?.trim() ?? '';
 
   const updateSelectedPattern = useCallback((pattern: SearchPattern) => {
     setSelectedPattern(pattern);
@@ -444,6 +447,8 @@ export function useMissionControl(): MissionControlState {
 
     const missionId = state.missionId?.trim() ?? '';
     const validationError = getAbortMissionValidationError({
+      phase: state.phase,
+      pausedAt: state.pausedAt,
       rosConnected: rosConnected && !!ros,
       missionId,
     });
@@ -480,6 +485,8 @@ export function useMissionControl(): MissionControlState {
     callMissionService,
     ros,
     rosConnected,
+    state.pausedAt,
+    state.phase,
     state.missionId,
   ]);
 
@@ -515,6 +522,13 @@ export function useMissionControl(): MissionControlState {
       pausedAt: state.pausedAt,
       hasValidStartZone,
       rosConnected,
+      missionId,
+    });
+    const abortUnavailableReason = getAbortMissionUnavailableReason({
+      phase: state.phase,
+      pausedAt: state.pausedAt,
+      rosConnected,
+      missionId,
     });
 
     return {
@@ -527,9 +541,10 @@ export function useMissionControl(): MissionControlState {
       canPause: controlFlags.canPause,
       canResume: controlFlags.canResume,
       canAbort: controlFlags.canAbort,
+      abortUnavailableReason,
       hasValidStartZone,
     };
-  }, [rosConnected, hasValidStartZone, state.phase, state.pausedAt, state.missionId]);
+  }, [hasValidStartZone, missionId, rosConnected, state.missionId, state.phase, state.pausedAt]);
 
   return {
     ...computedState,
@@ -552,6 +567,7 @@ export function useMissionControl(): MissionControlState {
     setSelectedPattern: updateSelectedPattern,
     startMissionError: effectiveStartMissionError,
     abortMissionError,
+    abortUnavailableReason: computedState.abortUnavailableReason,
     rosConnected,
     vehicleSlamModes,
     vehicleMissionMeta,

--- a/software/viewer/src/hooks/useMissionControl.ts
+++ b/software/viewer/src/hooks/useMissionControl.ts
@@ -448,7 +448,6 @@ export function useMissionControl(): MissionControlState {
     const missionId = state.missionId?.trim() ?? '';
     const validationError = getAbortMissionValidationError({
       phase: state.phase,
-      pausedAt: state.pausedAt,
       rosConnected: rosConnected && !!ros,
       missionId,
     });
@@ -485,7 +484,6 @@ export function useMissionControl(): MissionControlState {
     callMissionService,
     ros,
     rosConnected,
-    state.pausedAt,
     state.phase,
     state.missionId,
   ]);
@@ -526,7 +524,6 @@ export function useMissionControl(): MissionControlState {
     });
     const abortUnavailableReason = getAbortMissionUnavailableReason({
       phase: state.phase,
-      pausedAt: state.pausedAt,
       rosConnected,
       missionId,
     });
@@ -536,7 +533,7 @@ export function useMissionControl(): MissionControlState {
       isActive: controlFlags.isActive,
       isPaused: controlFlags.isPaused,
       isComplete: controlFlags.isComplete,
-      missionId: state.missionId,
+      missionId: missionId || undefined,
       canStart: controlFlags.canStart,
       canPause: controlFlags.canPause,
       canResume: controlFlags.canResume,
@@ -544,7 +541,7 @@ export function useMissionControl(): MissionControlState {
       abortUnavailableReason,
       hasValidStartZone,
     };
-  }, [hasValidStartZone, missionId, rosConnected, state.missionId, state.phase, state.pausedAt]);
+  }, [hasValidStartZone, missionId, rosConnected, state.phase, state.pausedAt]);
 
   return {
     ...computedState,

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -20,6 +20,10 @@ export function cancelEmergencyStopHold() {
   return createIdleEmergencyStopHold();
 }
 
+export function cancelEmergencyStopHoldState(state) {
+  return state.phase === "holding" ? cancelEmergencyStopHold() : state;
+}
+
 export function isAbortRequestPending({
   abortRequested,
   abortError,

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -1,0 +1,43 @@
+export const HOLD_TO_ABORT_MS = 1500;
+
+export function createIdleEmergencyStopHold() {
+  return {
+    phase: "idle",
+    progress: 0,
+  };
+}
+
+export function beginEmergencyStopHold(now) {
+  return {
+    phase: "holding",
+    startedAt: now,
+    progress: 0,
+  };
+}
+
+export function cancelEmergencyStopHold() {
+  return createIdleEmergencyStopHold();
+}
+
+export function tickEmergencyStopHold(state, now, holdDurationMs = HOLD_TO_ABORT_MS) {
+  if (state.phase !== "holding") {
+    return state;
+  }
+
+  const elapsedMs = Math.max(0, now - state.startedAt);
+  const progress = Math.min(elapsedMs / holdDurationMs, 1);
+
+  if (progress >= 1) {
+    return {
+      phase: "completed",
+      progress: 1,
+      startedAt: state.startedAt,
+      completedAt: now,
+    };
+  }
+
+  return {
+    ...state,
+    progress,
+  };
+}

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -1,4 +1,5 @@
 export const HOLD_TO_ABORT_MS = 1500;
+const ACTIVE_ABORT_PHASES = new Set(["SEARCHING", "TRACKING"]);
 
 export function createIdleEmergencyStopHold() {
   return {
@@ -17,6 +18,14 @@ export function beginEmergencyStopHold(now) {
 
 export function cancelEmergencyStopHold() {
   return createIdleEmergencyStopHold();
+}
+
+export function isAbortRequestPending({
+  abortRequested,
+  abortError,
+  missionPhase,
+}) {
+  return abortRequested && !abortError && ACTIVE_ABORT_PHASES.has(missionPhase);
 }
 
 export function tickEmergencyStopHold(state, now, holdDurationMs = HOLD_TO_ABORT_MS) {

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -28,6 +28,35 @@ export function isAbortRequestPending({
   return abortRequested && !abortError && ACTIVE_ABORT_PHASES.has(missionPhase);
 }
 
+export function advanceEmergencyStopHold({
+  state,
+  now,
+  canAbort,
+  abortPending,
+  holdDurationMs = HOLD_TO_ABORT_MS,
+}) {
+  if (state.phase !== "holding") {
+    return {
+      nextState: state,
+      shouldDispatchAbort: false,
+    };
+  }
+
+  if (!canAbort || abortPending) {
+    return {
+      nextState: createIdleEmergencyStopHold(),
+      shouldDispatchAbort: false,
+    };
+  }
+
+  const nextState = tickEmergencyStopHold(state, now, holdDurationMs);
+  return {
+    nextState:
+      nextState.phase === "completed" ? createIdleEmergencyStopHold() : nextState,
+    shouldDispatchAbort: nextState.phase === "completed",
+  };
+}
+
 export function tickEmergencyStopHold(state, now, holdDurationMs = HOLD_TO_ABORT_MS) {
   if (state.phase !== "holding") {
     return state;

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -6,6 +6,7 @@ import {
   beginEmergencyStopHold,
   cancelEmergencyStopHold,
   createIdleEmergencyStopHold,
+  isAbortRequestPending,
   tickEmergencyStopHold,
 } from "./emergencyStopHold.js";
 
@@ -39,4 +40,39 @@ test("cancel events clear hold progress without dispatching completion", () => {
   assert.ok(ticking.progress > 0);
   assert.deepEqual(cancelled, createIdleEmergencyStopHold());
   assert.deepEqual(afterCancel, createIdleEmergencyStopHold());
+});
+
+test("abort request state clears once the mission leaves the active abort path", () => {
+  assert.equal(
+    isAbortRequestPending({
+      abortRequested: true,
+      abortError: null,
+      missionPhase: "SEARCHING",
+    }),
+    true
+  );
+  assert.equal(
+    isAbortRequestPending({
+      abortRequested: true,
+      abortError: null,
+      missionPhase: "ABORTED",
+    }),
+    false
+  );
+  assert.equal(
+    isAbortRequestPending({
+      abortRequested: true,
+      abortError: null,
+      missionPhase: "IDLE",
+    }),
+    false
+  );
+  assert.equal(
+    isAbortRequestPending({
+      abortRequested: true,
+      abortError: "Mission abort was rejected by orchestrator.",
+      missionPhase: "SEARCHING",
+    }),
+    false
+  );
 });

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  advanceEmergencyStopHold,
   HOLD_TO_ABORT_MS,
   beginEmergencyStopHold,
   cancelEmergencyStopHold,
@@ -28,6 +29,19 @@ test("hold progress completes only after the full dwell threshold", () => {
   assert.ok(beforeThreshold.progress < 1);
   assert.equal(completed.phase, "completed");
   assert.equal(completed.progress, 1);
+});
+
+test("advancing a completed hold emits one abort signal and resets local hold state", () => {
+  const started = beginEmergencyStopHold(500);
+  const result = advanceEmergencyStopHold({
+    state: started,
+    now: 500 + HOLD_TO_ABORT_MS,
+    canAbort: true,
+    abortPending: false,
+  });
+
+  assert.deepEqual(result.nextState, createIdleEmergencyStopHold());
+  assert.equal(result.shouldDispatchAbort, true);
 });
 
 test("cancel events clear hold progress without dispatching completion", () => {

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -6,6 +6,7 @@ import {
   HOLD_TO_ABORT_MS,
   beginEmergencyStopHold,
   cancelEmergencyStopHold,
+  cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
   tickEmergencyStopHold,
@@ -42,6 +43,14 @@ test("advancing a completed hold emits one abort signal and resets local hold st
 
   assert.deepEqual(result.nextState, createIdleEmergencyStopHold());
   assert.equal(result.shouldDispatchAbort, true);
+});
+
+test("cancelling from the current hold state yields idle state immediately", () => {
+  const holding = beginEmergencyStopHold(250);
+  const idle = createIdleEmergencyStopHold();
+
+  assert.deepEqual(cancelEmergencyStopHoldState(holding), idle);
+  assert.equal(cancelEmergencyStopHoldState(idle), idle);
 });
 
 test("cancel events clear hold progress without dispatching completion", () => {

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  HOLD_TO_ABORT_MS,
+  beginEmergencyStopHold,
+  cancelEmergencyStopHold,
+  createIdleEmergencyStopHold,
+  tickEmergencyStopHold,
+} from "./emergencyStopHold.js";
+
+test("quick tap never completes the emergency stop hold", () => {
+  beginEmergencyStopHold(100);
+  const released = cancelEmergencyStopHold();
+  const afterRelease = tickEmergencyStopHold(released, 100 + HOLD_TO_ABORT_MS);
+
+  assert.deepEqual(afterRelease, createIdleEmergencyStopHold());
+});
+
+test("hold progress completes only after the full dwell threshold", () => {
+  const started = beginEmergencyStopHold(500);
+  const beforeThreshold = tickEmergencyStopHold(started, 500 + HOLD_TO_ABORT_MS - 1);
+  const completed = tickEmergencyStopHold(started, 500 + HOLD_TO_ABORT_MS);
+
+  assert.equal(beforeThreshold.phase, "holding");
+  assert.ok(beforeThreshold.progress > 0.99);
+  assert.ok(beforeThreshold.progress < 1);
+  assert.equal(completed.phase, "completed");
+  assert.equal(completed.progress, 1);
+});
+
+test("cancel events clear hold progress without dispatching completion", () => {
+  const started = beginEmergencyStopHold(0);
+  const ticking = tickEmergencyStopHold(started, HOLD_TO_ABORT_MS / 2);
+  const cancelled = cancelEmergencyStopHold();
+  const afterCancel = tickEmergencyStopHold(cancelled, HOLD_TO_ABORT_MS * 2);
+
+  assert.equal(ticking.phase, "holding");
+  assert.ok(ticking.progress > 0);
+  assert.deepEqual(cancelled, createIdleEmergencyStopHold());
+  assert.deepEqual(afterCancel, createIdleEmergencyStopHold());
+});

--- a/software/viewer/src/lib/missionControlBehavior.d.ts
+++ b/software/viewer/src/lib/missionControlBehavior.d.ts
@@ -78,7 +78,6 @@ export function computeMissionControlFlags(args: {
  */
 export function getAbortMissionUnavailableReason(args: {
   phase: MissionControlPhase;
-  pausedAt: number | undefined;
   rosConnected: boolean;
   missionId: string | undefined;
 }): string | null;
@@ -95,7 +94,6 @@ export function getAbortMissionUnavailableReason(args: {
  */
 export function getAbortMissionValidationError(args: {
   phase?: MissionControlPhase | undefined;
-  pausedAt?: number | undefined;
   rosConnected: boolean;
   missionId: string | undefined;
 }): string | null;

--- a/software/viewer/src/lib/missionControlBehavior.d.ts
+++ b/software/viewer/src/lib/missionControlBehavior.d.ts
@@ -67,7 +67,21 @@ export function computeMissionControlFlags(args: {
   pausedAt: number | undefined;
   hasValidStartZone: boolean;
   rosConnected: boolean;
+  missionId?: string | undefined;
 }): MissionControlFlags;
+
+/**
+ * Reports why the emergency stop is unavailable, if it cannot be used.
+ *
+ * This is the canonical UI contract for disabled-state messaging so the
+ * persistent emergency stop and the service-call path stay aligned.
+ */
+export function getAbortMissionUnavailableReason(args: {
+  phase: MissionControlPhase;
+  pausedAt: number | undefined;
+  rosConnected: boolean;
+  missionId: string | undefined;
+}): string | null;
 
 /**
  * Validates preconditions for aborting a mission.
@@ -80,6 +94,8 @@ export function computeMissionControlFlags(args: {
  * @returns Error message if validation fails, null if abort is permitted
  */
 export function getAbortMissionValidationError(args: {
+  phase?: MissionControlPhase | undefined;
+  pausedAt?: number | undefined;
   rosConnected: boolean;
   missionId: string | undefined;
 }): string | null;

--- a/software/viewer/src/lib/missionControlBehavior.js
+++ b/software/viewer/src/lib/missionControlBehavior.js
@@ -6,12 +6,10 @@ export function isMissionPaused(phase, pausedAt) {
 
 export function getAbortMissionUnavailableReason({
   phase,
-  pausedAt,
   rosConnected,
   missionId,
 }) {
-  const abortableForPhase =
-    ACTIVE_PHASES.has(phase) || (ACTIVE_PHASES.has(phase) && pausedAt !== undefined);
+  const abortableForPhase = ACTIVE_PHASES.has(phase);
 
   if (!abortableForPhase) {
     return "Emergency stop is unavailable until a mission is active.";
@@ -41,7 +39,6 @@ export function computeMissionControlFlags({
   const isIdle = phase === "IDLE";
   const abortUnavailableReason = getAbortMissionUnavailableReason({
     phase,
-    pausedAt,
     rosConnected,
     missionId,
   });
@@ -59,13 +56,11 @@ export function computeMissionControlFlags({
 
 export function getAbortMissionValidationError({
   phase = "SEARCHING",
-  pausedAt,
   rosConnected,
   missionId,
 }) {
   return getAbortMissionUnavailableReason({
     phase,
-    pausedAt,
     rosConnected,
     missionId,
   });

--- a/software/viewer/src/lib/missionControlBehavior.js
+++ b/software/viewer/src/lib/missionControlBehavior.js
@@ -4,29 +4,19 @@ export function isMissionPaused(phase, pausedAt) {
   return ACTIVE_PHASES.has(phase) && pausedAt !== undefined;
 }
 
-export function computeMissionControlFlags({
+export function getAbortMissionUnavailableReason({
   phase,
   pausedAt,
-  hasValidStartZone,
   rosConnected,
+  missionId,
 }) {
-  const isActive = ACTIVE_PHASES.has(phase);
-  const isPaused = isMissionPaused(phase, pausedAt);
-  const isComplete = phase === "COMPLETE";
-  const isIdle = phase === "IDLE";
+  const abortableForPhase =
+    ACTIVE_PHASES.has(phase) || (ACTIVE_PHASES.has(phase) && pausedAt !== undefined);
 
-  return {
-    isActive,
-    isPaused,
-    isComplete,
-    canStart: isIdle && !isPaused && hasValidStartZone && rosConnected,
-    canPause: isActive && !isPaused,
-    canResume: isPaused,
-    canAbort: isActive || isPaused,
-  };
-}
+  if (!abortableForPhase) {
+    return "Emergency stop is unavailable until a mission is active.";
+  }
 
-export function getAbortMissionValidationError({ rosConnected, missionId }) {
   if (!rosConnected) {
     return "ROS is disconnected. Reconnect before aborting the mission.";
   }
@@ -36,6 +26,49 @@ export function getAbortMissionValidationError({ rosConnected, missionId }) {
   }
 
   return null;
+}
+
+export function computeMissionControlFlags({
+  phase,
+  pausedAt,
+  hasValidStartZone,
+  rosConnected,
+  missionId,
+}) {
+  const isActive = ACTIVE_PHASES.has(phase);
+  const isPaused = isMissionPaused(phase, pausedAt);
+  const isComplete = phase === "COMPLETE";
+  const isIdle = phase === "IDLE";
+  const abortUnavailableReason = getAbortMissionUnavailableReason({
+    phase,
+    pausedAt,
+    rosConnected,
+    missionId,
+  });
+
+  return {
+    isActive,
+    isPaused,
+    isComplete,
+    canStart: isIdle && !isPaused && hasValidStartZone && rosConnected,
+    canPause: isActive && !isPaused,
+    canResume: isPaused,
+    canAbort: abortUnavailableReason === null,
+  };
+}
+
+export function getAbortMissionValidationError({
+  phase = "SEARCHING",
+  pausedAt,
+  rosConnected,
+  missionId,
+}) {
+  return getAbortMissionUnavailableReason({
+    phase,
+    pausedAt,
+    rosConnected,
+    missionId,
+  });
 }
 
 export function withServiceTimeout(invoke, timeoutMs, label = "service call") {

--- a/software/viewer/src/lib/missionControlBehavior.test.mjs
+++ b/software/viewer/src/lib/missionControlBehavior.test.mjs
@@ -57,7 +57,6 @@ test("abort availability reports non-abortable phases before the emergency stop 
   assert.equal(
     getAbortMissionUnavailableReason({
       phase: "IDLE",
-      pausedAt: undefined,
       rosConnected: true,
       missionId: "mission-1",
     }),
@@ -67,7 +66,6 @@ test("abort availability reports non-abortable phases before the emergency stop 
   assert.equal(
     getAbortMissionUnavailableReason({
       phase: "SEARCHING",
-      pausedAt: Date.now(),
       rosConnected: true,
       missionId: "mission-1",
     }),

--- a/software/viewer/src/lib/missionControlBehavior.test.mjs
+++ b/software/viewer/src/lib/missionControlBehavior.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   computeMissionControlFlags,
+  getAbortMissionUnavailableReason,
   getAbortMissionValidationError,
   withServiceTimeout,
 } from "./missionControlBehavior.js";
@@ -26,6 +27,7 @@ test("SEARCHING phase remains abortable and resumable when paused", () => {
     pausedAt: Date.now(),
     hasValidStartZone: true,
     rosConnected: true,
+    missionId: "mission-1",
   });
 
   assert.equal(flags.isPaused, true);
@@ -48,6 +50,28 @@ test("abort validation enforces connectivity and mission id", () => {
       missionId: "   ",
     }),
     "Mission abort failed: active mission id is missing."
+  );
+});
+
+test("abort availability reports non-abortable phases before the emergency stop is armed", () => {
+  assert.equal(
+    getAbortMissionUnavailableReason({
+      phase: "IDLE",
+      pausedAt: undefined,
+      rosConnected: true,
+      missionId: "mission-1",
+    }),
+    "Emergency stop is unavailable until a mission is active."
+  );
+
+  assert.equal(
+    getAbortMissionUnavailableReason({
+      phase: "SEARCHING",
+      pausedAt: Date.now(),
+      rosConnected: true,
+      missionId: "mission-1",
+    }),
+    null
   );
 });
 


### PR DESCRIPTION
## Summary
- Move emergency stop into a persistent operator-only shell control.
- Require a deliberate press-and-hold gesture with visible progress and cancellation paths.
- Reuse the existing mission abort flow with clear unavailable, pending, and error states.

## Done
- Quick taps and canceled holds cannot dispatch abort.
- Completed holds dispatch exactly once through the existing mission abort path.
- Emergency stop remains visible outside the mission controls card and resets cleanly across mission state changes.

Closes #47

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the inline abort countdown in `ControlsCard` with a persistent, operator-only press-and-hold emergency stop surface (`EmergencyStopControl`) mounted outside the mission controls card via a new `topRightOverlay` slot in `GCSLayout`. The hold gesture is backed by a pure state machine in `emergencyStopHold.js`, and abort dispatch is correctly separated from the hold tick loop via a nonce-based `useEffect`.

- **New `EmergencyStopControl` component**: requires a deliberate 1.5-second hold with visible progress, Escape/blur cancellation, and clear unavailable/pending/error states; keyed by `missionPhase` to auto-reset on mission state transitions.
- **`missionControlBehavior.js` refactor**: introduces `getAbortMissionUnavailableReason` as the single source of truth for disabled-state messaging, used by both `computeMissionControlFlags` (for `canAbort`) and the new hook return value `abortUnavailableReason`.
- **`page.tsx` mock-alert refactor**: timestamps are now stable across reconnects, dismissed alert IDs are tracked in a ref, and a display-nonce prevents programmatic dismissals from being recorded as manual ones.

<h3>Confidence Score: 4/5</h3>

The hold-to-abort gesture and nonce dispatch are structurally sound, but the dispatch effect depends on the `onAbort` prop identity — a ROS reconnect while the nonce is live can retrigger `abortMission` and send a duplicate abort command to the fleet.

The core dispatch flow works correctly under normal conditions, but the `[abortDispatchNonce, onAbort]` dependency array means any identity change in `onAbort` (triggered by `ros`, `rosConnected`, or `missionId` changes inside `useMissionControl`) re-executes `onAbort()` while the nonce is still non-zero. For a drone fleet emergency stop, sending the abort command a second time during a ROS reconnect is the specific failure scenario. Fixing it requires one additional `useRef` line and removing `onAbort` from the dependency array.

software/viewer/src/components/mission/EmergencyStopControl.tsx — the dispatch effect at lines 81–87

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/viewer/src/components/mission/EmergencyStopControl.tsx | New hold-to-abort component with correct nonce-based dispatch pattern, but the dispatch effect depends on `onAbort` identity — causing a potential double-dispatch when `abortMission` is recreated (e.g. ROS reconnect) while the nonce is non-zero. |
| software/viewer/src/lib/emergencyStopHold.js | Pure state machine for the hold gesture — well-separated from React, fully testable, and the `advanceEmergencyStopHold` / `shouldDispatchAbort` signal pattern is sound. |
| software/viewer/src/lib/missionControlBehavior.js | Added `getAbortMissionUnavailableReason` and refactored `computeMissionControlFlags` to derive `canAbort` from it. `getAbortMissionValidationError`'s `phase = "SEARCHING"` default is a backward-compat shim; the only call site now passes phase explicitly, so it is low risk. |
| software/viewer/src/hooks/useMissionControl.ts | Adds `abortUnavailableReason` to the hook return and cleans up deps, but the inner `const missionId` inside `abortMission` was not removed after the outer binding was added, leaving a shadowing inconsistency. |
| software/viewer/src/components/cards/ControlsCard.tsx | Cleanly removes the old countdown abort button and its associated state/effect; `canAbort` and `onAbort` props are correctly dropped from the interface. |
| software/viewer/src/components/layout/GCSLayout.tsx | Minimal additive change: adds `topRightOverlay` slot and adjusts the right-column container to `flex-col` when either the overlay or alerts are present. |
| software/viewer/src/components/alerts/AlertStack.tsx | Adds optional `onDismiss` to the `Alert` interface and threads it through `showAlert`; the wrapper `() => onDismiss()` is unnecessary but harmless. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Op as Operator
    participant ESC as EmergencyStopControl
    participant Hold as emergencyStopHold
    participant Hook as useMissionControl
    participant ROS as ROS Service

    Op->>ESC: onPointerDown
    ESC->>Hold: beginEmergencyStopHold(now)
    loop every 50ms
        ESC->>Hold: advanceEmergencyStopHold(state, now, canAbort, abortPending)
        Hold-->>ESC: "{ nextState, shouldDispatchAbort }"
        alt "shouldDispatchAbort === true"
            ESC->>ESC: setAbortDispatchNonce(n+1)
            ESC->>ESC: setAbortRequested(true)
        end
    end
    note over ESC: useEffect fires on nonce change
    ESC->>Hook: onAbort() → abortMission()
    Hook->>ROS: abort_mission service call
    ROS-->>Hook: "{ success, message }"
    alt success
        Hook->>ESC: "abortMissionError = null"
        note over ESC: missionPhase → ABORTED resets component via key
    else failure
        Hook->>ESC: "abortMissionError = message"
        ESC->>ESC: "abortPending = false"
    end
    Op->>ESC: onPointerUp / Escape / blur
    ESC->>Hold: cancelEmergencyStopHoldState(state)
    Hold-->>ESC: idleHoldState
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
software/viewer/src/components/mission/EmergencyStopControl.tsx:81-87
`onAbort()` re-fires whenever `onAbort` changes identity while the dispatch nonce is non-zero. React's `useEffect` runs after every change to its dependency array. `onAbort` is `abortMission` from `useMissionControl`, which is recreated whenever `ros`, `rosConnected`, `state.missionId`, or `state.phase` changes. A ROS reconnect (new `ros` object) while `abortDispatchNonce` is already 1 causes a second call to `onAbort()` — the nonce guard only checks `=== 0`, not whether the nonce itself changed on this run. The result is a duplicate `abort_mission` service call sent to the fleet while the first is still in flight. Store `onAbort` in a ref so the dispatch effect depends only on the nonce.

```suggestion
  const onAbortRef = useRef(onAbort);
  useEffect(() => {
    onAbortRef.current = onAbort;
  }, [onAbort]);

  useEffect(() => {
    if (abortDispatchNonce === 0) {
      return;
    }

    onAbortRef.current();
  }, [abortDispatchNonce]);
```

### Issue 2 of 2
software/viewer/src/hooks/useMissionControl.ts:448-449
`missionId` is declared twice in the same function scope. A top-level `const missionId` was added for the `computedState` memo, but the identical expression `state.missionId?.trim() ?? ''` was left inside the `abortMission` callback. The inner declaration shadows the outer one; both evaluate identically, but the duplication increases the surface area for drift if `missionId` derivation ever needs to change. Remove the inner declaration and let the callback close over the outer binding.

```suggestion
    const validationError = getAbortMissionValidationError({
```

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["viewer: preserve mock alert visibility s..."](https://github.com/aeris-drones/aeris/commit/93cd1d23dc1b31aa95cb5c87ff280711610c626b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33445033)</sub>

<!-- /greptile_comment -->