### PR TITLE
Harden MAVLink command acknowledgements against UDP spoofing

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py
@@ -578,6 +578,19 @@ class MavlinkAdapter:
         return False
 
 
+    def _source_matches_partner(
+        self, source_host: str, source_port: int | None = None
+    ) -> bool:
+        if str(source_host) != self._host:
+            return False
+        if source_port is None:
+            return True
+
+        allowed_ports = {self._command_port}
+        if self._port != self._command_port:
+            allowed_ports.add(self._port)
+        return int(source_port) in allowed_ports
+
     def _message_matches_partner(self, message) -> bool:
         source_addr = getattr(message, "source_addr", None)
         if not isinstance(source_addr, tuple) or not source_addr:
@@ -586,12 +599,25 @@ class MavlinkAdapter:
             return True
 
         source_host = str(source_addr[0])
-        source_port = int(source_addr[1]) if len(source_addr) > 1 else None
-        if source_host != self._host:
+        try:
+            source_port = int(source_addr[1]) if len(source_addr) > 1 else None
+        except (TypeError, ValueError):
             return False
-        if source_port is not None and source_port != self._command_port:
-            return False
-        return True
+        return self._source_matches_partner(source_host, source_port)
+
+    def _clients_include_partner(self, clients: set[object]) -> bool:
+        for client in clients:
+            if isinstance(client, tuple) and client:
+                source_host = str(client[0])
+                try:
+                    source_port = int(client[1]) if len(client) > 1 else None
+                except (TypeError, ValueError):
+                    continue
+                if self._source_matches_partner(source_host, source_port):
+                    return True
+            elif isinstance(client, str) and self._source_matches_partner(client):
+                return True
+        return False
 
     def _message_matches_target(self, message) -> bool:
         """Check if a MAVLink message originates from the target system.
@@ -729,7 +755,7 @@ class MavlinkAdapter:
 
         with self._connection_lock:
             clients = getattr(self._mav_connection, "clients", None)
-            if isinstance(clients, set) and clients:
+            if isinstance(clients, set) and self._clients_include_partner(clients):
                 self._partner_ready = True
                 return True
 

--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py
@@ -542,6 +542,8 @@ class MavlinkAdapter:
                 return None
             if not self._message_matches_target(ack):
                 continue
+            if not self._message_matches_partner(ack):
+                continue
             if int(getattr(ack, "command", -1)) != command_id:
                 continue
             return ack
@@ -569,9 +571,27 @@ class MavlinkAdapter:
                 return False
             if not self._message_matches_target(heartbeat):
                 continue
+            if not self._message_matches_partner(heartbeat):
+                continue
             if self._heartbeat_indicates_rtl(heartbeat):
                 return True
         return False
+
+
+    def _message_matches_partner(self, message) -> bool:
+        source_addr = getattr(message, "source_addr", None)
+        if not isinstance(source_addr, tuple) or not source_addr:
+            # Some pymavlink transports do not provide socket peer metadata.
+            # Preserve existing behavior in those cases.
+            return True
+
+        source_host = str(source_addr[0])
+        source_port = int(source_addr[1]) if len(source_addr) > 1 else None
+        if source_host != self._host:
+            return False
+        if source_port is not None and source_port != self._command_port:
+            return False
+        return True
 
     def _message_matches_target(self, message) -> bool:
         """Check if a MAVLink message originates from the target system.
@@ -733,7 +753,7 @@ class MavlinkAdapter:
                 self._logger(f"MAVLink endpoint handshake failed: {error}")
                 return False
 
-            if message is not None:
+            if message is not None and self._message_matches_partner(message):
                 self._partner_ready = True
                 return True
 

--- a/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
@@ -76,14 +76,16 @@ class _FakeConnection:
 
 
 class _FakeAck:
-    def __init__(self, command: int, result: int) -> None:
+    def __init__(self, command: int, result: int, source_addr=None) -> None:
         self.command = command
         self.result = result
+        self.source_addr = source_addr
 
 
 class _FakeHeartbeat:
-    def __init__(self, custom_mode: int) -> None:
+    def __init__(self, custom_mode: int, source_addr=None) -> None:
         self.custom_mode = custom_mode
+        self.source_addr = source_addr
 
 
 def _px4_rtl_custom_mode() -> int:
@@ -425,4 +427,38 @@ def test_adapter_sends_commands_to_command_port_when_it_differs(monkeypatch) -> 
     assert connections[1].mav.command_long_calls
     assert connections[1].mav.command_long_calls[0][0] == 2
     assert not connections[0].mav.command_long_calls
+    adapter.close()
+
+
+def test_adapter_rejects_spoofed_partner_messages_on_split_command_port(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14541, command_port=14581, stream_hz=20.0)
+
+    connections[0].messages_by_type.setdefault("__any__", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode(), source_addr=("127.0.0.2", 14581))
+    )
+    connections[0].messages_by_type.setdefault("COMMAND_ACK", []).append(
+        _FakeAck(
+            mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+            mavutil.mavlink.MAV_RESULT_ACCEPTED,
+            source_addr=("127.0.0.2", 14581),
+        )
+    )
+    connections[0].messages_by_type.setdefault("HEARTBEAT", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode(), source_addr=("127.0.0.2", 14581))
+    )
+
+    assert not adapter.send_return_to_launch()
     adapter.close()

--- a/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py
@@ -462,3 +462,49 @@ def test_adapter_rejects_spoofed_partner_messages_on_split_command_port(monkeypa
 
     assert not adapter.send_return_to_launch()
     adapter.close()
+
+
+def test_adapter_does_not_trust_unmatched_udpin_clients(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14541, command_port=14581, stream_hz=20.0)
+    connections[0].clients = {("127.0.0.2", 14581)}
+
+    assert not adapter._ensure_partner_ready(timeout_sec=0.0)
+    assert not adapter._partner_ready
+    adapter.close()
+
+
+def test_adapter_accepts_partner_handshake_from_stream_port(monkeypatch) -> None:
+    connections: list[_FakeConnection] = []
+
+    def _fake_connection(endpoint: str, source_system: int, source_component: int):
+        del source_system, source_component
+        conn = _FakeConnection(endpoint)
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(
+        "aeris_orchestrator.mavlink_adapter.mavutil.mavlink_connection",
+        _fake_connection,
+    )
+
+    adapter = MavlinkAdapter(host="127.0.0.1", port=14541, command_port=14581, stream_hz=20.0)
+    connections[0].messages_by_type.setdefault("__any__", []).append(
+        _FakeHeartbeat(_px4_rtl_custom_mode(), source_addr=("127.0.0.1", 14541))
+    )
+
+    assert adapter._ensure_partner_ready(timeout_sec=0.01)
+    assert adapter._partner_ready
+    adapter.close()


### PR DESCRIPTION
### Motivation
- A split `command_port` path opened a wildcard UDP listener and accepted any incoming MAVLink packet as partner readiness or command acknowledgment, allowing an on-network host to spoof `COMMAND_ACK` and `HEARTBEAT` and falsely confirm safety-critical commands. 
- The change aims to ensure partner priming and command completion only accept messages from the configured UDP peer when transport metadata is available.

### Description
- Added a centralized `_message_matches_partner(message)` helper that checks `message.source_addr` against the configured `host` and `command_port`, while preserving behavior for transports that do not expose peer metadata. 
- Tightened readiness priming in `_ensure_partner_ready` to only mark the partner ready when an observed message also passes `_message_matches_partner`. 
- Applied partner-source validation to `_wait_for_command_ack` and `_wait_for_heartbeat_rtl` so `COMMAND_ACK` and RTL-confirming `HEARTBEAT` messages must come from the configured peer. 
- Added a regression test `test_adapter_rejects_spoofed_partner_messages_on_split_command_port` that simulates spoofed packets from a non-configured source and verifies an RTL command is rejected.

### Testing
- Ran `pytest -q software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py` to exercise the adapter tests, but test collection failed with `ModuleNotFoundError: No module named 'pymavlink'` in this environment, so automated test execution could not complete. 
- The new regression test was added to the existing test file and is ready to run in CI or a developer environment with the `pymavlink` dependency installed. 
- Static inspection and local test harnesses using the repository's `_FakeConnection` stubs were used to validate the new partner-matching logic and that behavior is preserved when `source_addr` metadata is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ae8d8e408326914bc4a6f243a56d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verify inbound COMMAND_ACK and HEARTBEAT messages originate from the configured partner endpoint before use.
  * Tighten partner-readiness checks to only mark a partner ready after a valid handshake from the expected endpoint.

* **Tests**
  * Added tests to reject spoofed partner messages.
  * Added tests ensuring unmatched endpoints are not trusted and valid handshakes from the expected stream port are accepted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds UDP source-address validation to the MAVLink adapter's split command-port path, preventing on-network hosts from spoofing `COMMAND_ACK` or `HEARTBEAT` messages to falsely confirm safety-critical commands such as RTL.

- A new `_message_matches_partner` helper compares `message.source_addr` against `self._host` / `self._command_port`, returning `True` when transport metadata is absent to preserve behaviour for non-UDP connections.
- The check is wired into `_wait_for_command_ack`, `_wait_for_heartbeat_rtl`, and the message-based branch of `_ensure_partner_ready`.
- A regression test (`test_adapter_rejects_spoofed_partner_messages_on_split_command_port`) queues spoofed packets from `127.0.0.2` and asserts `send_return_to_launch()` returns `False`.

<h3>Confidence Score: 3/5</h3>

The COMMAND_ACK and HEARTBEAT spoofing vectors on the safety-critical command path are correctly closed, but the `clients`-set early-return in `_ensure_partner_ready` lets any UDP packet from any source mark the partner as ready without IP validation, partially undermining the hardening goal for the streaming path.

The new `_message_matches_partner` guard works correctly in `_wait_for_command_ack` and `_wait_for_heartbeat_rtl`, and the regression test validates COMMAND_ACK rejection. However, `_ensure_partner_ready` has a separate early-return branch (the pymavlink `clients` set) that fires before `_message_matches_partner` is consulted — any attacker packet reaching the wildcard UDP listener satisfies it, setting `_partner_ready = True` without source validation. Additionally, the test's `__any__` heartbeat is never consumed during the test flow, so partner-priming spoofing is not actually exercised by the new test.

Both changed files need attention: `mavlink_adapter.py` for the `clients`-set bypass in `_ensure_partner_ready`, and `test_mavlink_adapter.py` to add a test that actually exercises the partner-priming code path with a spoofed source.

<details open><summary><h3>Security Review</h3></summary>

- **Partner-priming bypass via `clients` set** (`mavlink_adapter.py` lines 730–734): the `udpin` socket's `clients` set is populated by any arriving UDP datagram regardless of source. An attacker that sends one packet to the stream port satisfies this early-return before `_message_matches_partner` is ever called, setting `_partner_ready = True` without IP validation.
- The `_wait_for_command_ack` and `_wait_for_heartbeat_rtl` guards are correctly applied and close the COMMAND_ACK / HEARTBEAT spoofing vector for safety-critical commands.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py | Adds `_message_matches_partner` to validate UDP source IP/port on COMMAND_ACK, HEARTBEAT, and partner-priming messages. The `_wait_for_command_ack` and `_wait_for_heartbeat_rtl` guards are correct, but `_ensure_partner_ready` still has an early-return path via the pymavlink `clients` set that accepts any packet from any source without invoking the new check, leaving a bypass in the streaming-readiness path. |
| software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py | Adds `source_addr` to `_FakeAck` / `_FakeHeartbeat` and a new regression test for split-port spoofing. The test correctly verifies COMMAND_ACK rejection, but the `__any__` heartbeat placed in the queue is never consumed during the test flow, so partner-priming spoofing (via `_ensure_partner_ready`) is not actually exercised. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Attacker as Attacker (127.0.0.2)
    participant GCS as GCS (MavlinkAdapter)
    participant Drone as Drone (127.0.0.1:14581)

    note over GCS: Split-port mode<br/>_mav_connection = udpin:0.0.0.0:14541<br/>_command_connection = udpout:127.0.0.1:14581

    GCS->>Drone: command_long_send (RTL) via _command_connection
    Attacker-->>GCS: "COMMAND_ACK (spoofed, source=127.0.0.2:14581)"
    GCS->>GCS: "_message_matches_partner()<br/>source_host 127.0.0.2 != 127.0.0.1 → False, rejected"

    Drone->>GCS: "COMMAND_ACK (source=127.0.0.1:14581)"
    GCS->>GCS: _message_matches_partner() host+port match → accepted

    GCS->>GCS: _wait_for_heartbeat_rtl()
    Attacker-->>GCS: "HEARTBEAT (spoofed, source=127.0.0.2:14581)"
    GCS->>GCS: _message_matches_partner() → False, rejected

    Drone->>GCS: "HEARTBEAT RTL mode (source=127.0.0.1:14581)"
    GCS->>GCS: _message_matches_partner() + _heartbeat_indicates_rtl() → confirmed

    note over GCS: Bypass path still open<br/>Attacker UDP packet to stream port<br/>populates clients set<br/>_ensure_partner_ready returns True<br/>without calling _message_matches_partner
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py`, line 730-734 ([link](https://github.com/aeris-drones/aeris/blob/822048e8d128e6900ea52a22d217e084366cfcbc/software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py#L730-L734)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **`clients` early-return bypasses `_message_matches_partner`**

   The `clients` set is populated by pymavlink's `udpin` socket whenever any UDP datagram arrives, regardless of source. An on-network attacker can send a single garbage packet to `udpin:0.0.0.0:{port}`, their address is added to `clients`, and this branch fires — setting `_partner_ready = True` without touching `_message_matches_partner`. In split-port mode the streaming thread calls `_ensure_partner_ready` via `_stream_loop`; once `_partner_ready` is set here it is never re-validated, so the adapter begins streaming setpoints to the vehicle based on a spoofed readiness signal. The `clients` set should be filtered for the configured host before trusting it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py
   Line: 730-734

   Comment:
   **`clients` early-return bypasses `_message_matches_partner`**

   The `clients` set is populated by pymavlink's `udpin` socket whenever any UDP datagram arrives, regardless of source. An on-network attacker can send a single garbage packet to `udpin:0.0.0.0:{port}`, their address is added to `clients`, and this branch fires — setting `_partner_ready = True` without touching `_message_matches_partner`. In split-port mode the streaming thread calls `_ensure_partner_ready` via `_stream_loop`; once `_partner_ready` is set here it is never re-validated, so the adapter begins streaming setpoints to the vehicle based on a spoofed readiness signal. The `clients` set should be filtered for the configured host before trusting it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py:730-734
**`clients` early-return bypasses `_message_matches_partner`**

The `clients` set is populated by pymavlink's `udpin` socket whenever any UDP datagram arrives, regardless of source. An on-network attacker can send a single garbage packet to `udpin:0.0.0.0:{port}`, their address is added to `clients`, and this branch fires — setting `_partner_ready = True` without touching `_message_matches_partner`. In split-port mode the streaming thread calls `_ensure_partner_ready` via `_stream_loop`; once `_partner_ready` is set here it is never re-validated, so the adapter begins streaming setpoints to the vehicle based on a spoofed readiness signal. The `clients` set should be filtered for the configured host before trusting it.

### Issue 2 of 3
software/edge/src/aeris_orchestrator/test/test_mavlink_adapter.py:449-451
**`__any__` spoofed heartbeat is never consumed by the test flow**

When `command_port != port`, `_command_connection` is not `None`, so `_send_command_with_ack` skips the `_ensure_partner_ready` call entirely. The heartbeat pushed into the `__any__` queue is therefore never polled during `send_return_to_launch()`, and the test passes because the spoofed `COMMAND_ACK` is rejected — not because partner-priming spoofing was validated. This creates false confidence that `_ensure_partner_ready` is covered by the new regression test; a test that actually calls `_ensure_partner_ready` with a spoofed `__any__` message (and separately exercises the `clients`-set bypass) would be needed to close that gap.

### Issue 3 of 3
software/edge/src/aeris_orchestrator/aeris_orchestrator/mavlink_adapter.py:581-582
**`_message_matches_partner` is missing a docstring**

Every other private helper in this class carries a docstring; `_message_matches_partner` is the only one that doesn't. Without one, a reader can't immediately tell that the method intentionally returns `True` when `source_addr` is absent (preserving behaviour for non-UDP transports).

```suggestion
    def _message_matches_partner(self, message) -> bool:
        """Check if a MAVLink message originates from the configured partner.

        Validates the message's UDP source address against the configured host
        and command port. Returns True unconditionally when the transport does
        not expose peer metadata (e.g. pymavlink udpout connections), preserving
        existing behaviour for those transports.

        Args:
            message: MAVLink message object to validate.

        Returns:
            True if the message source matches the partner or source metadata
            is unavailable; False if the source IP or port does not match.
        """
        source_addr = getattr(message, "source_addr", None)
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Harden MAVLink partner validation for sp..."](https://github.com/aeris-drones/aeris/commit/822048e8d128e6900ea52a22d217e084366cfcbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531253)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->