### PR TITLE
viewer: preserve emergency-stop hold across mission phase churn

### DIFF
--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -164,10 +164,10 @@ test("IC mode keeps one canonical page-shell flag and propagates it", () => {
     /<EmergencyStopControl[\s\S]*onAbort=\{abortMission\}/,
     "page should route the persistent control through the existing abortMission callback"
   );
-  assert.match(
+  assert.doesNotMatch(
     source,
     /<EmergencyStopControl[\s\S]*key=\{missionPhase\}/,
-    "mission-phase changes should reset the emergency-stop hold and pending state"
+    "emergency-stop hold state must persist across active mission-phase transitions"
   );
 });
 

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -673,7 +673,6 @@ function V2PageContent() {
 
       topRightOverlay={icViewModeEnabled ? undefined : (
         <EmergencyStopControl
-          key={missionPhase}
           missionPhase={missionPhase}
           canAbort={canAbort}
           abortUnavailableReason={abortUnavailableReason}

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -12,6 +12,7 @@ import {
   cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
+  shouldResetAbortRequest,
 } from '@/lib/emergencyStopHold';
 
 interface EmergencyStopControlProps {
@@ -56,6 +57,13 @@ export function EmergencyStopControl({
   useEffect(() => {
     onAbortRef.current = onAbort;
   }, [onAbort]);
+
+  useEffect(() => {
+    if (!shouldResetAbortRequest({ abortRequested, missionPhase })) {
+      return;
+    }
+    setAbortRequested(false);
+  }, [abortRequested, missionPhase]);
 
   useEffect(() => {
     if (holdState.phase !== 'holding') {

--- a/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
+++ b/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
@@ -136,4 +136,13 @@ test("EmergencyStopControl dispatches abort only from nonce changes", () => {
     /onAbortRef\.current\(\);\s*\}, \[abortDispatchNonce\]\);/s,
     "abort dispatch effect should only depend on the dispatch nonce"
   );
+  assert.ok(
+    source.includes("shouldResetAbortRequest({ abortRequested, missionPhase })"),
+    "control should explicitly clear stale abort-request state when the mission leaves the active abort lifecycle"
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*if \(!shouldResetAbortRequest\([\s\S]*?\)\) \{\s*return;\s*\}\s*setAbortRequested\(false\);\s*\}, \[abortRequested, missionPhase\]\);/s,
+    "control should reset abortRequested from a phase-change effect instead of waiting for a remount"
+  );
 });

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -32,6 +32,13 @@ export function isAbortRequestPending({
   return abortRequested && !abortError && ACTIVE_ABORT_PHASES.has(missionPhase);
 }
 
+export function shouldResetAbortRequest({
+  abortRequested,
+  missionPhase,
+}) {
+  return abortRequested && !ACTIVE_ABORT_PHASES.has(missionPhase);
+}
+
 export function advanceEmergencyStopHold({
   state,
   now,

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -9,6 +9,7 @@ import {
   cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
+  shouldResetAbortRequest,
   tickEmergencyStopHold,
 } from "./emergencyStopHold.js";
 
@@ -95,6 +96,37 @@ test("abort request state clears once the mission leaves the active abort path",
       abortRequested: true,
       abortError: "Mission abort was rejected by orchestrator.",
       missionPhase: "SEARCHING",
+    }),
+    false
+  );
+});
+
+test("abort request resets once the mission leaves active abort phases", () => {
+  assert.equal(
+    shouldResetAbortRequest({
+      abortRequested: true,
+      missionPhase: "ABORTED",
+    }),
+    true
+  );
+  assert.equal(
+    shouldResetAbortRequest({
+      abortRequested: true,
+      missionPhase: "IDLE",
+    }),
+    true
+  );
+  assert.equal(
+    shouldResetAbortRequest({
+      abortRequested: true,
+      missionPhase: "SEARCHING",
+    }),
+    false
+  );
+  assert.equal(
+    shouldResetAbortRequest({
+      abortRequested: false,
+      missionPhase: "ABORTED",
     }),
     false
   );


### PR DESCRIPTION
### Motivation
- A `key={missionPhase}` was causing `EmergencyStopControl` to remount on every mission phase update, which reset its local hold and `abortRequested` state and allowed rapid phase churn to cancel an in-progress hold-to-abort before `onAbort` could fire.
- This behavior degrades availability of the emergency abort command during active missions and is a security-relevant availability issue.

### Description
- Removed the `key={missionPhase}` prop from `EmergencyStopControl` in `software/viewer/src/app/page.tsx` so React no longer remounts the control on phase transitions.
- Updated `software/viewer/src/app/icViewModeSurface.test.mjs` to assert that `EmergencyStopControl` is not keyed by `missionPhase` by replacing the previous `assert.match` with `assert.doesNotMatch` and adjusted the assertion message accordingly.
- Preserves existing emergency-stop behavior while ensuring hold progress and `abortRequested` state persist across active mission-phase changes.

### Testing
- Executed `node --test software/viewer/src/lib/emergencyStopHold.test.mjs software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs software/viewer/src/app/icViewModeSurface.test.mjs` and all tests passed (`14/14`).
- Surface tests verify the control renders and the source-level assertion ensures the control is not keyed by mission phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bee4915c8326ae982f7c7bbdcfb7)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Using `key` tied to mission phase was causing EmergencyStopControl to unmount on every phase transition, resetting in-progress hold and abort state before the abort could fire. Removing that prop lets React preserve the component instance while still receiving updated props.

- `page.tsx`: one-line removal stops the component from remounting on phase updates; `missionPhase` is still forwarded so phase-gated internal logic is unaffected.
- `icViewModeSurface.test.mjs`: assertion flipped to `doesNotMatch` with an updated message to encode the new invariant.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is correct and the internal hold logic already handles canAbort transitions gracefully.

The one-line removal correctly stops React from tearing down EmergencyStopControl on phase changes, and advanceEmergencyStopHold already resets to idle when canAbort is false or abortPending is true, so no double-fire or runaway timer risk. The minor open question is that abortRequested is never cleared by a phase transition, which is a new behavioral difference introduced by removing the key reset.

No files require special attention beyond the note about stale abortRequested state in page.tsx.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/viewer/src/app/page.tsx | Removes the remount-on-phase-change trigger from EmergencyStopControl so hold and abort state survive phase transitions. The missionPhase prop is still forwarded, so phase-aware logic in the component continues to work correctly. |
| software/viewer/src/app/icViewModeSurface.test.mjs | Flips the key-assertion from assert.match to assert.doesNotMatch and updates the message to reflect the new invariant; change is mechanically correct and consistent with the page.tsx edit. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ESC as EmergencyStopControl
    participant Timer as Hold Timer
    participant Page as Page Shell

    Note over ESC: Before this PR
    User->>ESC: pointer down, hold begins
    Timer->>ESC: progress advances to 80%
    Page-->>ESC: phase prop changes, React unmounts + remounts
    Note over ESC: holdState and abortRequested reset to idle

    Note over ESC: After this PR
    User->>ESC: pointer down, hold begins
    Timer->>ESC: progress advances to 80%
    Page-->>ESC: phase prop changes, React re-renders only
    Note over ESC: holdState preserved, timer continues
    Timer->>ESC: hold completes, shouldDispatchAbort true
    ESC->>Page: onAbort fires successfully
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `software/viewer/src/app/page.tsx`, line 675-681 ([link](https://github.com/aeris-drones/aeris/blob/28c194c15c87e9999f7e7090c37d37550713a15a/software/viewer/src/app/page.tsx#L675-L681)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale `abortRequested` flag on phase cycling**

   `abortRequested` is never reset by a phase transition — only by the next `onPointerDown` event. With the `key` removed, if the mission phase cycles back to `SEARCHING` or `TRACKING` after a completed abort (rare but possible during contingency replanning), `isAbortRequestPending` will return `true` again and the button will display "ABORT REQUESTED" as if a fresh abort is still in flight, even though `onAbort` has already fired. The timer tick will then immediately reset `holdState` to idle (because `abortPending` is true), so no double-fire occurs — but the brief misleading state could confuse an operator during a critical moment. Consider resetting `abortRequested` to `false` whenever `missionPhase` exits an active-abort phase.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/app/page.tsx
   Line: 675-681

   Comment:
   **Stale `abortRequested` flag on phase cycling**

   `abortRequested` is never reset by a phase transition — only by the next `onPointerDown` event. With the `key` removed, if the mission phase cycles back to `SEARCHING` or `TRACKING` after a completed abort (rare but possible during contingency replanning), `isAbortRequestPending` will return `true` again and the button will display "ABORT REQUESTED" as if a fresh abort is still in flight, even though `onAbort` has already fired. The timer tick will then immediately reset `holdState` to idle (because `abortPending` is true), so no double-fire occurs — but the brief misleading state could confuse an operator during a critical moment. Consider resetting `abortRequested` to `false` whenever `missionPhase` exits an active-abort phase.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/viewer/src/app/page.tsx:675-681
**Stale `abortRequested` flag on phase cycling**

`abortRequested` is never reset by a phase transition — only by the next `onPointerDown` event. With the `key` removed, if the mission phase cycles back to `SEARCHING` or `TRACKING` after a completed abort (rare but possible during contingency replanning), `isAbortRequestPending` will return `true` again and the button will display "ABORT REQUESTED" as if a fresh abort is still in flight, even though `onAbort` has already fired. The timer tick will then immediately reset `holdState` to idle (because `abortPending` is true), so no double-fire occurs — but the brief misleading state could confuse an operator during a critical moment. Consider resetting `abortRequested` to `false` whenever `missionPhase` exits an active-abort phase.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["viewer: keep emergency stop state across..."](https://github.com/aeris-drones/aeris/commit/28c194c15c87e9999f7e7090c37d37550713a15a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531264)</sub>

<!-- /greptile_comment -->