### PR TITLE
Fix ABR startup regression and harden ACK parsing

### DIFF
--- a/software/edge/config/srt/abr_ladder.yaml
+++ b/software/edge/config/srt/abr_ladder.yaml
@@ -52,20 +52,20 @@ ladder:
     gop: 60
     fps: 30
 
-  # Maximum quality for detailed survey missions
-  - name: survey_1080p
-    resolution: 1920x1080
-    target_bitrate_kbps: 5200
-    max_bitrate_kbps: 6500
-    gop: 60
-    fps: 30
-
   # Higher bitrate 720p for low-light noise reduction
   - name: lowlight_720p
     resolution: 1280x720
     target_bitrate_kbps: 4200
     max_bitrate_kbps: 5200
     gop: 30  # Shorter GOP for faster recovery
+    fps: 30
+
+  # Maximum quality for detailed survey missions
+  - name: survey_1080p
+    resolution: 1920x1080
+    target_bitrate_kbps: 5200
+    max_bitrate_kbps: 6500
+    gop: 60
     fps: 30
 
 # Global streaming constraints

--- a/software/edge/config/srt/abr_ladder.yaml
+++ b/software/edge/config/srt/abr_ladder.yaml
@@ -10,8 +10,8 @@
 #   - base_360p:    Minimum viable quality for low-bandwidth links
 #   - perf_540p:    Balanced quality for moderate bandwidth
 #   - detail_720p:  High quality for inspection tasks
-#   - survey_1080p: Maximum quality for detailed survey work
 #   - lowlight_720p: Enhanced bitrate for noise reduction in low light
+#   - survey_1080p: Maximum quality for detailed survey work
 #
 # Configuration Keys:
 #   resolution:           Video dimensions (WIDTHxHEIGHT)

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -1051,7 +1051,7 @@ class StoreForwardTiles(Node):
             return
         try:
             accepted = self._abr_controller.observe_encoder_ack(msg.data)
-        except (ValueError, TypeError, OverflowError):
+        except ValueError:
             self.get_logger().warning("invalid ABR ack payload; ignoring")
             return
         if accepted:

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py
@@ -1051,7 +1051,7 @@ class StoreForwardTiles(Node):
             return
         try:
             accepted = self._abr_controller.observe_encoder_ack(msg.data)
-        except ValueError:
+        except (ValueError, TypeError, OverflowError):
             self.get_logger().warning("invalid ABR ack payload; ignoring")
             return
         if accepted:

--- a/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
+++ b/software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py
@@ -115,7 +115,7 @@ class EncoderAck:
             raise ValueError("encoder ack is missing command_id")
         try:
             command_id = int(command_id_raw)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError("encoder ack command_id is invalid") from exc
         profile_name = str(raw.get("profile_name", "")).strip()
         applied_raw = raw.get("applied_at_ts")
@@ -124,7 +124,7 @@ class EncoderAck:
         else:
             try:
                 applied_at_ts = float(applied_raw)
-            except (TypeError, ValueError) as exc:
+            except (TypeError, ValueError, OverflowError) as exc:
                 raise ValueError("encoder ack applied_at_ts is invalid") from exc
         status = str(raw.get("status", "ok")).strip().lower() or "ok"
         if not profile_name:


### PR DESCRIPTION
### Motivation
- The ABR ladder parser enforces strictly increasing `target_bitrate_kbps`, and the stock `abr_ladder.yaml` had a higher-then-lower ordering that caused ABR initialization to raise and block `store_forward_tiles` startup.
- Encoder ACK payload coercion could raise `TypeError` or `OverflowError` that were not handled by the ROS subscription callback, allowing a malformed ACK to crash the node.

### Description
- Reordered ladder tiers in `software/edge/config/srt/abr_ladder.yaml` so `target_bitrate_kbps` values are strictly increasing and the default config passes the new validator.
- In `video_abr_controller.py` updated `EncoderAck.from_payload` to treat `OverflowError` from numeric coercion as an invalid payload by converting it into `ValueError` for both `command_id` and `applied_at_ts` parsing.
- In `store_forward_tiles.py` broadened the ACK callback exception handler to `except (ValueError, TypeError, OverflowError):` so malformed ACK inputs cannot escape the ROS subscription callback.

### Testing
- Ran `python -m pytest -q test/test_video_abr_policy.py`, which failed during test collection due to missing dependency `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so the test suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a7f764d48326891891b6d71e7ddc)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related startup/stability issues in the ABR video subsystem: a mis-ordered ladder config that prevented node startup, and unhandled numeric coercion exceptions that could crash the ACK callback.

- **`abr_ladder.yaml`**: Moves `survey_1080p` (5 200 kbps) after `lowlight_720p` (4 200 kbps) so all `target_bitrate_kbps` values are strictly increasing, satisfying the ladder validator and unblocking `store_forward_tiles` initialization.
- **`video_abr_controller.py`**: Adds `OverflowError` to both coercion handlers in `EncoderAck.from_payload`, correctly covering the case where a JSON value like `1e999` is parsed to Python `float('inf')` and then passed to `int()`.
- **`store_forward_tiles.py`**: Broadens the ROS subscription exception guard to `(ValueError, TypeError, OverflowError)`, though `TypeError` and `OverflowError` are already re-raised as `ValueError` inside `from_payload`, making the extra types redundant.

<h3>Confidence Score: 4/5</h3>

The YAML reordering and the OverflowError additions are both correct; the main nit is a stale header comment and a redundant outer exception catch that is harmless at runtime.

The YAML fix correctly unblocks startup and the from_payload hardening handles a real edge case. The outer handler in store_forward_tiles.py catches exception types that from_payload already converts upstream, so the extra clauses are dead code that could silently mask unexpected errors from future additions to the same try block.

store_forward_tiles.py around the broadened exception handler, and the Quality Tiers comment block in abr_ladder.yaml.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/config/srt/abr_ladder.yaml | Reorders survey_1080p (5 200 kbps) after lowlight_720p (4 200 kbps) to satisfy the strictly-increasing target_bitrate_kbps validator; fix is correct, but the Quality Tiers header comment still lists the old order. |
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/video_abr_controller.py | Adds OverflowError to both int() and float() coercion handlers in EncoderAck.from_payload; correctly handles the case where a JSON value like 1e999 (parsed to Python float inf) would otherwise raise an unhandled OverflowError when passed to int(). |
| software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py | Broadens the ACK callback handler from except ValueError to except (ValueError, TypeError, OverflowError); the added types are already converted to ValueError upstream in from_payload, making the extra catches redundant defensive code. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ROS as ROS Subscription
    participant SFT as StoreForwardTiles._handle_abr_ack
    participant CTRL as VideoAbrController.observe_encoder_ack
    participant ACK as EncoderAck.from_payload

    ROS->>SFT: msg.data (String)
    SFT->>CTRL: observe_encoder_ack(msg.data)
    CTRL->>ACK: from_payload(payload)
    note over ACK: int(command_id_raw)<br/>catches TypeError, ValueError,<br/>OverflowError → raises ValueError
    note over ACK: float(applied_raw)<br/>catches TypeError, ValueError,<br/>OverflowError → raises ValueError
    ACK-->>CTRL: EncoderAck or raises ValueError
    CTRL-->>SFT: bool or raises ValueError
    alt Valid ACK
        SFT->>SFT: log / update state
    else ValueError (or now TypeError/OverflowError)
        SFT->>SFT: log warning, return
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `software/edge/config/srt/abr_ladder.yaml`, line 12-15 ([link](https://github.com/aeris-drones/aeris/blob/916a2c771f6403a2ac86cc1b5916f2322cf61f08/software/edge/config/srt/abr_ladder.yaml#L12-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale tier order in header comment**

   The `# Quality Tiers:` block still lists `survey_1080p` before `lowlight_720p`, but the reordering in the ladder body now places `lowlight_720p` (4 200 kbps) immediately above `detail_720p` and `survey_1080p` last. Readers comparing the comment to the YAML entries will see a mismatch that could cause confusion about the intended ladder order.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/edge/config/srt/abr_ladder.yaml
   Line: 12-15

   Comment:
   **Stale tier order in header comment**

   The `# Quality Tiers:` block still lists `survey_1080p` before `lowlight_720p`, but the reordering in the ladder body now places `lowlight_720p` (4 200 kbps) immediately above `detail_720p` and `survey_1080p` last. Readers comparing the comment to the YAML entries will see a mismatch that could cause confusion about the intended ladder order.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
software/edge/config/srt/abr_ladder.yaml:12-15
**Stale tier order in header comment**

The `# Quality Tiers:` block still lists `survey_1080p` before `lowlight_720p`, but the reordering in the ladder body now places `lowlight_720p` (4 200 kbps) immediately above `detail_720p` and `survey_1080p` last. Readers comparing the comment to the YAML entries will see a mismatch that could cause confusion about the intended ladder order.

### Issue 2 of 2
software/edge/src/aeris_mesh_agent/aeris_mesh_agent/store_forward_tiles.py:1054
**Redundant exception types in outer handler**

`EncoderAck.from_payload` now re-raises every `TypeError` and `OverflowError` it encounters as a `ValueError`, so neither type can escape `observe_encoder_ack` under normal conditions. Catching them again at this boundary adds no runtime protection and silently swallows any unexpected `TypeError` or `OverflowError` that originates from unrelated future code inside the same `try` block, making bugs harder to detect.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix ABR startup and ACK parsing robustne..."](https://github.com/aeris-drones/aeris/commit/916a2c771f6403a2ac86cc1b5916f2322cf61f08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531404)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->