### PR TITLE
perception: only consume thermal publish budget on publish

### DIFF
--- a/software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py
@@ -252,7 +252,6 @@ class ThermalHotspotNode(Node):
             min_interval = 1.0 / self._target_publish_rate_hz
             if now - self._last_publish_monotonic < min_interval:
                 return
-        self._last_publish_monotonic = now
 
         frame_celsius = self._image_to_temperature_celsius(message)
         if frame_celsius is None:
@@ -278,6 +277,7 @@ class ThermalHotspotNode(Node):
             output.frame_id = frame_id
             self._publisher.publish(output)
 
+        self._last_publish_monotonic = now
         self._process_times.append(now)
         if now - self._last_rate_log_monotonic >= 5.0 and len(self._process_times) > 2:
             elapsed = self._process_times[-1] - self._process_times[0]

--- a/software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py
@@ -152,6 +152,7 @@ class ThermalHotspotNode(Node):
         self._subscription = self.create_subscription(
             Image, thermal_image_topic, self._handle_thermal_image, 10
         )
+        self._last_processed_monotonic = 0.0
         self._last_publish_monotonic = 0.0
         self._process_times = deque(maxlen=60)
         self._last_rate_log_monotonic = time.monotonic()
@@ -250,8 +251,9 @@ class ThermalHotspotNode(Node):
         now = time.monotonic()
         if self._target_publish_rate_hz > 0.0:
             min_interval = 1.0 / self._target_publish_rate_hz
-            if now - self._last_publish_monotonic < min_interval:
+            if now - self._last_processed_monotonic < min_interval:
                 return
+        self._last_processed_monotonic = now
 
         frame_celsius = self._image_to_temperature_celsius(message)
         if frame_celsius is None:

--- a/software/edge/src/aeris_perception/test/test_thermal_hotspot_node_ros.py
+++ b/software/edge/src/aeris_perception/test/test_thermal_hotspot_node_ros.py
@@ -1,10 +1,12 @@
 import time
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 rclpy = pytest.importorskip("rclpy")
 sensor_msgs = pytest.importorskip("sensor_msgs.msg")
+import aeris_perception.thermal_hotspot_node as thermal_hotspot_node_module
 from rclpy.parameter import Parameter
 from sensor_msgs.msg import Image
 
@@ -81,6 +83,61 @@ def test_rate_limiter_applies_even_when_no_hotspots_detected() -> None:
         node._handle_thermal_image(message)
 
         assert calls == 1
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def test_publish_budget_is_consumed_only_when_hotspot_is_published(
+    monkeypatch,
+) -> None:
+    rclpy.init()
+    node = ThermalHotspotNode()
+    recorder = _RecorderPublisher()
+    try:
+        node._target_publish_rate_hz = 2.0
+        node._publisher = recorder
+
+        times = iter((10.0, 10.2, 10.6))
+        monkeypatch.setattr(
+            thermal_hotspot_node_module.time,
+            "monotonic",
+            lambda: next(times),
+        )
+
+        detect_calls = 0
+
+        def fake_image_to_temperature(_message: Image):
+            return np.full((8, 8), 20.0, dtype=np.float32)
+
+        def fake_detect(_frame: np.ndarray):
+            nonlocal detect_calls
+            detect_calls += 1
+            if detect_calls == 1:
+                return []
+            return [
+                SimpleNamespace(
+                    bbox_xyxy=(1, 2, 3, 4),
+                    temp_c=42.0,
+                    confidence=0.9,
+                )
+            ]
+
+        node._image_to_temperature_celsius = fake_image_to_temperature
+        node._detector.detect = fake_detect
+        message = _make_thermal_image_message(np.full((8, 8), 20, dtype=np.uint16))
+
+        node._handle_thermal_image(message)
+        assert node._last_publish_monotonic == pytest.approx(0.0)
+
+        node._handle_thermal_image(message)
+        assert detect_calls == 1
+        assert recorder.messages == []
+
+        node._handle_thermal_image(message)
+        assert detect_calls == 2
+        assert len(recorder.messages) == 1
+        assert node._last_publish_monotonic == pytest.approx(10.6)
     finally:
         node.destroy_node()
         rclpy.shutdown()

--- a/test/test_thermal_hotspot_rate_limit.py
+++ b/test/test_thermal_hotspot_rate_limit.py
@@ -1,0 +1,36 @@
+"""Source-level tests for thermal hotspot rate-limit behavior."""
+
+from pathlib import Path
+
+
+THERMAL_NODE = Path(
+    "software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py"
+)
+
+
+def _read_handle_thermal_image() -> str:
+    source = THERMAL_NODE.read_text(encoding="utf-8")
+    start = source.index("    def _handle_thermal_image(self, message: Image) -> None:")
+    end = source.index("\n\ndef main(")
+    return source[start:end]
+
+
+def test_processing_rate_limit_uses_dedicated_processed_timestamp() -> None:
+    source = THERMAL_NODE.read_text(encoding="utf-8")
+
+    assert "self._last_processed_monotonic = 0.0" in source
+
+    function_source = _read_handle_thermal_image()
+    assert "if now - self._last_processed_monotonic < min_interval:" in function_source
+    assert "self._last_processed_monotonic = now" in function_source
+
+
+def test_publish_timestamp_updates_only_after_publish_loop() -> None:
+    function_source = _read_handle_thermal_image()
+
+    publish_call = "self._publisher.publish(output)"
+    publish_timestamp = "self._last_publish_monotonic = now"
+
+    assert publish_call in function_source
+    assert publish_timestamp in function_source
+    assert function_source.index(publish_call) < function_source.index(publish_timestamp)


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled malformed or cool frames from consuming the thermal publish rate limiter by updating the limiter only when a publish actually occurs.

### Description
- Move the update of `self._last_publish_monotonic` in `ThermalHotspotNode._handle_thermal_image` to after the loop that publishes `ThermalHotspot` messages in `software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py` so frames that fail decoding or produce no detections do not advance the limiter.

### Testing
- Attempted to run `pytest -q software/edge/src/aeris_perception/test/test_thermal_hotspot_node.py` but test collection failed with `ModuleNotFoundError: No module named 'numpy'` in this environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a90e78788326bdc5914cffa0aa0e)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `self._last_publish_monotonic = now` from immediately after the rate-limiter check to the end of the `_handle_thermal_image` method, just after the publish loop. The intent is to prevent malformed or "cool" (no-detection) frames from consuming the publish rate budget, so that a subsequent valid hotspot frame in the same interval is not dropped.

- The security fix is correct: a cool or decode-failing frame no longer advances the limiter, so the next legitimate hotspot frame in the same window is still processed and published.
- As a side effect, the rate limiter no longer throttles decoding and detection — only publishing. In cool-scene conditions (the common case), the detector now runs at the full incoming frame rate rather than at `target_publish_rate_hz`, increasing steady-state CPU usage proportionally to the camera-rate/target-rate ratio.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two-line relocation is small and the security intent is sound, but the processing-rate side effect in cool scenes deserves a deliberate sign-off.

The change correctly prevents cool/malformed frames from exhausting the publish budget. The one concern is that `_last_publish_monotonic` is now only updated on a real publish, so decode and detection run on every frame that passes the interval check whenever no hotspots are present — which is the common operating mode. Whether the extra CPU load is acceptable at the deployed camera frame rate is worth confirming before merging.

software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py — specifically the rate-limiter logic around lines 251–281.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py | Moves `_last_publish_monotonic` update to after the publish loop so failed-decode or no-detection frames no longer consume the rate budget; side effect is that decoding and detection now run on every incoming frame during cool scenes, not just once per interval. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Frame arrives] --> B{Rate check\nnow - last_publish < min_interval?}
    B -- Yes --> C[Drop frame / return]
    B -- No --> D[Decode image\n_image_to_temperature_celsius]
    D -- Decode failure --> E[return\nlast_publish NOT updated]
    D -- Success --> F[Detect hotspots]
    F -- No detections --> G[return\nlast_publish NOT updated]
    F -- Detections found --> H[Publish ThermalHotspot messages]
    H --> I[last_publish_monotonic = now\nAppend to _process_times\nLog rate]

    style E fill:#f9f,stroke:#c00
    style G fill:#f9f,stroke:#c00
    style I fill:#9f9,stroke:#090
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py`, line 251-262 ([link](https://github.com/aeris-drones/aeris/blob/ec7d899f71a1408e62f8e2399bc9dab68ac5f5aa/software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py#L251-L262)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Rate limiter no longer throttles decode/detect, only publishing**

   Before this change the rate check also served as a processing gate — one frame per interval was ever decoded or fed to the detector. After the move, `_last_publish_monotonic` is only updated on a successful publish, so every frame that arrives while no hotspots are being found (the normal operating mode over cold terrain) passes the rate check and is fully decoded and run through the detector. At a 30 Hz camera and a 10 Hz `target_publish_rate_hz`, the cold-scene CPU load is now 3× higher than it was before. The same unbounded-processing path applies when the stream contains a burst of malformed frames — each one passes the rate check and incurs a full decode attempt.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py
   Line: 251-262

   Comment:
   **Rate limiter no longer throttles decode/detect, only publishing**

   Before this change the rate check also served as a processing gate — one frame per interval was ever decoded or fed to the detector. After the move, `_last_publish_monotonic` is only updated on a successful publish, so every frame that arrives while no hotspots are being found (the normal operating mode over cold terrain) passes the rate check and is fully decoded and run through the detector. At a 30 Hz camera and a 10 Hz `target_publish_rate_hz`, the cold-scene CPU load is now 3× higher than it was before. The same unbounded-processing path applies when the stream contains a burst of malformed frames — each one passes the rate check and incurs a full decode attempt.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/edge/src/aeris_perception/aeris_perception/thermal_hotspot_node.py:251-262
**Rate limiter no longer throttles decode/detect, only publishing**

Before this change the rate check also served as a processing gate — one frame per interval was ever decoded or fed to the detector. After the move, `_last_publish_monotonic` is only updated on a successful publish, so every frame that arrives while no hotspots are being found (the normal operating mode over cold terrain) passes the rate check and is fully decoded and run through the detector. At a 30 Hz camera and a 10 Hz `target_publish_rate_hz`, the cold-scene CPU load is now 3× higher than it was before. The same unbounded-processing path applies when the stream contains a burst of malformed frames — each one passes the rate check and incurs a full decode attempt.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perception: only consume thermal publish..."](https://github.com/aeris-drones/aeris/commit/ec7d899f71a1408e62f8e2399bc9dab68ac5f5aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531445)</sub>

<!-- /greptile_comment -->