### PR TITLE
aeris_orchestrator: avoid fallback state mutation on RTL ack failure

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -2531,6 +2531,15 @@ class MissionNode(Node):
         normalized_vehicle_id = self._normalize_vehicle_id(vehicle_id)
         if not normalized_vehicle_id:
             return False, "vehicle_id is required for px4 fallback"
+        endpoint = self._resolve_scout_endpoint(normalized_vehicle_id)
+        if endpoint is None:
+            return (
+                False,
+                f"px4 native RTL fallback failed for '{normalized_vehicle_id}': unknown endpoint",
+            )
+        sent, error = self._dispatch_return_to_launch_for_endpoint(endpoint)
+        if not sent:
+            return False, error
         self._set_return_fallback_reason(normalized_vehicle_id, reason)
         self._set_scout_assignment(
             normalized_vehicle_id,
@@ -2540,13 +2549,7 @@ class MissionNode(Node):
         self._return_paths_by_vehicle.pop(normalized_vehicle_id, None)
         self._return_path_index_by_vehicle.pop(normalized_vehicle_id, None)
         self._return_last_updated_sec_by_vehicle[normalized_vehicle_id] = self._now_seconds()
-        endpoint = self._resolve_scout_endpoint(normalized_vehicle_id)
-        if endpoint is None:
-            return (
-                False,
-                f"px4 native RTL fallback failed for '{normalized_vehicle_id}': unknown endpoint",
-            )
-        return self._dispatch_return_to_launch_for_endpoint(endpoint)
+        return True, ""
 
     def _start_vio_return_execution(
         self, endpoint: ScoutEndpoint

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -1623,6 +1623,50 @@ def test_vio_recall_falls_back_to_px4_native_rtl_when_map_is_stale(
     assert trajectory["fallbackReason"]
 
 
+def test_vio_recall_px4_fallback_ack_failure_does_not_mutate_return_state(
+    mission_harness_vio_return, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_vio_return
+    mission_node._state = "SEARCHING"
+    mission_node._mission_id = "vio-recall-fallback-ack-failure"
+    mission_node._active_scout_vehicle_id = "scout_1"
+    mission_node._scout_plans = {
+        "scout_1": MissionPlanState(
+            pattern_type="lawnmower",
+            zone_id="zone-return",
+            waypoints=[{"x": 100.0, "z": 0.0, "altitude_m": 20.0}],
+            current_waypoint_index=0,
+            scout_position={"x": 0.0, "z": 0.0},
+        )
+    }
+    mission_node._set_scout_assignment("scout_1", "SEARCHING", label="SEARCHING:zone-return")
+    mission_node._return_paths_by_vehicle["scout_1"] = [
+        {"x": 5.0, "z": 0.0, "altitude_m": 20.0},
+        {"x": 0.0, "z": 0.0, "altitude_m": 20.0},
+    ]
+    mission_node._return_path_index_by_vehicle["scout_1"] = 0
+    _publish_scout_telemetry(observer, mission_node, vehicle_id="scout1")
+    _inject_scout_odometry(mission_node, observer, "scout1", x_m=0.0, y_m=0.0)
+    _inject_scout_odometry(mission_node, observer, "scout1", x_m=2.0, y_m=0.0)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_return_to_launch", lambda: False)
+
+    request = SimpleNamespace(
+        command="RECALL",
+        vehicle_id="scout1",
+        mission_id="vio-recall-fallback-ack-failure",
+    )
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)
+
+    assert not result.success
+    assert "not acknowledged" in result.message
+    assert mission_node._vehicle_assignments["scout_1"] == "SEARCHING"
+    assert mission_node._assignment_labels["scout_1"] == "SEARCHING:zone-return"
+    assert "scout_1" not in mission_node._return_fallback_reasons
+    assert mission_node._return_paths_by_vehicle.get("scout_1")
+    assert mission_node._return_path_index_by_vehicle.get("scout_1") == 0
+
+
 def test_vio_return_waypoint_builder_filters_stale_and_off_mission_breadcrumbs(
     mission_harness_vio_return,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Fix a state-ordering bug where the PX4-native RTL fallback mutated mission state (set `RETURNING`, cleared return path, set fallback reason) before the native RTL command was dispatched and acknowledged, which could leave a vehicle in an inert/misleading state if the RTL was not acknowledged.

### Description
- Change ` _activate_px4_return_fallback()` to resolve the endpoint and call `_dispatch_return_to_launch_for_endpoint()` first and return on failure, so mission state is only mutated after successful dispatch. 
- Ensure on unknown endpoint or failed/negative RTL acknowledgement the function returns without setting the assignment, clearing return path state, or recording a fallback reason. 
- Add a regression test `test_vio_recall_px4_fallback_ack_failure_does_not_mutate_return_state` that simulates `send_return_to_launch()` returning `False` and asserts the mission assignment, assignment label, fallback maps, return path, and return index remain unchanged. 
- Modified files: `software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py` and `software/edge/src/aeris_orchestrator/test/test_mission_node.py`.

### Testing
- Added unit test `test_vio_recall_px4_fallback_ack_failure_does_not_mutate_return_state` in `test_mission_node.py` that exercises the failed-ack path and asserts state is unchanged. 
- Ran targeted pytest invocations in the environment: `pytest -q software/edge/src/aeris_orchestrator/test/test_mission_node.py -k "vio_recall_falls_back_to_px4_native_rtl_when_map_is_stale or vio_recall_px4_fallback_ack_failure_does_not_mutate_return_state"` and `pytest -q software/edge/src/aeris_orchestrator/test/test_mission_node.py -k "px4_fallback"`, both of which were skipped in this environment (pytest exited with code 5 and reported skipped tests), so the added test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ab6f35cc832699841986f22fc8ec)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a state-ordering bug in `_activate_px4_return_fallback` where mission state (assignment set to `RETURNING`, return path cleared, fallback reason recorded) was mutated before the PX4 RTL command was dispatched and acknowledged. If the RTL was not acknowledged, the vehicle was left in an inert/misleading state with no valid return path.

- **Logic fix in `mission_node.py`**: Moved `_resolve_scout_endpoint` and `_dispatch_return_to_launch_for_endpoint` to the top of `_activate_px4_return_fallback`, guarding all state mutations behind a successful-dispatch check so the function returns early on unknown endpoint or failed acknowledgement without touching assignment, return path, or fallback reason state.
- **Regression test**: `test_vio_recall_px4_fallback_ack_failure_does_not_mutate_return_state` simulates `send_return_to_launch()` returning `False` through the VIO-recall→px4-fallback code path and asserts that all relevant state dictionaries are left unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a two-file, targeted reordering of a single function with a purpose-built regression test covering the fixed path.

The reordering in `_activate_px4_return_fallback` is straightforward and affects only the failure branch — the happy path (dispatch succeeds) produces identical observable behaviour to before. No other call site or shared state is touched. The regression test mirrors an existing passing test and correctly traces the RECALL→VIO-return→px4-fallback chain end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Reorders `_activate_px4_return_fallback` to dispatch RTL first and gate all state mutations on success; the change is minimal, correct, and does not affect any other call site. |
| software/edge/src/aeris_orchestrator/test/test_mission_node.py | Adds a targeted regression test that correctly exercises the failed-ack path via RECALL→VIO-return→px4-fallback and asserts five mission-state invariants; minor omission of `_return_last_updated_sec_by_vehicle` assertion but that field is not pre-seeded in the test so it cannot produce a false positive. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant HC as _handle_vehicle_command
    participant DVC as _dispatch_vehicle_command
    participant SVR as _start_vio_return_execution
    participant APF as _activate_px4_return_fallback
    participant DRL as _dispatch_return_to_launch_for_endpoint
    participant MAV as MAVLink Adapter

    HC->>DVC: "RECALL (gps_denied_mode=True)"
    DVC->>SVR: _start_vio_return_execution(endpoint)
    SVR->>SVR: _build_vio_return_waypoints() → None (stale map)
    SVR->>APF: _activate_px4_return_fallback(vehicle_id, reason)

    Note over APF: BEFORE fix: state mutated here
    Note over APF: AFTER fix: dispatch first, guard state mutations

    APF->>APF: _resolve_scout_endpoint()
    alt endpoint not found
        APF-->>SVR: (False, unknown endpoint)
    else endpoint found
        APF->>DRL: _dispatch_return_to_launch_for_endpoint(endpoint)
        DRL->>MAV: send_return_to_launch()
        alt RTL not acknowledged
            MAV-->>DRL: False
            DRL-->>APF: (False, not acknowledged)
            APF-->>SVR: (False, error) — NO state mutation
            SVR-->>DVC: (False, error)
            DVC-->>HC: (False, error)
        else RTL acknowledged
            MAV-->>DRL: True
            DRL-->>APF: (True, empty)
            APF->>APF: set_return_fallback_reason()
            APF->>APF: set_scout_assignment(RETURNING)
            APF->>APF: pop return_paths, pop return_path_index
            APF->>APF: update return_last_updated_sec
            APF-->>SVR: (True, empty)
            SVR-->>DVC: (True, empty)
            DVC-->>HC: (True, empty)
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["aeris\_orchestrator: avoid fallback state..."](https://github.com/aeris-drones/aeris/commit/b216c5ed709da72b77d71090aa13fda3ab387bb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531497)</sub>

<!-- /greptile_comment -->