### PR TITLE
Stop ranger overwatch stream when active ranger receives HOLD/RECALL

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -2700,13 +2700,12 @@ class MissionNode(Node):
         command_targets_active_ranger = (
             self._active_ranger_vehicle_id == endpoint.vehicle_id
         )
-        if (
+        should_stop_ranger_stream = (
             command_targets_active_ranger
             and command in {"HOLD", "RECALL"}
             and self._ranger_mavlink_adapter is not None
             and self._ranger_mavlink_adapter.is_streaming
-        ):
-            self._ranger_mavlink_adapter.stop_stream()
+        )
 
         previous_host, previous_port = self._mavlink_adapter.endpoint
         previous_command_port = self._mavlink_adapter.command_port
@@ -2798,6 +2797,10 @@ class MissionNode(Node):
                 False,
                 f"vehicle_command '{command}' was not acknowledged by '{endpoint.vehicle_id}'",
             )
+
+        if should_stop_ranger_stream:
+            self._ranger_mavlink_adapter.stop_stream()
+
         return True, ""
 
     def _is_ranger_overwatch_suppressed(self) -> bool:
@@ -2805,8 +2808,8 @@ class MissionNode(Node):
         if not active_ranger_vehicle_id:
             return False
         return self._vehicle_command_states.get(active_ranger_vehicle_id) in {
-            "HOLDING",
-            "RETURNING",
+            self._VEHICLE_COMMAND_STATE_HOLDING,
+            self._VEHICLE_COMMAND_STATE_RETURNING,
         }
 
     def _apply_mavlink_endpoint(self, endpoint: ScoutEndpoint) -> None:

--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -2697,6 +2697,17 @@ class MissionNode(Node):
         if dispatch is None:
             return False, f"unsupported command '{command}'"
 
+        command_targets_active_ranger = (
+            self._active_ranger_vehicle_id == endpoint.vehicle_id
+        )
+        if (
+            command_targets_active_ranger
+            and command in {"HOLD", "RECALL"}
+            and self._ranger_mavlink_adapter is not None
+            and self._ranger_mavlink_adapter.is_streaming
+        ):
+            self._ranger_mavlink_adapter.stop_stream()
+
         previous_host, previous_port = self._mavlink_adapter.endpoint
         previous_command_port = self._mavlink_adapter.command_port
         previous_target_system, previous_target_component = self._mavlink_adapter.target
@@ -2788,6 +2799,15 @@ class MissionNode(Node):
                 f"vehicle_command '{command}' was not acknowledged by '{endpoint.vehicle_id}'",
             )
         return True, ""
+
+    def _is_ranger_overwatch_suppressed(self) -> bool:
+        active_ranger_vehicle_id = self._active_ranger_vehicle_id
+        if not active_ranger_vehicle_id:
+            return False
+        return self._vehicle_command_states.get(active_ranger_vehicle_id) in {
+            "HOLDING",
+            "RETURNING",
+        }
 
     def _apply_mavlink_endpoint(self, endpoint: ScoutEndpoint) -> None:
         command_port = endpoint.command_port if endpoint.command_port > 0 else endpoint.port
@@ -3322,6 +3342,13 @@ class MissionNode(Node):
             return
         if not self._mission_id or not self._active_ranger_vehicle_id:
             return
+        if self._is_ranger_overwatch_suppressed():
+            if (
+                self._ranger_mavlink_adapter is not None
+                and self._ranger_mavlink_adapter.is_streaming
+            ):
+                self._ranger_mavlink_adapter.stop_stream()
+            return
         if not self._ranger_orbit_waypoints:
             return
 
@@ -3351,6 +3378,8 @@ class MissionNode(Node):
 
     def _update_ranger_overwatch_orbit(self) -> None:
         if not self._active_ranger_vehicle_id:
+            return
+        if self._is_ranger_overwatch_suppressed():
             return
         if not self._ranger_orbit_waypoints:
             return

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -2545,3 +2545,63 @@ def test_reset_vehicle_command_states_includes_ranger_endpoints(
         "scout_1": mission_node._VEHICLE_COMMAND_STATE_ACTIVE,
         "scout_2": mission_node._VEHICLE_COMMAND_STATE_ACTIVE,
     }
+
+
+def test_vehicle_command_hold_stops_active_ranger_overwatch_stream(
+    mission_harness_multi_vehicle, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_multi_vehicle
+    del observer
+
+    now = time.monotonic()
+    mission_node._state = "SEARCHING"
+    mission_node._mission_id = "ranger-hold"
+    mission_node._active_ranger_vehicle_id = "ranger_1"
+    mission_node._ranger_endpoints = [
+        ScoutEndpoint(vehicle_id="ranger_1", host="127.0.0.1", port=14543),
+    ]
+    mission_node._reset_vehicle_command_states()
+    mission_node._ranger_last_seen_monotonic = {"ranger_1": now}
+
+    stop_calls: list[int] = []
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", lambda: True)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_target", lambda *args, **kwargs: None)
+
+    class _FakeRangerAdapter:
+        is_streaming = True
+
+        def stop_stream(self) -> None:
+            stop_calls.append(1)
+            self.is_streaming = False
+
+    mission_node._ranger_mavlink_adapter = _FakeRangerAdapter()
+
+    request = SimpleNamespace(command="HOLD", vehicle_id="ranger1", mission_id="ranger-hold")
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)
+
+    assert result.success
+    assert stop_calls == [1]
+
+
+def test_update_ranger_overwatch_orbit_respects_holding_state(
+    mission_harness_multi_vehicle, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_multi_vehicle
+    del observer
+
+    mission_node._active_ranger_vehicle_id = "ranger_1"
+    mission_node._vehicle_command_states["ranger_1"] = mission_node._VEHICLE_COMMAND_STATE_HOLDING
+    mission_node._ranger_orbit_waypoints = [{"x": 1.0, "z": 2.0, "altitude_m": 30.0}]
+
+    start_calls: list[int] = []
+    monkeypatch.setattr(
+        mission_node,
+        "_start_ranger_overwatch_execution",
+        lambda: start_calls.append(1),
+    )
+
+    mission_node._update_ranger_overwatch_orbit()
+
+    assert start_calls == []

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -2585,6 +2585,81 @@ def test_vehicle_command_hold_stops_active_ranger_overwatch_stream(
     assert stop_calls == [1]
 
 
+def test_vehicle_command_hold_does_not_stop_stream_when_dispatch_fails(
+    mission_harness_multi_vehicle, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_multi_vehicle
+    del observer
+
+    now = time.monotonic()
+    mission_node._state = "SEARCHING"
+    mission_node._mission_id = "ranger-hold-failure"
+    mission_node._active_ranger_vehicle_id = "ranger_1"
+    mission_node._ranger_endpoints = [
+        ScoutEndpoint(vehicle_id="ranger_1", host="127.0.0.1", port=14543),
+    ]
+    mission_node._reset_vehicle_command_states()
+    mission_node._ranger_last_seen_monotonic = {"ranger_1": now}
+
+    stop_calls: list[int] = []
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_hold_position", lambda: False)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_target", lambda *args, **kwargs: None)
+
+    class _FakeRangerAdapter:
+        is_streaming = True
+
+        def stop_stream(self) -> None:
+            stop_calls.append(1)
+
+    mission_node._ranger_mavlink_adapter = _FakeRangerAdapter()
+
+    request = SimpleNamespace(command="HOLD", vehicle_id="ranger1", mission_id="ranger-hold-failure")
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)
+
+    assert not result.success
+    assert stop_calls == []
+
+
+def test_vehicle_command_recall_stops_active_ranger_overwatch_stream(
+    mission_harness_multi_vehicle, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_multi_vehicle
+    del observer
+
+    now = time.monotonic()
+    mission_node._state = "SEARCHING"
+    mission_node._mission_id = "ranger-recall"
+    mission_node._active_ranger_vehicle_id = "ranger_1"
+    mission_node._ranger_endpoints = [
+        ScoutEndpoint(vehicle_id="ranger_1", host="127.0.0.1", port=14543),
+    ]
+    mission_node._reset_vehicle_command_states()
+    mission_node._ranger_last_seen_monotonic = {"ranger_1": now}
+
+    stop_calls: list[int] = []
+    monkeypatch.setattr(mission_node._mavlink_adapter, "send_return_to_launch", lambda: True)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_endpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mission_node._mavlink_adapter, "set_target", lambda *args, **kwargs: None)
+
+    class _FakeRangerAdapter:
+        is_streaming = True
+
+        def stop_stream(self) -> None:
+            stop_calls.append(1)
+            self.is_streaming = False
+
+    mission_node._ranger_mavlink_adapter = _FakeRangerAdapter()
+
+    request = SimpleNamespace(command="RECALL", vehicle_id="ranger1", mission_id="ranger-recall")
+    response = SimpleNamespace(success=False, message="")
+    result = mission_node._handle_vehicle_command(request, response)
+
+    assert result.success
+    assert stop_calls == [1]
+
+
 def test_update_ranger_overwatch_orbit_respects_holding_state(
     mission_harness_multi_vehicle, monkeypatch
 ) -> None:
@@ -2593,6 +2668,28 @@ def test_update_ranger_overwatch_orbit_respects_holding_state(
 
     mission_node._active_ranger_vehicle_id = "ranger_1"
     mission_node._vehicle_command_states["ranger_1"] = mission_node._VEHICLE_COMMAND_STATE_HOLDING
+    mission_node._ranger_orbit_waypoints = [{"x": 1.0, "z": 2.0, "altitude_m": 30.0}]
+
+    start_calls: list[int] = []
+    monkeypatch.setattr(
+        mission_node,
+        "_start_ranger_overwatch_execution",
+        lambda: start_calls.append(1),
+    )
+
+    mission_node._update_ranger_overwatch_orbit()
+
+    assert start_calls == []
+
+
+def test_update_ranger_overwatch_orbit_respects_returning_state(
+    mission_harness_multi_vehicle, monkeypatch
+) -> None:
+    mission_node, observer = mission_harness_multi_vehicle
+    del observer
+
+    mission_node._active_ranger_vehicle_id = "ranger_1"
+    mission_node._vehicle_command_states["ranger_1"] = mission_node._VEHICLE_COMMAND_STATE_RETURNING
     mission_node._ranger_orbit_waypoints = [{"x": 1.0, "z": 2.0, "altitude_m": 30.0}]
 
     start_calls: list[int] = []

--- a/test/test_ranger_overwatch_stream.py
+++ b/test/test_ranger_overwatch_stream.py
@@ -1,0 +1,38 @@
+"""Source-level tests for ranger overwatch suppression ordering."""
+
+from pathlib import Path
+
+
+MISSION_NODE = Path(
+    "software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py"
+)
+
+
+def _read_dispatch_vehicle_command() -> str:
+    source = MISSION_NODE.read_text(encoding="utf-8")
+    start = source.index("    def _dispatch_vehicle_command(")
+    end = source.index("    def _is_ranger_overwatch_suppressed(")
+    return source[start:end]
+
+
+def test_ranger_stream_stop_happens_after_successful_dispatch() -> None:
+    source = _read_dispatch_vehicle_command()
+
+    stop_call = "self._ranger_mavlink_adapter.stop_stream()"
+    dispatch_call = "command_sent = dispatch()"
+
+    assert stop_call in source
+    assert dispatch_call in source
+    assert source.index(dispatch_call) < source.index(
+        stop_call
+    ), "ranger overwatch stream should only stop after vehicle command dispatch succeeds"
+
+
+def test_ranger_suppression_uses_command_state_constants() -> None:
+    source = MISSION_NODE.read_text(encoding="utf-8")
+    start = source.index("    def _is_ranger_overwatch_suppressed(")
+    end = source.index("    def _apply_mavlink_endpoint(")
+    function_source = source[start:end]
+
+    assert 'self._VEHICLE_COMMAND_STATE_HOLDING' in function_source
+    assert 'self._VEHICLE_COMMAND_STATE_RETURNING' in function_source


### PR DESCRIPTION
### Motivation
- A change expanded `vehicle_command` to accept ranger endpoints but did not stop the dedicated ranger overwatch MAVLink stream, allowing accepted HOLD/RECALL responses to coexist with continuing autonomous overwatch setpoints and breaking safety semantics.  

### Description
- Stop the dedicated ranger overwatch stream when a `vehicle_command` targets the active ranger with `HOLD` or `RECALL` by calling `self._ranger_mavlink_adapter.stop_stream()` inside `_dispatch_vehicle_command` when appropriate.  
- Add `_is_ranger_overwatch_suppressed()` which returns True when the active ranger's per-vehicle command state is `HOLDING` or `RETURNING`.  
- Integrate the suppression check into `_start_ranger_overwatch_execution()` and `_update_ranger_overwatch_orbit()` to prevent restarting or updating the ranger stream while suppressed.  
- Add unit tests `test_vehicle_command_hold_stops_active_ranger_overwatch_stream` and `test_update_ranger_overwatch_orbit_respects_holding_state` to `test_mission_node.py` to verify the stream stop and suppression behavior.  

### Testing
- Ran the focused pytest invocation `pytest -q software/edge/src/aeris_orchestrator/test/test_mission_node.py -k 'ranger_overwatch_orbit_respects_holding_state or vehicle_command_hold_stops_active_ranger_overwatch_stream'`.  
- The test run in this environment completed with the selected tests skipped (`1 skipped`), so no failing tests were observed for the added checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ac5bafa4832686b3e5c50492eba8)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds safety logic to stop the dedicated ranger overwatch MAVLink stream when a `vehicle_command` targets the active ranger with `HOLD` or `RECALL`, and prevents the control loop from restarting it while the vehicle is holding or returning.

- **`_dispatch_vehicle_command`**: Calls `stop_stream()` on the ranger adapter when the command targets the active ranger with HOLD/RECALL, but does so *before* the MAVLink dispatch is attempted — if the command is rejected by the vehicle the stream is stopped with no confirmed hold in place.
- **`_is_ranger_overwatch_suppressed()`**: New helper that checks whether the active ranger's state is HOLDING or RETURNING; integrated into `_start_ranger_overwatch_execution()` and `_update_ranger_overwatch_orbit()` to block stream restarts during suppression.
- **Tests**: Two new unit tests cover the stream-stop path and the holding-state suppression path, but the stream-stop test only exercises the success path and does not assert the stream is not prematurely stopped on a failed dispatch.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the stream can be killed before the command is confirmed, leaving the ranger without autonomous setpoints and without a confirmed hold.

The stream is stopped unconditionally before the MAVLink dispatch call. On a failed dispatch the vehicle state remains ACTIVE, so the control loop will restart the stream on the next tick — but for one full cycle the ranger flies with no setpoints and no confirmed HOLD, which is the precise safety gap the PR is designed to eliminate.

The ordering of `stop_stream()` relative to `dispatch()` in `_dispatch_vehicle_command` inside `mission_node.py` needs a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Adds ranger overwatch stream suppression on HOLD/RECALL, but stops the stream before the command is confirmed sent — if dispatch fails, the stream is killed while the vehicle state stays ACTIVE, leaving a safety gap until the next control-loop cycle restarts it. |
| software/edge/src/aeris_orchestrator/test/test_mission_node.py | Adds two new focused tests; the stream-stop test only exercises the happy path and does not assert that stop_stream is not called when dispatch returns False. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant MissionNode
    participant RangerAdapter
    participant MAVLink

    Client->>MissionNode: vehicle_command(HOLD, ranger_1)
    MissionNode->>MissionNode: _handle_vehicle_command()
    MissionNode->>MissionNode: _dispatch_vehicle_command()
    Note over MissionNode,RangerAdapter: Stream stopped BEFORE dispatch
    MissionNode->>RangerAdapter: stop_stream()
    MissionNode->>MAVLink: dispatch() send_hold_position()
    alt Command acknowledged
        MAVLink-->>MissionNode: True
        MissionNode->>MissionNode: "_vehicle_command_states[ranger_1] = HOLDING"
        MissionNode-->>Client: "success=True"
    else Command rejected / comms failure
        MAVLink-->>MissionNode: False
        Note over MissionNode: State stays ACTIVE
        MissionNode-->>Client: "success=False"
        Note over RangerAdapter: Stream already stopped!
        Note over MissionNode: Next control-loop tick: suppressed=False, stream restarted
    end

    MissionNode->>MissionNode: control_loop tick
    MissionNode->>MissionNode: _update_ranger_overwatch_orbit()
    MissionNode->>MissionNode: _is_ranger_overwatch_suppressed()
    alt State is HOLDING or RETURNING
        MissionNode->>MissionNode: return suppressed
    else State is ACTIVE
        MissionNode->>MissionNode: _start_ranger_overwatch_execution()
        MissionNode->>RangerAdapter: start_stream()
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py:2703-2709
**Stream stopped before dispatch succeeds**

`stop_stream()` is called unconditionally before `dispatch()` is invoked. If the MAVLink command is not acknowledged (e.g. comms hiccup, vehicle rejects it), the ranger overwatch stream is silently killed while `_vehicle_command_states` remains `"ACTIVE"`. `_is_ranger_overwatch_suppressed()` then returns `False` on the very next control-loop tick, causing `_start_ranger_overwatch_execution()` to re-open the stream — but for one full control-loop period the ranger flies without any autonomous setpoints and without a confirmed HOLD, which is exactly the safety gap this PR is trying to close. The stream stop should be moved to after `dispatch()` returns `True`, not before it is called.

### Issue 2 of 3
software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py:2807-2810
`_is_ranger_overwatch_suppressed()` hard-codes the string literals `"HOLDING"` and `"RETURNING"` instead of the class constants `_VEHICLE_COMMAND_STATE_HOLDING` / `_VEHICLE_COMMAND_STATE_RETURNING`. If either constant is ever renamed, this check will silently stop working.

```suggestion
        return self._vehicle_command_states.get(active_ranger_vehicle_id) in {
            self._VEHICLE_COMMAND_STATE_HOLDING,
            self._VEHICLE_COMMAND_STATE_RETURNING,
        }
```

### Issue 3 of 3
software/edge/src/aeris_orchestrator/test/test_mission_node.py:2580-2585
**Test passes even when dispatch fails silently**

The test stubs `send_hold_position` as `lambda: True` and relies on the stream stop happening before the `dispatch()` call — which is the exact ordering bug in the production code. A more robust test should also verify the no-op case: when `send_hold_position` returns `False`, `stop_stream()` should NOT have been called. Without this negative assertion the test would continue to pass even after the production ordering is corrected to the safer post-dispatch pattern, while providing no evidence that the guard is conditional on command success.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Stop ranger overwatch stream on HOLD/REC..."](https://github.com/aeris-drones/aeris/commit/9b8ce609c5c1dd943b1cfd8919a4af395afc73bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531527)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->