### PR TITLE
Harden abort mission identity checks before fleet RTL dispatch

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -3530,7 +3530,8 @@ class MissionNode(Node):
             response.message = f"abort_mission rejected while in {self._state}"
             return response
 
-        if request.mission_id.strip() and request.mission_id.strip() != self._mission_id:
+        request_mission_id = request.mission_id.strip()
+        if not request_mission_id or request_mission_id != self._mission_id:
             response.success = False
             response.message = "abort_mission rejected due to mission_id mismatch"
             return response

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -392,6 +392,35 @@ def test_abort_mission_rejects_mission_id_mismatch(mission_harness) -> None:
     assert "ABORTED" not in observer.states
 
 
+def test_abort_mission_rejects_blank_mission_id(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "blank-abort"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    abort_request = MissionCommand.Request()
+    abort_request.command = "ABORT"
+    abort_request.mission_id = ""
+    abort_request.zone_geometry = ""
+    abort_future = observer.abort_client.call_async(abort_request)
+
+    assert _wait_until(lambda: abort_future.done())
+    response = abort_future.result()
+    assert response is not None
+    assert not response.success
+    assert "mission_id mismatch" in response.message
+    assert "ABORTED" not in observer.states
+
+
 def test_start_mission_rejects_missing_zone_geometry(mission_harness) -> None:
     _, observer = mission_harness
 


### PR DESCRIPTION
### Motivation
- Prevent a bypass where an `ABORT` request with a blank `mission_id` could reach the fleet RTL dispatch and send physical RTL commands to vehicles, which allows unauthenticated network clients to trigger unsafe behavior.

### Description
- Change `abort_mission` validation to require a non-empty `mission_id` that exactly matches the active mission by introducing `request_mission_id = request.mission_id.strip()` and rejecting when it is empty or different from `self._mission_id` in `mission_node.py`.
- Preserve the existing rejection message (`"abort_mission rejected due to mission_id mismatch"`) so existing behavior and tests remain consistent.
- Add a regression test `test_abort_mission_rejects_blank_mission_id` in `test_mission_node.py` to assert blank `mission_id` abort requests are rejected and do not transition the mission to `ABORTED`.

### Testing
- Added unit test `test_abort_mission_rejects_blank_mission_id` to `software/edge/src/aeris_orchestrator/test/test_mission_node.py` and retained the existing mismatch test; both are present in the test suite.
- Ran `pytest software/edge/src/aeris_orchestrator/test/test_mission_node.py -k "abort_mission_rejects_mission_id_mismatch or abort_mission_rejects_blank_mission_id"` in this environment and the test module was collected as skipped (no runnable ROS `rclpy` runtime available), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07adaeb6c483269a55aaa2f0e20919)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a bypass where an `ABORT` request carrying a blank `mission_id` could slip past the identity guard and trigger fleet-wide RTL dispatch. The old condition `if request.mission_id.strip() and ...` evaluated to `False` for empty input (Python short-circuit), silently skipping validation; the new condition `if not request_mission_id or request_mission_id != self._mission_id` correctly rejects both empty and mismatched values.

- **`mission_node.py`**: Two-line change inverts the guard to require a non-empty, exactly-matching `mission_id` before any RTL command is dispatched to the fleet.
- **`test_mission_node.py`**: Adds `test_abort_mission_rejects_blank_mission_id` to assert that a blank `mission_id` abort is rejected without transitioning the mission to `ABORTED`; the existing mismatch test is preserved.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core logic fix is correct and closes a real bypass path in abort mission handling.

The production change is minimal and accurate: inverting the guard ensures blank and mismatched mission IDs are both rejected before any RTL command reaches the fleet. The only gap is that the new regression test exercises the empty-string case but not whitespace-only input, leaving that branch unconfirmed by the test suite.

The test file would benefit from an additional whitespace-only mission_id variant to fully exercise the strip() path that the production code relies on.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Fixes a security bypass in _handle_abort_mission: the old condition skipped validation for blank mission_id (falsy short-circuit), the new condition correctly rejects any empty or mismatched mission_id before RTL dispatch. |
| software/edge/src/aeris_orchestrator/test/test_mission_node.py | Adds test_abort_mission_rejects_blank_mission_id covering the empty-string case; whitespace-only mission_id (e.g. "   ") is not tested, leaving a minor coverage gap. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant MissionNode
    participant FleetRTL

    Client->>MissionNode: "ABORT (mission_id="")"
    Note over MissionNode: strip() → ""<br/>not request_mission_id → True
    MissionNode-->>Client: "success=False, "mission_id mismatch""
    Note over FleetRTL: RTL dispatch never reached

    Client->>MissionNode: "ABORT (mission_id="other-id")"
    Note over MissionNode: strip() → "other-id"<br/>other-id ≠ self._mission_id → True
    MissionNode-->>Client: "success=False, "mission_id mismatch""
    Note over FleetRTL: RTL dispatch never reached

    Client->>MissionNode: "ABORT (mission_id="correct-id")"
    Note over MissionNode: strip() → "correct-id"<br/>matches self._mission_id → proceed
    MissionNode->>FleetRTL: _dispatch_abort_rtl(target_endpoints)
    FleetRTL-->>MissionNode: successful_dispatches / total
    MissionNode-->>Client: "success=True, mission aborted"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/edge/src/aeris_orchestrator/test/test_mission_node.py:410-414
The new test covers the empty-string case but not a whitespace-only `mission_id` (e.g. `"   "`). The production code calls `.strip()` before the check, so `"   "` would also be rejected — but without an explicit test the behaviour is unverified. Adding a second parametrize variant here would close that gap.

```suggestion
    abort_request = MissionCommand.Request()
    abort_request.command = "ABORT"
    abort_request.mission_id = "   "  # whitespace-only; strip() → "" should also be rejected
    abort_request.zone_geometry = ""
    abort_future = observer.abort_client.call_async(abort_request)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Harden abort mission\_id validation for R..."](https://github.com/aeris-drones/aeris/commit/7a8ba8b0af6cc52dc45763a09a0a3bd696603d14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531615)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->