### PR TITLE
fix(orchestrator): reject abort requests without mission_id

### DIFF
--- a/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
+++ b/software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py
@@ -3530,7 +3530,13 @@ class MissionNode(Node):
             response.message = f"abort_mission rejected while in {self._state}"
             return response
 
-        if request.mission_id.strip() and request.mission_id.strip() != self._mission_id:
+        requested_mission_id = request.mission_id.strip()
+        if not requested_mission_id:
+            response.success = False
+            response.message = "abort_mission rejected due to missing mission_id"
+            return response
+
+        if requested_mission_id != self._mission_id:
             response.success = False
             response.message = "abort_mission rejected due to mission_id mismatch"
             return response

--- a/software/edge/src/aeris_orchestrator/test/test_mission_node.py
+++ b/software/edge/src/aeris_orchestrator/test/test_mission_node.py
@@ -392,6 +392,35 @@ def test_abort_mission_rejects_mission_id_mismatch(mission_harness) -> None:
     assert "ABORTED" not in observer.states
 
 
+def test_abort_mission_rejects_missing_mission_id(mission_harness) -> None:
+    mission_node, observer = mission_harness
+    _publish_scout_telemetry(observer, mission_node)
+
+    start_request = MissionCommand.Request()
+    start_request.command = "START"
+    start_request.mission_id = "missing-id-abort"
+    start_request.zone_geometry = VALID_ZONE_GEOMETRY
+    start_future = observer.start_client.call_async(start_request)
+
+    assert _wait_until(lambda: start_future.done())
+    assert start_future.result() is not None
+    assert start_future.result().success
+    assert _wait_until(lambda: "SEARCHING" in observer.states)
+
+    abort_request = MissionCommand.Request()
+    abort_request.command = "ABORT"
+    abort_request.mission_id = "   "
+    abort_request.zone_geometry = ""
+    abort_future = observer.abort_client.call_async(abort_request)
+
+    assert _wait_until(lambda: abort_future.done())
+    response = abort_future.result()
+    assert response is not None
+    assert not response.success
+    assert "missing mission_id" in response.message
+    assert "ABORTED" not in observer.states
+
+
 def test_start_mission_rejects_missing_zone_geometry(mission_harness) -> None:
     _, observer = mission_harness
 


### PR DESCRIPTION
### Motivation
- The `abort_mission` handler previously treated an empty `mission_id` as a wildcard, allowing unauthenticated clients to abort any active mission and transition the state machine into a terminal `ABORTED` state that blocks future `START` requests.
- Because `start_mission` only accepts requests from `IDLE`, this behavior created a durable denial-of-service against mission orchestration that must be prevented by requiring an explicit mission identifier.

### Description
- Require a non-empty trimmed mission id in `_handle_abort_mission` by assigning `requested_mission_id = request.mission_id.strip()` and rejecting requests where `requested_mission_id` is empty with `response.message = "abort_mission rejected due to missing mission_id"`.
- Preserve the existing mission-id mismatch protection by comparing `requested_mission_id` to `self._mission_id` and rejecting when they differ.
- Add an integration test `test_abort_mission_rejects_missing_mission_id` that starts a mission, issues an `ABORT` with whitespace `mission_id`, asserts the abort is rejected, and verifies no `ABORTED` state is emitted.
- Modified files: `software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py` and `software/edge/src/aeris_orchestrator/test/test_mission_node.py`.

### Testing
- Ran the focused pytest invocation `pytest -q software/edge/src/aeris_orchestrator/test/test_mission_node.py -k 'abort_mission_rejects_mission_id_mismatch or abort_mission_rejects_missing_mission_id'`, which was skipped in this environment because ROS 2 `rclpy` is not available; the test harness is present and exercised by CI where ROS 2 is available.
- Verified locally in the repository that the new logic rejects blank/whitespace `mission_id` before performing the id comparison and that the test asserts the expected rejection message and absence of the `ABORTED` state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07adbe4bdc8326adc365999cb8db2a)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a denial-of-service path in `_handle_abort_mission` where a blank or whitespace `mission_id` passed the original short-circuit guard (`if mission_id.strip() and …`) and drove the state machine into `ABORTED`, blocking any subsequent `START` from `IDLE`. The fix adds an explicit early-return for empty `mission_id` before the mismatch check, and refactors the double `.strip()` call into a single variable.

- **`mission_node.py`**: Extracts `requested_mission_id = request.mission_id.strip()`, rejects empty values immediately, then compares the stripped value against `self._mission_id`—eliminating the wildcard abort vulnerability.
- **`test_mission_node.py`**: Adds `test_abort_mission_rejects_missing_mission_id`, which starts a real mission, sends an ABORT with a whitespace-only `mission_id`, and asserts the request is rejected with the expected message and no `ABORTED` state is recorded.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a tightly scoped validation guard with no side effects on the happy path.

The logic change is minimal and surgical: one new early-return branch that can only fire before any abort side effects (RTL dispatch, state transition) are triggered. The existing mismatch check is preserved and now uses a pre-stripped variable instead of calling `.strip()` twice. The new test mirrors the established harness pattern and exercises the exact failure scenario described in the PR. No regression risk to the abort success path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_orchestrator/aeris_orchestrator/mission_node.py | Adds an explicit empty/whitespace mission_id guard in `_handle_abort_mission`, closing a DoS path where a blank mission_id bypassed the mismatch check and drove the state machine to ABORTED. |
| software/edge/src/aeris_orchestrator/test/test_mission_node.py | Adds `test_abort_mission_rejects_missing_mission_id`, which mirrors the existing mismatch test and correctly asserts the abort is rejected and no ABORTED state is emitted. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant MissionNode

    Client->>MissionNode: "abort_mission(command="ABORT", mission_id="   ")"
    Note over MissionNode: Check command == "ABORT" ✓
    Note over MissionNode: Check state in _ABORTABLE_STATES ✓
    Note over MissionNode: requested_mission_id = mission_id.strip() → ""
    Note over MissionNode: if not requested_mission_id → True
    MissionNode-->>Client: "success=False, "missing mission_id""

    Client->>MissionNode: "abort_mission(command="ABORT", mission_id="wrong-id")"
    Note over MissionNode: Check command == "ABORT" ✓
    Note over MissionNode: Check state in _ABORTABLE_STATES ✓
    Note over MissionNode: requested_mission_id = "wrong-id"
    Note over MissionNode: "wrong-id" != self._mission_id → True
    MissionNode-->>Client: "success=False, "mission_id mismatch""

    Client->>MissionNode: "abort_mission(command="ABORT", mission_id="correct-id")"
    Note over MissionNode: Check command == "ABORT" ✓
    Note over MissionNode: Check state in _ABORTABLE_STATES ✓
    Note over MissionNode: requested_mission_id = "correct-id"
    Note over MissionNode: "correct-id" == self._mission_id ✓
    Note over MissionNode: Dispatch RTL, transition to ABORTED
    MissionNode-->>Client: "success=True, "Mission aborted""
```

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): require mission\_id fo..."](https://github.com/aeris-drones/aeris/commit/8621ad0421ce73a351178d48ffb4df2f07fba422) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33531686)</sub>

<!-- /greptile_comment -->