### PR TITLE
Add maintenance fleet diagnostics dashboard

### DIFF
--- a/software/edge/src/aeris_msgs/CMakeLists.txt
+++ b/software/edge/src/aeris_msgs/CMakeLists.txt
@@ -27,6 +27,8 @@ set(interface_files
   "msg/PodStageTiming.msg"
   "msg/PodStatus.msg"
   "msg/PodStatusArray.msg"
+  "msg/VehicleMaintenanceDiagnostics.msg"
+  "msg/VehicleMaintenanceDiagnosticsArray.msg"
   "srv/MapTile.srv"
   "srv/GetMapTileBytes.srv"
   "srv/ThermalHotspot.srv"

--- a/software/edge/src/aeris_msgs/msg/VehicleMaintenanceDiagnostics.msg
+++ b/software/edge/src/aeris_msgs/msg/VehicleMaintenanceDiagnostics.msg
@@ -1,0 +1,18 @@
+# Canonical maintenance-only diagnostic snapshot for one vehicle.
+
+uint8 STATE_UNKNOWN=0
+uint8 STATE_HEALTHY=1
+uint8 STATE_WARNING=2
+uint8 STATE_BLOCKED=3
+
+string vehicle_id
+uint8 motor_health_state
+string motor_health_detail
+uint8 calibration_state
+string calibration_detail
+uint8 imu_state
+string imu_detail
+uint8 compass_state
+string compass_detail
+uint8 accelerometer_state
+string accelerometer_detail

--- a/software/edge/src/aeris_msgs/msg/VehicleMaintenanceDiagnosticsArray.msg
+++ b/software/edge/src/aeris_msgs/msg/VehicleMaintenanceDiagnosticsArray.msg
@@ -1,0 +1,4 @@
+# Fleet maintenance diagnostic snapshot for the maintenance viewer.
+
+builtin_interfaces/Time observed_at
+aeris_msgs/VehicleMaintenanceDiagnostics[] vehicles

--- a/software/viewer/src/app/ViewerAppProviders.tsx
+++ b/software/viewer/src/app/ViewerAppProviders.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { CoordinateOriginProvider } from '@/context/CoordinateOriginContext';
+import { ROSConnectionProvider } from '@/context/ROSConnectionContext';
+import { ZoneProvider } from '@/context/ZoneContext';
+import { MissionProvider } from '@/context/MissionContext';
+
+interface ViewerAppProvidersProps {
+  children: ReactNode;
+}
+
+export function ViewerAppProviders({ children }: ViewerAppProvidersProps) {
+  return (
+    <CoordinateOriginProvider>
+      <ROSConnectionProvider>
+        <ZoneProvider>
+          <MissionProvider>{children}</MissionProvider>
+        </ZoneProvider>
+      </ROSConnectionProvider>
+    </CoordinateOriginProvider>
+  );
+}

--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -183,6 +183,11 @@ test("IC mode keeps one canonical page-shell flag and propagates it", () => {
     /<EmergencyStopControl[\s\S]*onAbort=\{abortMission\}/,
     "page should route the persistent control through the existing abortMission callback"
   );
+  assert.match(
+    source,
+    /<EmergencyStopControl[\s\S]*missionId=\{missionId\}/,
+    "page should pass the current mission identity into the persistent abort control"
+  );
   assert.doesNotMatch(
     source,
     /<EmergencyStopControl[\s\S]*key=\{missionPhase\}/,

--- a/software/viewer/src/app/maintenance/page.tsx
+++ b/software/viewer/src/app/maintenance/page.tsx
@@ -1,0 +1,10 @@
+import { ViewerAppProviders } from '@/app/ViewerAppProviders';
+import { MaintenanceDashboardPage } from '@/components/maintenance/MaintenanceDashboardPage';
+
+export default function MaintenancePage() {
+  return (
+    <ViewerAppProviders>
+      <MaintenanceDashboardPage />
+    </ViewerAppProviders>
+  );
+}

--- a/software/viewer/src/app/maintenanceRouteSurface.test.mjs
+++ b/software/viewer/src/app/maintenanceRouteSurface.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("operator and maintenance routes both use the shared viewer provider seam", () => {
+  const providersSource = fs.readFileSync(path.join(ROOT, "app", "ViewerAppProviders.tsx"), "utf8");
+  const operatorSource = fs.readFileSync(path.join(ROOT, "app", "page.tsx"), "utf8");
+  const maintenanceSource = fs.readFileSync(path.join(ROOT, "app", "maintenance", "page.tsx"), "utf8");
+
+  assert.match(providersSource, /ROSConnectionProvider/, "shared providers should own the ROS connection surface");
+  assert.match(providersSource, /MissionProvider/, "shared providers should include the mission context");
+  assert.match(operatorSource, /ViewerAppProviders/, "operator page should reuse the shared viewer providers");
+  assert.match(maintenanceSource, /ViewerAppProviders/, "maintenance page should reuse the shared viewer providers");
+});
+
+test("viewer route navigation exposes both operations and maintenance destinations", () => {
+  const navSource = fs.readFileSync(path.join(ROOT, "components", "layout", "ViewerRouteNav.tsx"), "utf8");
+  const operatorSource = fs.readFileSync(path.join(ROOT, "app", "page.tsx"), "utf8");
+  const maintenanceSource = fs.readFileSync(path.join(ROOT, "app", "maintenance", "page.tsx"), "utf8");
+
+  assert.match(navSource, /href="\/"/, "route nav should retain the operator landing route");
+  assert.match(navSource, /href="\/maintenance"/, "route nav should expose the maintenance route");
+  assert.match(operatorSource, /ViewerRouteNav currentRoute="operations"/, "operator page should wire the route nav");
+  assert.match(maintenanceSource, /MaintenanceDashboardPage/, "maintenance route should render the dedicated diagnostics dashboard");
+});

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { GCSLayout } from '@/components/layout/GCSLayout';
+import { ViewerRouteNav } from '@/components/layout/ViewerRouteNav';
 import { StatusPill, MissionPhase } from '@/components/layout/StatusPill';
 import { CommandDock } from '@/components/layout/CommandDock';
 import { FleetCard, VehicleWarning } from '@/components/cards/FleetCard';
@@ -17,10 +18,7 @@ import { VehicleInfo } from '@/components/sheets/VehicleCard';
 import { LayersPanel } from '@/components/layers/LayersPanel';
 import { LayerVisibilityProvider } from '@/context/LayerVisibilityContext';
 import { useLayerVisibility } from '@/context/LayerVisibilityContext';
-import { ZoneProvider, useZoneContext } from '@/context/ZoneContext';
-import { CoordinateOriginProvider } from '@/context/CoordinateOriginContext';
-import { ROSConnectionProvider } from '@/context/ROSConnectionContext';
-import { MissionProvider } from '@/context/MissionContext';
+import { useZoneContext } from '@/context/ZoneContext';
 import { ZoneToolbar } from '@/components/zones/ZoneToolbar';
 import { PiPVideoFeed } from '@/components/pip/PiPVideoFeed';
 import { AlertToaster, showAlert, dismissAlert, type Alert } from '@/components/alerts';
@@ -42,6 +40,7 @@ import {
 import {
   deriveRouteRecommendations,
 } from '@/lib/routeRecommendations';
+import { ViewerAppProviders } from '@/app/ViewerAppProviders';
 
 /**
  * Mock detections for UI demonstration when ROS telemetry is unavailable.
@@ -92,21 +91,15 @@ const MOCK_ALERT_IDS = ['demo-critical', 'demo-warning'] as const;
  */
 export default function V2Page() {
   return (
-    <CoordinateOriginProvider>
-      <ROSConnectionProvider>
-        <LayerVisibilityProvider>
-          <ZoneProvider>
-            <MissionProvider>
-              <Suspense fallback={null}>
-                <V2PageContent />
-              </Suspense>
-              <AlertToaster visibleToasts={5} />
-              <KeyboardShortcutsOverlay />
-            </MissionProvider>
-          </ZoneProvider>
-        </LayerVisibilityProvider>
-      </ROSConnectionProvider>
-    </CoordinateOriginProvider>
+    <ViewerAppProviders>
+      <LayerVisibilityProvider>
+        <Suspense fallback={null}>
+          <V2PageContent />
+        </Suspense>
+        <AlertToaster visibleToasts={5} />
+        <KeyboardShortcutsOverlay />
+      </LayerVisibilityProvider>
+    </ViewerAppProviders>
   );
 }
 
@@ -729,13 +722,16 @@ function V2PageContent() {
       }
 
       topRightOverlay={icViewModeEnabled ? undefined : (
-        <EmergencyStopControl
-          missionPhase={missionPhase}
-          canAbort={canAbort}
-          abortUnavailableReason={abortUnavailableReason}
-          abortError={abortMissionError}
-          onAbort={abortMission}
-        />
+        <div className="flex flex-col items-end gap-3">
+          <ViewerRouteNav currentRoute="operations" />
+          <EmergencyStopControl
+            missionPhase={missionPhase}
+            canAbort={canAbort}
+            abortUnavailableReason={abortUnavailableReason}
+            abortError={abortMissionError}
+            onAbort={abortMission}
+          />
+        </div>
       )}
 
       zoneToolbar={icViewModeEnabled ? undefined : <ZoneToolbar />}

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -129,6 +129,7 @@ function V2PageContent() {
   );
 
   const {
+    missionId,
     phase: missionPhase,
     elapsedSeconds,
     coveragePercent,
@@ -725,6 +726,7 @@ function V2PageContent() {
         <div className="flex flex-col items-end gap-3">
           <ViewerRouteNav currentRoute="operations" />
           <EmergencyStopControl
+            missionId={missionId}
             missionPhase={missionPhase}
             canAbort={canAbort}
             abortUnavailableReason={abortUnavailableReason}

--- a/software/viewer/src/components/layout/ViewerRouteNav.tsx
+++ b/software/viewer/src/components/layout/ViewerRouteNav.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { Crosshair, Wrench } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface ViewerRouteNavProps {
+  currentRoute: 'operations' | 'maintenance';
+}
+
+export function ViewerRouteNav({ currentRoute }: ViewerRouteNavProps) {
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-white/12 bg-black/60 p-1 shadow-[0_0_24px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+      <Button
+        asChild
+        variant="ghost"
+        size="sm"
+        className={cn(
+          'h-9 rounded-full px-3 text-white/75 hover:bg-white/8 hover:text-white',
+          currentRoute === 'operations' && 'bg-white/12 text-white'
+        )}
+      >
+        <Link href="/">
+          <Crosshair className="mr-2 h-4 w-4" />
+          Ops
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant="ghost"
+        size="sm"
+        className={cn(
+          'h-9 rounded-full px-3 text-white/75 hover:bg-white/8 hover:text-white',
+          currentRoute === 'maintenance' && 'bg-white/12 text-white'
+        )}
+      >
+        <Link href="/maintenance">
+          <Wrench className="mr-2 h-4 w-4" />
+          Maintenance
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/software/viewer/src/components/maintenance/MaintenanceDashboardPage.tsx
+++ b/software/viewer/src/components/maintenance/MaintenanceDashboardPage.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+import { Activity, Battery, Radio, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ViewerRouteNav } from '@/components/layout/ViewerRouteNav';
+import { MaintenanceVehicleCard } from '@/components/maintenance/MaintenanceVehicleCard';
+import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
+import { useMissionControl } from '@/hooks/useMissionControl';
+import { usePodStatus } from '@/hooks/usePodStatus';
+import { useVehicleMaintenanceDiagnostics } from '@/hooks/useVehicleMaintenanceDiagnostics';
+import {
+  createDemoFleetDiagnostics,
+  projectFleetDiagnostics,
+} from '@/lib/maintenanceDiagnostics';
+import { normalizeMissionMetaForVehicle } from '@/lib/degradedVehicleState';
+
+function SummaryCard({
+  label,
+  value,
+  detail,
+  icon,
+  variant = 'outline',
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  icon: ReactNode;
+  variant?: 'outline' | 'success' | 'warning' | 'danger';
+}) {
+  return (
+    <Card className="border-white/10 bg-white/[0.04] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-white/80">
+          {icon}
+        </div>
+        <Badge variant={variant}>{label}</Badge>
+      </div>
+      <div className="mt-4 text-3xl font-semibold text-white">{value}</div>
+      <div className="mt-1 text-sm text-white/55">{detail}</div>
+    </Card>
+  );
+}
+
+export function MaintenanceDashboardPage() {
+  const { vehicles } = useVehicleTelemetry();
+  const { vehicleMissionMeta, rosConnected } = useMissionControl();
+  const podStatus = usePodStatus();
+  const diagnostics = useVehicleMaintenanceDiagnostics();
+  const [expandedVehicleIds, setExpandedVehicleIds] = useState<string[]>([]);
+
+  const liveDashboard = useMemo(
+    () =>
+      projectFleetDiagnostics({
+        telemetry: vehicles.map((vehicle) => {
+          const missionMeta = normalizeMissionMetaForVehicle(vehicle.id, vehicleMissionMeta);
+          return {
+            id: vehicle.id,
+            name: vehicle.id.replace(/[_-]/g, ' ').toUpperCase(),
+            batteryPercent:
+              typeof vehicle.batteryPercent === 'number' ? vehicle.batteryPercent : null,
+            altitudeMeters: vehicle.position.y,
+            linkQualityPercent: vehicle.linkQualityPercent,
+            lastUpdate: vehicle.lastUpdate,
+            deliveryMode: vehicle.deliveryMode,
+            isRetroactive: vehicle.isRetroactive,
+            missionOnline: missionMeta.online,
+          };
+        }),
+        diagnostics: diagnostics.vehicles,
+        pods: podStatus.pods,
+      }),
+    [diagnostics.vehicles, podStatus.pods, vehicleMissionMeta, vehicles]
+  );
+
+  const isDemoMode = !rosConnected && liveDashboard.vehicles.length === 0;
+  const dashboard = isDemoMode ? createDemoFleetDiagnostics() : liveDashboard;
+
+  const toggleVehicle = (vehicleId: string) => {
+    setExpandedVehicleIds((current) =>
+      current.includes(vehicleId)
+        ? current.filter((id) => id !== vehicleId)
+        : [...current, vehicleId]
+    );
+  };
+
+  return (
+    <div className="min-h-dvh bg-[linear-gradient(180deg,#05070b_0%,#0a1017_52%,#070b11_100%)] text-white">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-5 md:px-6 lg:px-8">
+        <header className="flex flex-col gap-4 border-b border-white/8 pb-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-200/70">
+              Fleet readiness
+            </div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Maintenance</h1>
+            <p className="mt-2 max-w-2xl text-sm text-white/60">
+              Read-only fleet diagnostics for deployment readiness, mesh health, and calibration follow-up.
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-3 lg:items-end">
+            <ViewerRouteNav currentRoute="maintenance" />
+            <Badge variant={isDemoMode ? 'warning' : rosConnected ? 'success' : 'outline'}>
+              {isDemoMode ? 'Demo data' : rosConnected ? 'ROS connected' : 'Waiting for ROS'}
+            </Badge>
+          </div>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <SummaryCard
+            label="Ready"
+            value={String(dashboard.summary.readyCount)}
+            detail="Vehicles clear for dispatch"
+            icon={<ShieldCheck className="h-5 w-5" />}
+            variant="success"
+          />
+          <SummaryCard
+            label="Attention"
+            value={String(dashboard.summary.warningCount)}
+            detail="Vehicles with review items"
+            icon={<TriangleAlert className="h-5 w-5" />}
+            variant="warning"
+          />
+          <SummaryCard
+            label="Blocked"
+            value={String(dashboard.summary.blockedCount)}
+            detail="Vehicles held from readiness"
+            icon={<Activity className="h-5 w-5" />}
+            variant="danger"
+          />
+          <SummaryCard
+            label="Mesh avg"
+            value={
+              dashboard.summary.averageLinkQuality == null
+                ? '--'
+                : `${dashboard.summary.averageLinkQuality}%`
+            }
+            detail={`${dashboard.summary.connectedCount} vehicles with current telemetry`}
+            icon={<Radio className="h-5 w-5" />}
+          />
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-2">
+          {dashboard.vehicles.length === 0 ? (
+            <Card className="border-white/10 bg-white/[0.04] p-8">
+              <div className="flex flex-col items-center justify-center gap-3 text-center text-white/55">
+                <Battery className="h-8 w-8 text-white/35" />
+                <div className="text-lg font-medium text-white">No fleet diagnostics yet</div>
+                <div className="max-w-md text-sm">
+                  Connect ROS telemetry and maintenance diagnostics to populate the readiness board.
+                </div>
+              </div>
+            </Card>
+          ) : (
+            dashboard.vehicles.map((vehicle) => (
+              <MaintenanceVehicleCard
+                key={vehicle.id}
+                vehicle={vehicle}
+                expanded={expandedVehicleIds.includes(vehicle.id)}
+                onToggle={() => toggleVehicle(vehicle.id)}
+              />
+            ))
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
@@ -56,6 +56,9 @@ export function MaintenanceVehicleCard({
   const readinessVariant = getReadinessBadgeVariant(vehicle.readiness);
   const batteryLabel =
     typeof vehicle.batteryPercent === 'number' ? `${Math.round(vehicle.batteryPercent)}%` : '--';
+  const altitudeLabel = Number.isFinite(vehicle.altitudeMeters)
+    ? `${Math.round(vehicle.altitudeMeters)}m`
+    : '--';
   const lastContactLabel = vehicle.isOffline
     ? `Last contact ${formatLastContactAge(vehicle.lastContactAgeMs)} ago`
     : 'Live telemetry';
@@ -84,7 +87,7 @@ export function MaintenanceVehicleCard({
           </div>
           <div className="flex items-center gap-1.5">
             <Gauge className="h-4 w-4" />
-            <span className="font-mono">{Math.round(vehicle.altitudeMeters)}m</span>
+            <span className="font-mono">{altitudeLabel}</span>
           </div>
         </div>
       </div>

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Activity, Battery, ChevronDown, ChevronUp, Compass, Cpu, Gauge, Radio, ShieldAlert } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import {
+  getDiagnosticBadgeVariant,
+  getReadinessBadgeVariant,
+  type MaintenanceCheckViewModel,
+  type MaintenanceVehicleViewModel,
+} from '@/lib/maintenanceDiagnostics';
+import { formatLastContactAge } from '@/lib/degradedVehicleState';
+
+interface MaintenanceVehicleCardProps {
+  vehicle: MaintenanceVehicleViewModel;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function DetailRow({
+  check,
+  icon,
+  testId,
+}: {
+  check: MaintenanceCheckViewModel;
+  icon: ReactNode;
+  testId?: string;
+}) {
+  return (
+    <div
+      className="grid gap-2 border-t border-white/8 py-3 first:border-t-0 first:pt-0 md:grid-cols-[auto_1fr_auto]"
+      data-testid={testId}
+    >
+      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-white/70">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-white">{check.label}</div>
+        <div className="text-sm text-white/60">{check.summary}</div>
+      </div>
+      <Badge variant={getDiagnosticBadgeVariant(check.state)} className="justify-self-start md:justify-self-end">
+        {check.state}
+      </Badge>
+    </div>
+  );
+}
+
+export function MaintenanceVehicleCard({
+  vehicle,
+  expanded,
+  onToggle,
+}: MaintenanceVehicleCardProps) {
+  const readinessVariant = getReadinessBadgeVariant(vehicle.readiness);
+  const batteryLabel =
+    typeof vehicle.batteryPercent === 'number' ? `${Math.round(vehicle.batteryPercent)}%` : '--';
+  const lastContactLabel = vehicle.isOffline
+    ? `Last contact ${formatLastContactAge(vehicle.lastContactAgeMs)} ago`
+    : 'Live telemetry';
+
+  return (
+    <Card
+      className={cn(
+        'border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.22)]',
+        vehicle.readiness === 'blocked' && 'border-red-500/20',
+        vehicle.readiness === 'warning' && 'border-amber-400/20'
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="truncate text-lg font-medium text-white">{vehicle.name}</h2>
+            <Badge variant={readinessVariant}>{vehicle.readiness}</Badge>
+          </div>
+          <p className="mt-1 text-sm text-white/60">{vehicle.readinessSummary}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-white/65">
+          <div className="flex items-center gap-1.5">
+            <Battery className="h-4 w-4" />
+            <span className="font-mono">{batteryLabel}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Gauge className="h-4 w-4" />
+            <span className="font-mono">{Math.round(vehicle.altitudeMeters)}m</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {[
+          vehicle.summaryChecks.motor,
+          vehicle.summaryChecks.sensors,
+          vehicle.summaryChecks.mesh,
+          vehicle.summaryChecks.calibration,
+        ].map((check) => (
+          <div key={check.label} className="rounded-lg border border-white/8 bg-black/18 px-3 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-sm font-medium text-white">{check.label}</div>
+              <Badge variant={getDiagnosticBadgeVariant(check.state)}>{check.state}</Badge>
+            </div>
+            <div className="mt-2 text-sm text-white/60">{check.summary}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/8 pt-4">
+        <div className="flex items-center gap-2 text-sm text-white/55">
+          <Activity className="h-4 w-4" />
+          <span>{lastContactLabel}</span>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-9 rounded-full border border-white/10 bg-white/[0.04] px-3 text-white hover:bg-white/10"
+          onClick={onToggle}
+          aria-expanded={expanded}
+        >
+          {expanded ? <ChevronUp className="mr-1.5 h-4 w-4" /> : <ChevronDown className="mr-1.5 h-4 w-4" />}
+          {expanded ? 'Hide details' : 'Show details'}
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="mt-4 rounded-xl border border-white/8 bg-black/18 p-4">
+          <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-white/45">
+            Calibration detail
+          </div>
+          <div className="space-y-1">
+            <DetailRow check={vehicle.detailChecks[0]} icon={<Cpu className="h-4 w-4" />} testId="maintenance-detail-imu" />
+            <DetailRow check={vehicle.detailChecks[1]} icon={<Compass className="h-4 w-4" />} testId="maintenance-detail-compass" />
+            <DetailRow check={vehicle.detailChecks[2]} icon={<Gauge className="h-4 w-4" />} testId="maintenance-detail-accelerometer" />
+          </div>
+
+          <div className="mt-4 border-t border-white/8 pt-4">
+            <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/45">
+              <ShieldAlert className="h-4 w-4" />
+              Attached pods
+            </div>
+            {vehicle.pods.length === 0 ? (
+              <div className="text-sm text-white/45">No pod status reported.</div>
+            ) : (
+              <div className="grid gap-2">
+                {vehicle.pods.map((pod) => (
+                  <div
+                    key={`${vehicle.id}-${pod.slotId}-${pod.podSerial}`}
+                    className="flex flex-col gap-2 rounded-lg border border-white/8 bg-white/[0.03] px-3 py-3 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Radio className="h-4 w-4 text-white/55" />
+                        <span className="truncate text-sm font-medium text-white">
+                          {pod.podType} · {pod.podSerial}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-sm text-white/55">
+                        {pod.slotId} · {pod.capabilities.join(', ') || 'No capabilities reported'}
+                      </div>
+                    </div>
+                    <Badge variant={getDiagnosticBadgeVariant(pod.state)}>{pod.lifecycleLabel}</Badge>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
@@ -59,6 +59,7 @@ export function MaintenanceVehicleCard({
   const lastContactLabel = vehicle.isOffline
     ? `Last contact ${formatLastContactAge(vehicle.lastContactAgeMs)} ago`
     : 'Live telemetry';
+  const [imuCheck, compassCheck, accelerometerCheck] = vehicle.detailChecks;
 
   return (
     <Card
@@ -129,9 +130,15 @@ export function MaintenanceVehicleCard({
             Calibration detail
           </div>
           <div className="space-y-1">
-            <DetailRow check={vehicle.detailChecks[0]} icon={<Cpu className="h-4 w-4" />} testId="maintenance-detail-imu" />
-            <DetailRow check={vehicle.detailChecks[1]} icon={<Compass className="h-4 w-4" />} testId="maintenance-detail-compass" />
-            <DetailRow check={vehicle.detailChecks[2]} icon={<Gauge className="h-4 w-4" />} testId="maintenance-detail-accelerometer" />
+            {imuCheck ? (
+              <DetailRow check={imuCheck} icon={<Cpu className="h-4 w-4" />} testId="maintenance-detail-imu" />
+            ) : null}
+            {compassCheck ? (
+              <DetailRow check={compassCheck} icon={<Compass className="h-4 w-4" />} testId="maintenance-detail-compass" />
+            ) : null}
+            {accelerometerCheck ? (
+              <DetailRow check={accelerometerCheck} icon={<Gauge className="h-4 w-4" />} testId="maintenance-detail-accelerometer" />
+            ) : null}
           </div>
 
           <div className="mt-4 border-t border-white/8 pt-4">

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
@@ -166,3 +166,19 @@ test("MaintenanceVehicleCard renders expanded calibration and pod detail states"
   assert.match(markup, /GAS-9/);
   assert.match(markup, /aria-expanded="true"/);
 });
+
+test("MaintenanceVehicleCard tolerates missing calibration detail rows", async () => {
+  const markup = await renderCard({
+    vehicle: {
+      ...vehicle,
+      detailChecks: [vehicle.detailChecks[0]],
+    },
+    expanded: true,
+    onToggle: () => {},
+  });
+
+  assert.match(markup, /IMU calibration/);
+  assert.doesNotMatch(markup, /Compass calibration/);
+  assert.doesNotMatch(markup, /Accelerometer/);
+  assert.match(markup, /Attached pods/);
+});

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
@@ -1,0 +1,168 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-maintenance-card-render-"));
+const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "..", "..", "node_modules");
+
+fs.symlinkSync(VIEWER_NODE_MODULES, path.join(TEMP_ROOT, "node_modules"), "dir");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "button.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Button({ children, className = "", ...props }) {
+    return _jsx("button", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "card.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Card({ children, className = "", ...props }) {
+    return _jsx("div", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "badge.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Badge({ children, className = "", ...props }) {
+    return _jsx("span", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "utils.mjs"), `
+  export function cn(...values) {
+    return values.flatMap((value) => Array.isArray(value) ? value : [value]).filter(Boolean).join(" ");
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "maintenanceDiagnostics.mjs"), `
+  export function getDiagnosticBadgeVariant(state) {
+    if (state === "healthy") return "success";
+    if (state === "blocked") return "danger";
+    if (state === "warning") return "warning";
+    return "outline";
+  }
+  export function getReadinessBadgeVariant(readiness) {
+    if (readiness === "ready") return "success";
+    if (readiness === "blocked") return "danger";
+    return "warning";
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "degradedVehicleState.mjs"), `
+  export function formatLastContactAge(value) {
+    return value == null ? "--" : Math.floor(value / 1000) + "s";
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "lucide-react.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  function icon(name) {
+    return function Icon({ className = "", ...props }) {
+      return _jsx("svg", { "data-icon": name, className, ...props });
+    };
+  }
+  export const Activity = icon("Activity");
+  export const Battery = icon("Battery");
+  export const ChevronDown = icon("ChevronDown");
+  export const ChevronUp = icon("ChevronUp");
+  export const Compass = icon("Compass");
+  export const Cpu = icon("Cpu");
+  export const Gauge = icon("Gauge");
+  export const Radio = icon("Radio");
+  export const ShieldAlert = icon("ShieldAlert");
+`, "utf8");
+
+async function renderCard(props) {
+  const sourcePath = path.join(ROOT, "MaintenanceVehicleCard.tsx");
+  let source = fs.readFileSync(sourcePath, "utf8");
+  source = source
+    .replaceAll("@/components/ui/button", "./button.mjs")
+    .replaceAll("@/components/ui/card", "./card.mjs")
+    .replaceAll("@/components/ui/badge", "./badge.mjs")
+    .replaceAll("@/lib/utils", "./utils.mjs")
+    .replaceAll("@/lib/maintenanceDiagnostics", "./maintenanceDiagnostics.mjs")
+    .replaceAll("@/lib/degradedVehicleState", "./degradedVehicleState.mjs")
+    .replaceAll("lucide-react", "./lucide-react.mjs");
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  }).outputText;
+
+  const modulePath = path.join(TEMP_ROOT, `MaintenanceVehicleCard-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(modulePath, compiled, "utf8");
+  const { MaintenanceVehicleCard } = await import(pathToFileURL(modulePath).href);
+  return renderToStaticMarkup(createElement(MaintenanceVehicleCard, props));
+}
+
+const vehicle = {
+  id: "scout_2",
+  name: "SCOUT 2",
+  readiness: "warning",
+  readinessSummary: "Diagnostics need maintenance review",
+  batteryPercent: 54,
+  altitudeMeters: 0,
+  lastContactAgeMs: 1900,
+  isOffline: false,
+  summaryChecks: {
+    motor: { label: "Motor health", state: "warning", summary: "Motor 3 current ripple above baseline" },
+    sensors: { label: "Sensors", state: "warning", summary: "1 pod needs attention" },
+    mesh: { label: "Mesh radio", state: "warning", summary: "58% degraded mesh link" },
+    calibration: { label: "Calibration", state: "warning", summary: "Compass recalibration due soon" },
+  },
+  detailChecks: [
+    { label: "IMU calibration", state: "healthy", summary: "IMU drift nominal" },
+    { label: "Compass calibration", state: "warning", summary: "Recheck before next sortie" },
+    { label: "Accelerometer", state: "healthy", summary: "Accelerometer aligned" },
+  ],
+  pods: [
+    {
+      slotId: "belly",
+      podSerial: "GAS-9",
+      podType: "hazmat",
+      lifecycleLabel: "Registered",
+      state: "warning",
+      capabilities: ["gas", "hazmat"],
+    },
+  ],
+};
+
+test("MaintenanceVehicleCard keeps calibration details hidden until expanded", async () => {
+  const markup = await renderCard({
+    vehicle,
+    expanded: false,
+    onToggle: () => {},
+  });
+
+  assert.match(markup, /Show details/);
+  assert.match(markup, /Motor health/);
+  assert.doesNotMatch(markup, /IMU calibration/);
+  assert.doesNotMatch(markup, /Attached pods/);
+});
+
+test("MaintenanceVehicleCard renders expanded calibration and pod detail states", async () => {
+  const markup = await renderCard({
+    vehicle,
+    expanded: true,
+    onToggle: () => {},
+  });
+
+  assert.match(markup, /Hide details/);
+  assert.match(markup, /IMU calibration/);
+  assert.match(markup, /Compass calibration/);
+  assert.match(markup, /Accelerometer/);
+  assert.match(markup, /Attached pods/);
+  assert.match(markup, /hazmat/);
+  assert.match(markup, /GAS-9/);
+  assert.match(markup, /aria-expanded="true"/);
+});

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
@@ -182,3 +182,17 @@ test("MaintenanceVehicleCard tolerates missing calibration detail rows", async (
   assert.doesNotMatch(markup, /Accelerometer/);
   assert.match(markup, /Attached pods/);
 });
+
+test("MaintenanceVehicleCard renders a safe altitude fallback for non-finite values", async () => {
+  const markup = await renderCard({
+    vehicle: {
+      ...vehicle,
+      altitudeMeters: Number.NaN,
+    },
+    expanded: false,
+    onToggle: () => {},
+  });
+
+  assert.match(markup, />--</);
+  assert.doesNotMatch(markup, /NaNm/);
+});

--- a/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
+++ b/software/viewer/src/components/maintenance/MaintenanceVehicleCardSurface.test.mjs
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -11,6 +11,10 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-maintenance-card-render-"));
 const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "..", "..", "node_modules");
+
+after(() => {
+  fs.rmSync(TEMP_ROOT, { recursive: true, force: true });
+});
 
 fs.symlinkSync(VIEWER_NODE_MODULES, path.join(TEMP_ROOT, "node_modules"), "dir");
 

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
@@ -8,10 +8,12 @@ import { cn } from '@/lib/utils';
 import type { MissionPhase } from '@/components/layout/StatusPill';
 import {
   advanceEmergencyStopHold,
+  advanceAbortRequestWindow,
   beginEmergencyStopHold,
   cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
+  resolveAbortRequestWindowId,
 } from '@/lib/emergencyStopHold';
 
 interface EmergencyStopControlProps {
@@ -20,6 +22,72 @@ interface EmergencyStopControlProps {
   abortUnavailableReason: string | null;
   abortError?: string | null;
   onAbort: () => void;
+}
+
+interface AbortLifecycleState {
+  activeWindowId: number;
+  isActiveWindow: boolean;
+  pendingWindowId: number | null;
+  resolvedWindowId: number | null;
+}
+
+type AbortLifecycleAction =
+  | {
+      type: 'sync-lifecycle';
+      missionPhase: MissionPhase;
+      abortError: string | null;
+    }
+  | {
+      type: 'mark-pending';
+      windowId: number;
+    }
+  | {
+      type: 'clear-for-retry';
+    };
+
+function abortLifecycleReducer(
+  state: AbortLifecycleState,
+  action: AbortLifecycleAction
+): AbortLifecycleState {
+  if (action.type === 'mark-pending') {
+    return {
+      ...state,
+      pendingWindowId: action.windowId,
+      resolvedWindowId: null,
+    };
+  }
+
+  if (action.type === 'clear-for-retry') {
+    return {
+      ...state,
+      pendingWindowId: null,
+      resolvedWindowId:
+        state.resolvedWindowId === state.activeWindowId
+          ? null
+          : state.resolvedWindowId,
+    };
+  }
+
+  const abortWindow = advanceAbortRequestWindow(
+    {
+      id: state.activeWindowId,
+      isActive: state.isActiveWindow,
+    },
+    action.missionPhase
+  );
+  const resolvedWindowId = resolveAbortRequestWindowId({
+    abortWindow,
+    pendingWindowId: state.pendingWindowId,
+    resolvedWindowId: state.resolvedWindowId,
+    abortError: action.abortError,
+  });
+
+  return {
+    ...state,
+    activeWindowId: abortWindow.id,
+    isActiveWindow: abortWindow.isActive,
+    resolvedWindowId,
+  };
 }
 
 export function EmergencyStopControl({
@@ -31,15 +99,31 @@ export function EmergencyStopControl({
 }: EmergencyStopControlProps) {
   const idleHoldState = useMemo(() => createIdleEmergencyStopHold(), []);
   const [holdState, setHoldState] = useState(createIdleEmergencyStopHold);
-  const [abortRequestedPhase, setAbortRequestedPhase] = useState<MissionPhase | null>(null);
+  const [abortLifecycle, dispatchAbortLifecycle] = useReducer(
+    abortLifecycleReducer,
+    {
+      activeWindowId: 0,
+      isActiveWindow: false,
+      pendingWindowId: null,
+      resolvedWindowId: null,
+    }
+  );
   const [abortDispatchNonce, setAbortDispatchNonce] = useState(0);
   const holdStateRef = useRef(holdState);
   const onAbortRef = useRef(onAbort);
-  const abortRequested = abortRequestedPhase === missionPhase;
+  const abortLifecycleRef = useRef(abortLifecycle);
+  const abortWindow = useMemo(
+    () => ({
+      id: abortLifecycle.activeWindowId,
+      isActive: abortLifecycle.isActiveWindow,
+    }),
+    [abortLifecycle.activeWindowId, abortLifecycle.isActiveWindow]
+  );
   const abortPending = isAbortRequestPending({
-    abortRequested,
+    abortWindow,
+    pendingWindowId: abortLifecycle.pendingWindowId,
+    resolvedWindowId: abortLifecycle.resolvedWindowId,
     abortError,
-    missionPhase,
   });
   const displayHoldState =
     canAbort && !abortPending ? holdState : idleHoldState;
@@ -59,6 +143,18 @@ export function EmergencyStopControl({
   }, [onAbort]);
 
   useEffect(() => {
+    abortLifecycleRef.current = abortLifecycle;
+  }, [abortLifecycle]);
+
+  useEffect(() => {
+    dispatchAbortLifecycle({
+      type: 'sync-lifecycle',
+      missionPhase,
+      abortError,
+    });
+  }, [abortError, missionPhase]);
+
+  useEffect(() => {
     if (holdState.phase !== 'holding') {
       return;
     }
@@ -74,7 +170,10 @@ export function EmergencyStopControl({
       setHoldState(nextState);
 
       if (shouldDispatchAbort) {
-        setAbortRequestedPhase(missionPhase);
+        dispatchAbortLifecycle({
+          type: 'mark-pending',
+          windowId: abortLifecycleRef.current.activeWindowId,
+        });
         setAbortDispatchNonce((value) => value + 1);
       }
     };
@@ -82,7 +181,7 @@ export function EmergencyStopControl({
     tick();
     const intervalId = window.setInterval(tick, 50);
     return () => window.clearInterval(intervalId);
-  }, [abortPending, canAbort, holdState.phase, missionPhase]);
+  }, [abortPending, canAbort, holdState.phase]);
 
   useEffect(() => {
     if (abortDispatchNonce === 0) {
@@ -158,9 +257,7 @@ export function EmergencyStopControl({
           if (!canAbort || abortPending) {
             return;
           }
-          if (abortRequestedPhase !== null) {
-            setAbortRequestedPhase(null);
-          }
+          dispatchAbortLifecycle({ type: 'clear-for-retry' });
           setHoldState(beginEmergencyStopHold(Date.now()));
         }}
         onPointerUp={cancelHold}

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -12,7 +12,6 @@ import {
   cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
-  shouldResetAbortRequest,
 } from '@/lib/emergencyStopHold';
 
 interface EmergencyStopControlProps {
@@ -32,10 +31,11 @@ export function EmergencyStopControl({
 }: EmergencyStopControlProps) {
   const idleHoldState = useMemo(() => createIdleEmergencyStopHold(), []);
   const [holdState, setHoldState] = useState(createIdleEmergencyStopHold);
-  const [abortRequested, setAbortRequested] = useState(false);
+  const [abortRequestedPhase, setAbortRequestedPhase] = useState<MissionPhase | null>(null);
   const [abortDispatchNonce, setAbortDispatchNonce] = useState(0);
   const holdStateRef = useRef(holdState);
   const onAbortRef = useRef(onAbort);
+  const abortRequested = abortRequestedPhase === missionPhase;
   const abortPending = isAbortRequestPending({
     abortRequested,
     abortError,
@@ -59,13 +59,6 @@ export function EmergencyStopControl({
   }, [onAbort]);
 
   useEffect(() => {
-    if (!shouldResetAbortRequest({ abortRequested, missionPhase })) {
-      return;
-    }
-    setAbortRequested(false);
-  }, [abortRequested, missionPhase]);
-
-  useEffect(() => {
     if (holdState.phase !== 'holding') {
       return;
     }
@@ -81,7 +74,7 @@ export function EmergencyStopControl({
       setHoldState(nextState);
 
       if (shouldDispatchAbort) {
-        setAbortRequested(true);
+        setAbortRequestedPhase(missionPhase);
         setAbortDispatchNonce((value) => value + 1);
       }
     };
@@ -89,7 +82,7 @@ export function EmergencyStopControl({
     tick();
     const intervalId = window.setInterval(tick, 50);
     return () => window.clearInterval(intervalId);
-  }, [abortPending, canAbort, holdState.phase]);
+  }, [abortPending, canAbort, holdState.phase, missionPhase]);
 
   useEffect(() => {
     if (abortDispatchNonce === 0) {
@@ -165,7 +158,9 @@ export function EmergencyStopControl({
           if (!canAbort || abortPending) {
             return;
           }
-          setAbortRequested(false);
+          if (abortRequestedPhase !== null) {
+            setAbortRequestedPhase(null);
+          }
           setHoldState(beginEmergencyStopHold(Date.now()));
         }}
         onPointerUp={cancelHold}

--- a/software/viewer/src/components/mission/EmergencyStopControl.tsx
+++ b/software/viewer/src/components/mission/EmergencyStopControl.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/emergencyStopHold';
 
 interface EmergencyStopControlProps {
+  missionId?: string;
   missionPhase: MissionPhase;
   canAbort: boolean;
   abortUnavailableReason: string | null;
@@ -27,6 +28,7 @@ interface EmergencyStopControlProps {
 interface AbortLifecycleState {
   activeWindowId: number;
   isActiveWindow: boolean;
+  missionIdentity: string | null;
   pendingWindowId: number | null;
   resolvedWindowId: number | null;
 }
@@ -34,6 +36,7 @@ interface AbortLifecycleState {
 type AbortLifecycleAction =
   | {
       type: 'sync-lifecycle';
+      missionId?: string;
       missionPhase: MissionPhase;
       abortError: string | null;
     }
@@ -72,13 +75,16 @@ function abortLifecycleReducer(
     {
       id: state.activeWindowId,
       isActive: state.isActiveWindow,
+      missionIdentity: state.missionIdentity,
     },
-    action.missionPhase
+    action.missionPhase,
+    action.missionId ?? null
   );
+  const missionReset = abortWindow.missionIdentity !== state.missionIdentity;
   const resolvedWindowId = resolveAbortRequestWindowId({
     abortWindow,
-    pendingWindowId: state.pendingWindowId,
-    resolvedWindowId: state.resolvedWindowId,
+    pendingWindowId: missionReset ? null : state.pendingWindowId,
+    resolvedWindowId: missionReset ? null : state.resolvedWindowId,
     abortError: action.abortError,
   });
 
@@ -86,11 +92,14 @@ function abortLifecycleReducer(
     ...state,
     activeWindowId: abortWindow.id,
     isActiveWindow: abortWindow.isActive,
+    missionIdentity: abortWindow.missionIdentity,
+    pendingWindowId: missionReset ? null : state.pendingWindowId,
     resolvedWindowId,
   };
 }
 
 export function EmergencyStopControl({
+  missionId,
   missionPhase,
   canAbort,
   abortUnavailableReason,
@@ -104,6 +113,7 @@ export function EmergencyStopControl({
     {
       activeWindowId: 0,
       isActiveWindow: false,
+      missionIdentity: null,
       pendingWindowId: null,
       resolvedWindowId: null,
     }
@@ -116,8 +126,9 @@ export function EmergencyStopControl({
     () => ({
       id: abortLifecycle.activeWindowId,
       isActive: abortLifecycle.isActiveWindow,
+      missionIdentity: abortLifecycle.missionIdentity,
     }),
-    [abortLifecycle.activeWindowId, abortLifecycle.isActiveWindow]
+    [abortLifecycle.activeWindowId, abortLifecycle.isActiveWindow, abortLifecycle.missionIdentity]
   );
   const abortPending = isAbortRequestPending({
     abortWindow,
@@ -149,10 +160,11 @@ export function EmergencyStopControl({
   useEffect(() => {
     dispatchAbortLifecycle({
       type: 'sync-lifecycle',
+      missionId,
       missionPhase,
       abortError,
     });
-  }, [abortError, missionPhase]);
+  }, [abortError, missionId, missionPhase]);
 
   useEffect(() => {
     if (holdState.phase !== 'holding') {

--- a/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
+++ b/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
@@ -136,13 +136,24 @@ test("EmergencyStopControl dispatches abort only from nonce changes", () => {
     /onAbortRef\.current\(\);\s*\}, \[abortDispatchNonce\]\);/s,
     "abort dispatch effect should only depend on the dispatch nonce"
   );
-  assert.ok(
-    source.includes("shouldResetAbortRequest({ abortRequested, missionPhase })"),
-    "control should explicitly clear stale abort-request state when the mission leaves the active abort lifecycle"
+  assert.match(
+    source,
+    /const \[abortRequestedPhase, setAbortRequestedPhase\] = useState<MissionPhase \| null>\(null\);/,
+    "control should scope abort requests to the mission phase that triggered them"
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*if \(!shouldResetAbortRequest\([\s\S]*?\)\) \{\s*return;\s*\}\s*setAbortRequested\(false\);\s*\}, \[abortRequested, missionPhase\]\);/s,
-    "control should reset abortRequested from a phase-change effect instead of waiting for a remount"
+    /const abortRequested = abortRequestedPhase === missionPhase;/,
+    "control should derive pending abort state from the current mission phase"
+  );
+  assert.match(
+    source,
+    /setAbortRequestedPhase\(missionPhase\);[\s\S]*setAbortDispatchNonce\(\(value\) => value \+ 1\);/s,
+    "control should only mark an abort request active when the hold flow actually dispatches"
+  );
+  assert.match(
+    source,
+    /if \(abortRequestedPhase !== null\) \{\s*setAbortRequestedPhase\(null\);\s*\}/s,
+    "control should clear any stale abort-request phase before a fresh hold begins"
   );
 });

--- a/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
+++ b/software/viewer/src/components/mission/EmergencyStopControlSurface.test.mjs
@@ -138,22 +138,27 @@ test("EmergencyStopControl dispatches abort only from nonce changes", () => {
   );
   assert.match(
     source,
-    /const \[abortRequestedPhase, setAbortRequestedPhase\] = useState<MissionPhase \| null>\(null\);/,
-    "control should scope abort requests to the mission phase that triggered them"
+    /const \[abortLifecycle, dispatchAbortLifecycle\] = useReducer\(/,
+    "control should track pending abort state in a lifecycle reducer"
   );
   assert.match(
     source,
-    /const abortRequested = abortRequestedPhase === missionPhase;/,
-    "control should derive pending abort state from the current mission phase"
+    /advanceAbortRequestWindow/,
+    "control should advance a continuous abort window across active mission phases"
   );
   assert.match(
     source,
-    /setAbortRequestedPhase\(missionPhase\);[\s\S]*setAbortDispatchNonce\(\(value\) => value \+ 1\);/s,
-    "control should only mark an abort request active when the hold flow actually dispatches"
+    /resolveAbortRequestWindowId/,
+    "control should resolve pending abort state when the request completes or fails"
   );
   assert.match(
     source,
-    /if \(abortRequestedPhase !== null\) \{\s*setAbortRequestedPhase\(null\);\s*\}/s,
-    "control should clear any stale abort-request phase before a fresh hold begins"
+    /dispatchAbortLifecycle\(\{\s*type: 'mark-pending',\s*windowId: abortLifecycleRef\.current\.activeWindowId,\s*\}\);[\s\S]*setAbortDispatchNonce\(\(value\) => value \+ 1\);/s,
+    "control should only mark the current abort window pending when the hold actually dispatches"
+  );
+  assert.match(
+    source,
+    /dispatchAbortLifecycle\(\{ type: 'clear-for-retry' \}\);/,
+    "control should clear the previous pending lifecycle state before starting a fresh hold attempt"
   );
 });

--- a/software/viewer/src/hooks/rosConnectionSurface.test.mjs
+++ b/software/viewer/src/hooks/rosConnectionSurface.test.mjs
@@ -54,7 +54,14 @@ test("viewer ROS socket creation stays centralized in the shared connection hook
 });
 
 test("viewer app provides a shared ROS connection provider", () => {
+  const providersPath = path.join(ROOT, "app", "ViewerAppProviders.tsx");
   const pagePath = path.join(ROOT, "app", "page.tsx");
-  const source = fs.readFileSync(pagePath, "utf8");
-  assert.match(source, /ROSConnectionProvider/, "page.tsx should include ROSConnectionProvider");
+  const maintenancePagePath = path.join(ROOT, "app", "maintenance", "page.tsx");
+  const providersSource = fs.readFileSync(providersPath, "utf8");
+  const pageSource = fs.readFileSync(pagePath, "utf8");
+  const maintenanceSource = fs.readFileSync(maintenancePagePath, "utf8");
+
+  assert.match(providersSource, /ROSConnectionProvider/, "ViewerAppProviders should include ROSConnectionProvider");
+  assert.match(pageSource, /ViewerAppProviders/, "page.tsx should use the shared viewer providers");
+  assert.match(maintenanceSource, /ViewerAppProviders/, "maintenance route should use the shared viewer providers");
 });

--- a/software/viewer/src/hooks/rosConnectionSurface.test.mjs
+++ b/software/viewer/src/hooks/rosConnectionSurface.test.mjs
@@ -65,3 +65,21 @@ test("viewer app provides a shared ROS connection provider", () => {
   assert.match(pageSource, /ViewerAppProviders/, "page.tsx should use the shared viewer providers");
   assert.match(maintenanceSource, /ViewerAppProviders/, "maintenance route should use the shared viewer providers");
 });
+
+test("maintenance hooks bind cached state to the live ROS connection and clear it on unsubscribe", () => {
+  const podHook = fs.readFileSync(path.join(ROOT, "hooks", "usePodStatus.ts"), "utf8");
+  const diagnosticsHook = fs.readFileSync(
+    path.join(ROOT, "hooks", "useVehicleMaintenanceDiagnostics.ts"),
+    "utf8"
+  );
+
+  for (const [label, source] of [
+    ["usePodStatus", podHook],
+    ["useVehicleMaintenanceDiagnostics", diagnosticsHook],
+  ]) {
+    assert.match(source, /connection: ROSLIB\.Ros \| null/, `${label} should bind payloads to the active ROS connection`);
+    assert.match(source, /setState\(\{\s*connection: ros,\s*payload:/s, `${label} should stamp incoming payloads with the current ROS connection`);
+    assert.match(source, /setState\(\{\s*connection: null,\s*payload: EMPTY_STATE,\s*\}\);/s, `${label} should clear cached payloads during unsubscribe cleanup`);
+    assert.match(source, /state\.connection === ros/, `${label} should suppress stale cached payloads after reconnect until a fresh message arrives`);
+  }
+});

--- a/software/viewer/src/hooks/usePodStatus.ts
+++ b/software/viewer/src/hooks/usePodStatus.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import ROSLIB from 'roslib';
+import { useSharedROSConnection } from '@/context/ROSConnectionContext';
+import {
+  parsePodStatusArray,
+  type PodStatusArrayMessage,
+} from '@/lib/ros/podStatus';
+
+const EMPTY_STATE: PodStatusArrayMessage = {
+  observedAtMs: null,
+  pods: [],
+};
+
+export function usePodStatus(): PodStatusArrayMessage {
+  const { ros, isConnected } = useSharedROSConnection();
+  const [state, setState] = useState<PodStatusArrayMessage>(EMPTY_STATE);
+
+  useEffect(() => {
+    if (!ros || !isConnected) {
+      return;
+    }
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: '/device_manager/pods',
+      messageType: 'aeris_msgs/PodStatusArray',
+    });
+
+    const handleMessage = (message: ROSLIB.Message) => {
+      try {
+        setState(parsePodStatusArray(message));
+      } catch (error) {
+        console.warn('[usePodStatus] Ignoring invalid pod status payload:', error);
+      }
+    };
+
+    topic.subscribe(handleMessage);
+    return () => topic.unsubscribe(handleMessage);
+  }, [ros, isConnected]);
+
+  return ros && isConnected ? state : EMPTY_STATE;
+}

--- a/software/viewer/src/hooks/usePodStatus.ts
+++ b/software/viewer/src/hooks/usePodStatus.ts
@@ -13,7 +13,13 @@ const EMPTY_STATE: PodStatusArrayMessage = {
 
 export function usePodStatus(): PodStatusArrayMessage {
   const { ros, isConnected } = useSharedROSConnection();
-  const [state, setState] = useState<PodStatusArrayMessage>(EMPTY_STATE);
+  const [state, setState] = useState<{
+    connection: ROSLIB.Ros | null;
+    payload: PodStatusArrayMessage;
+  }>({
+    connection: null,
+    payload: EMPTY_STATE,
+  });
 
   useEffect(() => {
     if (!ros || !isConnected) {
@@ -28,15 +34,26 @@ export function usePodStatus(): PodStatusArrayMessage {
 
     const handleMessage = (message: ROSLIB.Message) => {
       try {
-        setState(parsePodStatusArray(message));
+        setState({
+          connection: ros,
+          payload: parsePodStatusArray(message),
+        });
       } catch (error) {
         console.warn('[usePodStatus] Ignoring invalid pod status payload:', error);
       }
     };
 
     topic.subscribe(handleMessage);
-    return () => topic.unsubscribe(handleMessage);
+    return () => {
+      topic.unsubscribe(handleMessage);
+      setState({
+        connection: null,
+        payload: EMPTY_STATE,
+      });
+    };
   }, [ros, isConnected]);
 
-  return ros && isConnected ? state : EMPTY_STATE;
+  return ros && isConnected && state.connection === ros
+    ? state.payload
+    : EMPTY_STATE;
 }

--- a/software/viewer/src/hooks/useVehicleMaintenanceDiagnostics.ts
+++ b/software/viewer/src/hooks/useVehicleMaintenanceDiagnostics.ts
@@ -13,7 +13,13 @@ const EMPTY_STATE: VehicleMaintenanceDiagnosticsArrayMessage = {
 
 export function useVehicleMaintenanceDiagnostics(): VehicleMaintenanceDiagnosticsArrayMessage {
   const { ros, isConnected } = useSharedROSConnection();
-  const [state, setState] = useState<VehicleMaintenanceDiagnosticsArrayMessage>(EMPTY_STATE);
+  const [state, setState] = useState<{
+    connection: ROSLIB.Ros | null;
+    payload: VehicleMaintenanceDiagnosticsArrayMessage;
+  }>({
+    connection: null,
+    payload: EMPTY_STATE,
+  });
 
   useEffect(() => {
     if (!ros || !isConnected) {
@@ -28,15 +34,26 @@ export function useVehicleMaintenanceDiagnostics(): VehicleMaintenanceDiagnostic
 
     const handleMessage = (message: ROSLIB.Message) => {
       try {
-        setState(parseVehicleMaintenanceDiagnosticsArray(message));
+        setState({
+          connection: ros,
+          payload: parseVehicleMaintenanceDiagnosticsArray(message),
+        });
       } catch (error) {
         console.warn('[useVehicleMaintenanceDiagnostics] Ignoring invalid maintenance payload:', error);
       }
     };
 
     topic.subscribe(handleMessage);
-    return () => topic.unsubscribe(handleMessage);
+    return () => {
+      topic.unsubscribe(handleMessage);
+      setState({
+        connection: null,
+        payload: EMPTY_STATE,
+      });
+    };
   }, [ros, isConnected]);
 
-  return ros && isConnected ? state : EMPTY_STATE;
+  return ros && isConnected && state.connection === ros
+    ? state.payload
+    : EMPTY_STATE;
 }

--- a/software/viewer/src/hooks/useVehicleMaintenanceDiagnostics.ts
+++ b/software/viewer/src/hooks/useVehicleMaintenanceDiagnostics.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import ROSLIB from 'roslib';
+import { useSharedROSConnection } from '@/context/ROSConnectionContext';
+import {
+  parseVehicleMaintenanceDiagnosticsArray,
+  type VehicleMaintenanceDiagnosticsArrayMessage,
+} from '@/lib/ros/maintenanceDiagnostics';
+
+const EMPTY_STATE: VehicleMaintenanceDiagnosticsArrayMessage = {
+  observedAtMs: null,
+  vehicles: [],
+};
+
+export function useVehicleMaintenanceDiagnostics(): VehicleMaintenanceDiagnosticsArrayMessage {
+  const { ros, isConnected } = useSharedROSConnection();
+  const [state, setState] = useState<VehicleMaintenanceDiagnosticsArrayMessage>(EMPTY_STATE);
+
+  useEffect(() => {
+    if (!ros || !isConnected) {
+      return;
+    }
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: '/vehicle/maintenance_diagnostics',
+      messageType: 'aeris_msgs/VehicleMaintenanceDiagnosticsArray',
+    });
+
+    const handleMessage = (message: ROSLIB.Message) => {
+      try {
+        setState(parseVehicleMaintenanceDiagnosticsArray(message));
+      } catch (error) {
+        console.warn('[useVehicleMaintenanceDiagnostics] Ignoring invalid maintenance payload:', error);
+      }
+    };
+
+    topic.subscribe(handleMessage);
+    return () => topic.unsubscribe(handleMessage);
+  }, [ros, isConnected]);
+
+  return ros && isConnected ? state : EMPTY_STATE;
+}

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -1,6 +1,34 @@
 export const HOLD_TO_ABORT_MS = 1500;
 const ACTIVE_ABORT_PHASES = new Set(["SEARCHING", "TRACKING"]);
 
+export function isActiveAbortPhase(missionPhase) {
+  return ACTIVE_ABORT_PHASES.has(missionPhase);
+}
+
+export function advanceAbortRequestWindow(currentWindow, missionPhase) {
+  const previous = currentWindow ?? { id: 0, isActive: false };
+  const nextIsActive = isActiveAbortPhase(missionPhase);
+
+  if (nextIsActive && !previous.isActive) {
+    return {
+      id: previous.id + 1,
+      isActive: true,
+    };
+  }
+
+  if (!nextIsActive && previous.isActive) {
+    return {
+      id: previous.id,
+      isActive: false,
+    };
+  }
+
+  return {
+    id: previous.id,
+    isActive: nextIsActive,
+  };
+}
+
 export function createIdleEmergencyStopHold() {
   return {
     phase: "idle",
@@ -25,18 +53,35 @@ export function cancelEmergencyStopHoldState(state) {
 }
 
 export function isAbortRequestPending({
-  abortRequested,
+  abortWindow,
+  pendingWindowId,
+  resolvedWindowId,
   abortError,
-  missionPhase,
 }) {
-  return abortRequested && !abortError && ACTIVE_ABORT_PHASES.has(missionPhase);
+  return (
+    pendingWindowId !== null &&
+    pendingWindowId === abortWindow.id &&
+    resolvedWindowId !== pendingWindowId &&
+    !abortError &&
+    abortWindow.isActive
+  );
 }
 
-export function shouldResetAbortRequest({
-  abortRequested,
-  missionPhase,
+export function resolveAbortRequestWindowId({
+  abortWindow,
+  pendingWindowId,
+  resolvedWindowId,
+  abortError,
 }) {
-  return abortRequested && !ACTIVE_ABORT_PHASES.has(missionPhase);
+  if (pendingWindowId === null || pendingWindowId !== abortWindow.id) {
+    return resolvedWindowId;
+  }
+
+  if (abortError || !abortWindow.isActive) {
+    return pendingWindowId;
+  }
+
+  return resolvedWindowId;
 }
 
 export function advanceEmergencyStopHold({

--- a/software/viewer/src/lib/emergencyStopHold.js
+++ b/software/viewer/src/lib/emergencyStopHold.js
@@ -5,14 +5,40 @@ export function isActiveAbortPhase(missionPhase) {
   return ACTIVE_ABORT_PHASES.has(missionPhase);
 }
 
-export function advanceAbortRequestWindow(currentWindow, missionPhase) {
-  const previous = currentWindow ?? { id: 0, isActive: false };
+/**
+ * @param {string | null | undefined} missionIdentity
+ */
+function normalizeMissionIdentity(missionIdentity) {
+  const normalized = typeof missionIdentity === "string" ? missionIdentity.trim() : "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * @param {{ id: number; isActive: boolean; missionIdentity?: string | null } | null | undefined} currentWindow
+ * @param {string} missionPhase
+ * @param {string | null | undefined} missionIdentity
+ */
+export function advanceAbortRequestWindow(currentWindow, missionPhase, missionIdentity = null) {
+  const previous = currentWindow ?? { id: 0, isActive: false, missionIdentity: null };
   const nextIsActive = isActiveAbortPhase(missionPhase);
+  const nextMissionIdentity = normalizeMissionIdentity(missionIdentity);
+
+  if (
+    nextMissionIdentity !== null &&
+    nextMissionIdentity !== previous.missionIdentity
+  ) {
+    return {
+      id: previous.id + 1,
+      isActive: nextIsActive,
+      missionIdentity: nextMissionIdentity,
+    };
+  }
 
   if (nextIsActive && !previous.isActive) {
     return {
       id: previous.id + 1,
       isActive: true,
+      missionIdentity: nextMissionIdentity ?? previous.missionIdentity ?? null,
     };
   }
 
@@ -20,12 +46,14 @@ export function advanceAbortRequestWindow(currentWindow, missionPhase) {
     return {
       id: previous.id,
       isActive: false,
+      missionIdentity: nextMissionIdentity ?? previous.missionIdentity ?? null,
     };
   }
 
   return {
     id: previous.id,
     isActive: nextIsActive,
+    missionIdentity: nextMissionIdentity ?? previous.missionIdentity ?? null,
   };
 }
 

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  advanceAbortRequestWindow,
   advanceEmergencyStopHold,
   HOLD_TO_ABORT_MS,
   beginEmergencyStopHold,
@@ -9,7 +10,7 @@ import {
   cancelEmergencyStopHoldState,
   createIdleEmergencyStopHold,
   isAbortRequestPending,
-  shouldResetAbortRequest,
+  resolveAbortRequestWindowId,
   tickEmergencyStopHold,
 } from "./emergencyStopHold.js";
 
@@ -66,67 +67,79 @@ test("cancel events clear hold progress without dispatching completion", () => {
   assert.deepEqual(afterCancel, createIdleEmergencyStopHold());
 });
 
-test("abort request state clears once the mission leaves the active abort path", () => {
+test("abort request state stays pending across active abort phases and drops outside the abort window", () => {
+  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
   assert.equal(
     isAbortRequestPending({
-      abortRequested: true,
+      abortWindow,
+      pendingWindowId: abortWindow.id,
+      resolvedWindowId: null,
       abortError: null,
-      missionPhase: "SEARCHING",
     }),
     true
   );
+
+  abortWindow = advanceAbortRequestWindow(abortWindow, "TRACKING");
   assert.equal(
     isAbortRequestPending({
-      abortRequested: true,
+      abortWindow,
+      pendingWindowId: abortWindow.id,
+      resolvedWindowId: null,
       abortError: null,
-      missionPhase: "ABORTED",
     }),
-    false
+    true
   );
+
+  abortWindow = advanceAbortRequestWindow(abortWindow, "ABORTED");
   assert.equal(
     isAbortRequestPending({
-      abortRequested: true,
+      abortWindow,
+      pendingWindowId: abortWindow.id,
+      resolvedWindowId: null,
       abortError: null,
-      missionPhase: "IDLE",
-    }),
-    false
-  );
-  assert.equal(
-    isAbortRequestPending({
-      abortRequested: true,
-      abortError: "Mission abort was rejected by orchestrator.",
-      missionPhase: "SEARCHING",
     }),
     false
   );
 });
 
-test("abort request resets once the mission leaves active abort phases", () => {
+test("abort request resolution prevents stale lockout when the same phase name returns later", () => {
+  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
+  const firstWindowId = abortWindow.id;
+  const resolvedWindowId = resolveAbortRequestWindowId({
+    abortWindow: advanceAbortRequestWindow(abortWindow, "ABORTED"),
+    pendingWindowId: firstWindowId,
+    resolvedWindowId: null,
+    abortError: null,
+  });
+
+  abortWindow = advanceAbortRequestWindow({ id: firstWindowId, isActive: false }, "SEARCHING");
+  assert.equal(abortWindow.id, firstWindowId + 1);
   assert.equal(
-    shouldResetAbortRequest({
-      abortRequested: true,
-      missionPhase: "ABORTED",
-    }),
-    true
-  );
-  assert.equal(
-    shouldResetAbortRequest({
-      abortRequested: true,
-      missionPhase: "IDLE",
-    }),
-    true
-  );
-  assert.equal(
-    shouldResetAbortRequest({
-      abortRequested: true,
-      missionPhase: "SEARCHING",
+    isAbortRequestPending({
+      abortWindow,
+      pendingWindowId: firstWindowId,
+      resolvedWindowId,
+      abortError: "Mission abort was rejected by orchestrator.",
     }),
     false
   );
+});
+
+test("abort request resolution latches failures until a new hold starts", () => {
+  const abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
+  const resolvedWindowId = resolveAbortRequestWindowId({
+    abortWindow,
+    pendingWindowId: abortWindow.id,
+    resolvedWindowId: null,
+    abortError: "Mission abort was rejected by orchestrator.",
+  });
+
   assert.equal(
-    shouldResetAbortRequest({
-      abortRequested: false,
-      missionPhase: "ABORTED",
+    isAbortRequestPending({
+      abortWindow,
+      pendingWindowId: abortWindow.id,
+      resolvedWindowId,
+      abortError: null,
     }),
     false
   );

--- a/software/viewer/src/lib/emergencyStopHold.test.mjs
+++ b/software/viewer/src/lib/emergencyStopHold.test.mjs
@@ -68,7 +68,7 @@ test("cancel events clear hold progress without dispatching completion", () => {
 });
 
 test("abort request state stays pending across active abort phases and drops outside the abort window", () => {
-  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
+  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false, missionIdentity: null }, "SEARCHING", "mission-a");
   assert.equal(
     isAbortRequestPending({
       abortWindow,
@@ -79,7 +79,7 @@ test("abort request state stays pending across active abort phases and drops out
     true
   );
 
-  abortWindow = advanceAbortRequestWindow(abortWindow, "TRACKING");
+  abortWindow = advanceAbortRequestWindow(abortWindow, "TRACKING", "mission-a");
   assert.equal(
     isAbortRequestPending({
       abortWindow,
@@ -90,7 +90,7 @@ test("abort request state stays pending across active abort phases and drops out
     true
   );
 
-  abortWindow = advanceAbortRequestWindow(abortWindow, "ABORTED");
+  abortWindow = advanceAbortRequestWindow(abortWindow, "ABORTED", "mission-a");
   assert.equal(
     isAbortRequestPending({
       abortWindow,
@@ -103,16 +103,20 @@ test("abort request state stays pending across active abort phases and drops out
 });
 
 test("abort request resolution prevents stale lockout when the same phase name returns later", () => {
-  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
+  let abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false, missionIdentity: null }, "SEARCHING", "mission-a");
   const firstWindowId = abortWindow.id;
   const resolvedWindowId = resolveAbortRequestWindowId({
-    abortWindow: advanceAbortRequestWindow(abortWindow, "ABORTED"),
+    abortWindow: advanceAbortRequestWindow(abortWindow, "ABORTED", "mission-a"),
     pendingWindowId: firstWindowId,
     resolvedWindowId: null,
     abortError: null,
   });
 
-  abortWindow = advanceAbortRequestWindow({ id: firstWindowId, isActive: false }, "SEARCHING");
+  abortWindow = advanceAbortRequestWindow(
+    { id: firstWindowId, isActive: false, missionIdentity: "mission-a" },
+    "SEARCHING",
+    "mission-b"
+  );
   assert.equal(abortWindow.id, firstWindowId + 1);
   assert.equal(
     isAbortRequestPending({
@@ -126,7 +130,7 @@ test("abort request resolution prevents stale lockout when the same phase name r
 });
 
 test("abort request resolution latches failures until a new hold starts", () => {
-  const abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false }, "SEARCHING");
+  const abortWindow = advanceAbortRequestWindow({ id: 0, isActive: false, missionIdentity: null }, "SEARCHING", "mission-a");
   const resolvedWindowId = resolveAbortRequestWindowId({
     abortWindow,
     pendingWindowId: abortWindow.id,
@@ -139,6 +143,32 @@ test("abort request resolution latches failures until a new hold starts", () => 
       abortWindow,
       pendingWindowId: abortWindow.id,
       resolvedWindowId,
+      abortError: null,
+    }),
+    false
+  );
+});
+
+test("active-to-active mission handoff clears stale pending abort state", () => {
+  const firstMissionWindow = advanceAbortRequestWindow(
+    { id: 0, isActive: false, missionIdentity: null },
+    "SEARCHING",
+    "mission-a"
+  );
+
+  const nextMissionWindow = advanceAbortRequestWindow(
+    firstMissionWindow,
+    "TRACKING",
+    "mission-b"
+  );
+
+  assert.equal(nextMissionWindow.id, firstMissionWindow.id + 1);
+  assert.equal(nextMissionWindow.missionIdentity, "mission-b");
+  assert.equal(
+    isAbortRequestPending({
+      abortWindow: nextMissionWindow,
+      pendingWindowId: firstMissionWindow.id,
+      resolvedWindowId: null,
       abortError: null,
     }),
     false

--- a/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
+++ b/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -9,6 +9,10 @@ import ts from "typescript";
 const sourcePath = new URL("./maintenanceDiagnostics.ts", import.meta.url);
 const source = fs.readFileSync(sourcePath, "utf8");
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-maintenance-diagnostics-"));
+
+after(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
 
 fs.writeFileSync(
   path.join(tempDir, "degradedVehicleState.mjs"),
@@ -234,4 +238,40 @@ test("registered pods with explicit readiness failures stay actionable as degrad
 
   assert.equal(projected.vehicles[0].pods[0].state, "warning");
   assert.equal(projected.vehicles[0].summaryChecks.sensors.state, "warning");
+});
+
+test("calibration roll-up keeps the worst reported detail state", () => {
+  const projected = projectFleetDiagnostics({
+    nowMs: 5_000,
+    telemetry: [
+      {
+        id: "scout_4",
+        name: "SCOUT 4",
+        batteryPercent: 88,
+        altitudeMeters: 0,
+        linkQualityPercent: 83,
+        lastUpdate: 4_900,
+        missionOnline: true,
+      },
+    ],
+    diagnostics: [
+      {
+        vehicleId: "scout_4",
+        motorHealthState: "healthy",
+        calibrationState: "healthy",
+        calibrationDetail: "Calibration current",
+        imuState: "blocked",
+        imuDetail: "Bias table missing",
+        compassState: "healthy",
+        compassDetail: "Compass offsets current",
+        accelerometerState: "healthy",
+        accelerometerDetail: "Accelerometer aligned",
+      },
+    ],
+    pods: [],
+  });
+
+  assert.equal(projected.vehicles[0].summaryChecks.calibration.state, "blocked");
+  assert.equal(projected.vehicles[0].summaryChecks.calibration.summary, "Calibration blocking readiness");
+  assert.equal(projected.vehicles[0].detailChecks[0].state, "blocked");
 });

--- a/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
+++ b/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const sourcePath = new URL("./maintenanceDiagnostics.ts", import.meta.url);
+const source = fs.readFileSync(sourcePath, "utf8");
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-maintenance-diagnostics-"));
+
+fs.writeFileSync(
+  path.join(tempDir, "degradedVehicleState.mjs"),
+  `
+    export function deriveVehicleDegradedState({
+      lastUpdate,
+      missionOnline,
+      deliveryMode,
+      isRetroactive,
+      now = Date.now(),
+      staleTimeoutMs = 5000,
+    } = {}) {
+      const hasTelemetry = Number.isFinite(lastUpdate);
+      const ageMs = hasTelemetry ? Math.max(0, now - lastUpdate) : Infinity;
+      const telemetryStale = ageMs > staleTimeoutMs;
+      const telemetryFresh = hasTelemetry && ageMs <= staleTimeoutMs;
+      const missionOffline = missionOnline === false && !telemetryFresh;
+      const offline = telemetryStale || missionOffline;
+      const replayed = deliveryMode === "replayed" || isRetroactive === true;
+      return {
+        status: offline ? "offline" : replayed ? "warning" : "active",
+        offline,
+        retained: ageMs <= 120000,
+        replayed,
+        lastContactAgeMs: hasTelemetry ? ageMs : null,
+        staleSinceMs: offline && hasTelemetry ? lastUpdate + staleTimeoutMs : null,
+      };
+    }
+  `,
+  "utf8"
+);
+
+const compiled = ts.transpileModule(
+  source.replace("./degradedVehicleState.js", "./degradedVehicleState.mjs"),
+  {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }
+).outputText;
+const modulePath = path.join(tempDir, "maintenanceDiagnostics.mjs");
+fs.writeFileSync(modulePath, compiled, "utf8");
+
+const {
+  createDemoFleetDiagnostics,
+  projectFleetDiagnostics,
+} = await import(pathToFileURL(modulePath).href);
+
+test("projectFleetDiagnostics merges telemetry, pods, and maintenance diagnostics into readiness buckets", () => {
+  const projected = projectFleetDiagnostics({
+    nowMs: 20_000,
+    telemetry: [
+      {
+        id: "scout_1",
+        name: "SCOUT 1",
+        batteryPercent: 81,
+        altitudeMeters: 0,
+        linkQualityPercent: 88,
+        lastUpdate: 18_000,
+        missionOnline: true,
+      },
+      {
+        id: "scout_2",
+        name: "SCOUT 2",
+        batteryPercent: 57,
+        altitudeMeters: 0,
+        linkQualityPercent: 52,
+        lastUpdate: 17_000,
+        missionOnline: true,
+      },
+      {
+        id: "ranger_1",
+        name: "RANGER 1",
+        batteryPercent: 64,
+        altitudeMeters: 0,
+        linkQualityPercent: 26,
+        lastUpdate: 11_000,
+        missionOnline: false,
+      },
+    ],
+    diagnostics: [
+      {
+        vehicleId: "scout_1",
+        motorHealthState: "healthy",
+        motorHealthDetail: "All motor tests nominal",
+        calibrationState: "healthy",
+        calibrationDetail: "Calibration current",
+        imuState: "healthy",
+        imuDetail: "IMU drift nominal",
+        compassState: "healthy",
+        compassDetail: "Compass offsets current",
+        accelerometerState: "healthy",
+        accelerometerDetail: "Accelerometer aligned",
+      },
+      {
+        vehicleId: "scout_2",
+        motorHealthState: "warning",
+        motorHealthDetail: "Motor 3 current ripple above baseline",
+        calibrationState: "warning",
+        calibrationDetail: "Compass recalibration due soon",
+        imuState: "healthy",
+        imuDetail: "IMU drift nominal",
+        compassState: "warning",
+        compassDetail: "Recheck before next sortie",
+        accelerometerState: "healthy",
+        accelerometerDetail: "Accelerometer aligned",
+      },
+      {
+        vehicleId: "ranger_1",
+        motorHealthState: "blocked",
+        motorHealthDetail: "Motor 2 ESC fault latched",
+        calibrationState: "blocked",
+        calibrationDetail: "IMU calibration invalid",
+        imuState: "blocked",
+        imuDetail: "Bias table missing",
+        compassState: "warning",
+        compassDetail: "Compass offsets stale",
+        accelerometerState: "warning",
+        accelerometerDetail: "Tolerance trending high",
+      },
+    ],
+    pods: [
+      {
+        vehicleId: "scout_1",
+        slotId: "front-left",
+        podSerial: "THM-1",
+        podType: "thermal",
+        lifecycleState: "registered",
+        connected: true,
+        powerReady: true,
+        linkReady: true,
+        capabilities: ["thermal"],
+      },
+      {
+        vehicleId: "scout_2",
+        slotId: "belly",
+        podSerial: "GAS-9",
+        podType: "hazmat",
+        lifecycleState: "registered",
+        connected: true,
+        powerReady: true,
+        linkReady: false,
+        capabilities: ["gas", "hazmat"],
+      },
+      {
+        vehicleId: "ranger_1",
+        slotId: "rear-bay",
+        podSerial: "LDR-4",
+        podType: "lidar",
+        lifecycleState: "faulted",
+        connected: false,
+        powerReady: false,
+        linkReady: false,
+        capabilities: ["lidar"],
+      },
+    ],
+  });
+
+  assert.equal(projected.summary.readyCount, 1);
+  assert.equal(projected.summary.warningCount, 1);
+  assert.equal(projected.summary.blockedCount, 1);
+  assert.equal(projected.summary.connectedCount, 2);
+  assert.equal(projected.summary.averageLinkQuality, 55);
+
+  const scoutOne = projected.vehicles.find((vehicle) => vehicle.id === "scout_1");
+  assert.equal(scoutOne.readiness, "ready");
+  assert.equal(scoutOne.summaryChecks.motor.summary, "All motor tests nominal");
+  assert.equal(scoutOne.summaryChecks.sensors.summary, "1/1 pods ready");
+
+  const scoutTwo = projected.vehicles.find((vehicle) => vehicle.id === "scout_2");
+  assert.equal(scoutTwo.readiness, "warning");
+  assert.equal(scoutTwo.summaryChecks.mesh.state, "warning");
+  assert.equal(scoutTwo.summaryChecks.calibration.state, "warning");
+
+  const ranger = projected.vehicles.find((vehicle) => vehicle.id === "ranger_1");
+  assert.equal(ranger.readiness, "blocked");
+  assert.equal(ranger.isOffline, true);
+  assert.equal(ranger.summaryChecks.motor.state, "blocked");
+  assert.equal(ranger.detailChecks[0].label, "IMU calibration");
+  assert.equal(ranger.pods[0].lifecycleLabel, "Faulted");
+});
+
+test("createDemoFleetDiagnostics keeps the maintenance route populated during disconnected local development", () => {
+  const projected = createDemoFleetDiagnostics();
+
+  assert.equal(projected.vehicles.length, 3);
+  assert.equal(projected.summary.readyCount, 1);
+  assert.equal(projected.summary.warningCount, 1);
+  assert.equal(projected.summary.blockedCount, 1);
+});

--- a/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
+++ b/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
@@ -190,6 +190,7 @@ test("projectFleetDiagnostics merges telemetry, pods, and maintenance diagnostic
   assert.equal(ranger.summaryChecks.motor.state, "blocked");
   assert.equal(ranger.detailChecks[0].label, "IMU calibration");
   assert.equal(ranger.pods[0].lifecycleLabel, "Faulted");
+  assert.equal(scoutTwo.pods[0].state, "warning");
 });
 
 test("createDemoFleetDiagnostics keeps the maintenance route populated during disconnected local development", () => {
@@ -199,4 +200,38 @@ test("createDemoFleetDiagnostics keeps the maintenance route populated during di
   assert.equal(projected.summary.readyCount, 1);
   assert.equal(projected.summary.warningCount, 1);
   assert.equal(projected.summary.blockedCount, 1);
+});
+
+test("registered pods with explicit readiness failures stay actionable as degraded warnings", () => {
+  const projected = projectFleetDiagnostics({
+    nowMs: 5_000,
+    telemetry: [
+      {
+        id: "scout_3",
+        name: "SCOUT 3",
+        batteryPercent: 73,
+        altitudeMeters: 0,
+        linkQualityPercent: 79,
+        lastUpdate: 4_500,
+        missionOnline: true,
+      },
+    ],
+    diagnostics: [],
+    pods: [
+      {
+        vehicleId: "scout_3",
+        slotId: "top-rail",
+        podSerial: "THM-11",
+        podType: "thermal",
+        lifecycleState: "registered",
+        connected: true,
+        powerReady: true,
+        linkReady: false,
+        capabilities: ["thermal"],
+      },
+    ],
+  });
+
+  assert.equal(projected.vehicles[0].pods[0].state, "warning");
+  assert.equal(projected.vehicles[0].summaryChecks.sensors.state, "warning");
 });

--- a/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
+++ b/software/viewer/src/lib/maintenanceDiagnostics.test.mjs
@@ -176,7 +176,7 @@ test("projectFleetDiagnostics merges telemetry, pods, and maintenance diagnostic
   assert.equal(projected.summary.warningCount, 1);
   assert.equal(projected.summary.blockedCount, 1);
   assert.equal(projected.summary.connectedCount, 2);
-  assert.equal(projected.summary.averageLinkQuality, 55);
+  assert.equal(projected.summary.averageLinkQuality, 70);
 
   const scoutOne = projected.vehicles.find((vehicle) => vehicle.id === "scout_1");
   assert.equal(scoutOne.readiness, "ready");
@@ -274,4 +274,44 @@ test("calibration roll-up keeps the worst reported detail state", () => {
   assert.equal(projected.vehicles[0].summaryChecks.calibration.state, "blocked");
   assert.equal(projected.vehicles[0].summaryChecks.calibration.summary, "Calibration blocking readiness");
   assert.equal(projected.vehicles[0].detailChecks[0].state, "blocked");
+});
+
+test("fleet mesh average excludes offline vehicles with stale link readings", () => {
+  const projected = projectFleetDiagnostics({
+    nowMs: 12_000,
+    telemetry: [
+      {
+        id: "scout_5",
+        name: "SCOUT 5",
+        batteryPercent: 91,
+        altitudeMeters: 0,
+        linkQualityPercent: 84,
+        lastUpdate: 11_500,
+        missionOnline: true,
+      },
+      {
+        id: "scout_6",
+        name: "SCOUT 6",
+        batteryPercent: 77,
+        altitudeMeters: 0,
+        linkQualityPercent: 56,
+        lastUpdate: 11_000,
+        missionOnline: true,
+      },
+      {
+        id: "ranger_2",
+        name: "RANGER 2",
+        batteryPercent: 42,
+        altitudeMeters: 0,
+        linkQualityPercent: 5,
+        lastUpdate: 4_000,
+        missionOnline: false,
+      },
+    ],
+    diagnostics: [],
+    pods: [],
+  });
+
+  assert.equal(projected.summary.connectedCount, 2);
+  assert.equal(projected.summary.averageLinkQuality, 70);
 });

--- a/software/viewer/src/lib/maintenanceDiagnostics.ts
+++ b/software/viewer/src/lib/maintenanceDiagnostics.ts
@@ -97,6 +97,10 @@ const DIAGNOSTIC_RANK: Record<DiagnosticState, number> = {
   blocked: 3,
 };
 
+function getWorseDiagnosticState(left: DiagnosticState, right: DiagnosticState): DiagnosticState {
+  return DIAGNOSTIC_RANK[left] >= DIAGNOSTIC_RANK[right] ? left : right;
+}
+
 function titleCaseLifecycle(input: string): string {
   return input
     .split(/[_\s-]+/)
@@ -234,10 +238,15 @@ function summarizeCalibration(diagnostics?: VehicleMaintenanceSnapshot): {
   ];
 
   const derivedWorstDetail = detailChecks.reduce<DiagnosticState>(
-    (current, detail) => (DIAGNOSTIC_RANK[detail.state] > DIAGNOSTIC_RANK[current] ? detail.state : current),
+    (current, detail) => getWorseDiagnosticState(current, detail.state),
     'healthy'
   );
-  const calibrationState = diagnostics?.calibrationState ?? derivedWorstDetail;
+  const reportedCalibrationState = diagnostics?.calibrationState ?? 'healthy';
+  const calibrationState = getWorseDiagnosticState(reportedCalibrationState, derivedWorstDetail);
+  const calibrationDetail =
+    DIAGNOSTIC_RANK[reportedCalibrationState] >= DIAGNOSTIC_RANK[derivedWorstDetail]
+      ? diagnostics?.calibrationDetail
+      : undefined;
 
   return {
     summary: {
@@ -252,9 +261,9 @@ function summarizeCalibration(diagnostics?: VehicleMaintenanceSnapshot): {
             : calibrationState === 'warning'
               ? 'Calibration follow-up required'
               : 'Calibration unavailable',
-        diagnostics?.calibrationDetail
+        calibrationDetail
       ),
-      detail: diagnostics?.calibrationDetail,
+      detail: calibrationDetail,
     },
     details: detailChecks,
   };

--- a/software/viewer/src/lib/maintenanceDiagnostics.ts
+++ b/software/viewer/src/lib/maintenanceDiagnostics.ts
@@ -1,0 +1,538 @@
+import { deriveVehicleDegradedState } from './degradedVehicleState.js';
+
+export type DiagnosticState = 'healthy' | 'warning' | 'blocked' | 'unknown';
+export type FleetReadinessState = 'ready' | 'warning' | 'blocked';
+
+export interface MaintenanceTelemetrySnapshot {
+  id: string;
+  name: string;
+  batteryPercent: number | null;
+  altitudeMeters: number;
+  linkQualityPercent?: number;
+  lastUpdate?: number;
+  deliveryMode?: 'live' | 'replayed';
+  isRetroactive?: boolean;
+  missionOnline?: boolean;
+}
+
+export interface MaintenancePodSnapshot {
+  vehicleId: string;
+  slotId: string;
+  podSerial: string;
+  podType: string;
+  lifecycleState: string;
+  connected: boolean;
+  powerReady: boolean;
+  linkReady: boolean;
+  capabilities: string[];
+  faultDetail?: string;
+  rejectionDetail?: string;
+}
+
+export interface VehicleMaintenanceSnapshot {
+  vehicleId: string;
+  motorHealthState: DiagnosticState;
+  motorHealthDetail?: string;
+  calibrationState: DiagnosticState;
+  calibrationDetail?: string;
+  imuState: DiagnosticState;
+  imuDetail?: string;
+  compassState: DiagnosticState;
+  compassDetail?: string;
+  accelerometerState: DiagnosticState;
+  accelerometerDetail?: string;
+  observedAtMs?: number | null;
+}
+
+export interface MaintenanceCheckViewModel {
+  label: string;
+  state: DiagnosticState;
+  summary: string;
+  detail?: string;
+}
+
+export interface MaintenancePodViewModel {
+  slotId: string;
+  podSerial: string;
+  podType: string;
+  lifecycleLabel: string;
+  state: DiagnosticState;
+  capabilities: string[];
+}
+
+export interface MaintenanceVehicleViewModel {
+  id: string;
+  name: string;
+  readiness: FleetReadinessState;
+  readinessSummary: string;
+  batteryPercent: number | null;
+  altitudeMeters: number;
+  lastContactAgeMs: number | null;
+  isOffline: boolean;
+  summaryChecks: {
+    motor: MaintenanceCheckViewModel;
+    sensors: MaintenanceCheckViewModel;
+    mesh: MaintenanceCheckViewModel;
+    calibration: MaintenanceCheckViewModel;
+  };
+  detailChecks: MaintenanceCheckViewModel[];
+  pods: MaintenancePodViewModel[];
+}
+
+export interface FleetDiagnosticsViewModel {
+  vehicles: MaintenanceVehicleViewModel[];
+  summary: {
+    readyCount: number;
+    warningCount: number;
+    blockedCount: number;
+    connectedCount: number;
+    averageLinkQuality: number | null;
+  };
+}
+
+const DIAGNOSTIC_RANK: Record<DiagnosticState, number> = {
+  healthy: 0,
+  unknown: 1,
+  warning: 2,
+  blocked: 3,
+};
+
+function titleCaseLifecycle(input: string): string {
+  return input
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function summarizeDiagnosticState(state: DiagnosticState, fallback: string, detail?: string): string {
+  if (detail && detail.trim().length > 0) {
+    return detail.trim();
+  }
+  return fallback;
+}
+
+function summarizeLinkQuality(linkQualityPercent?: number): MaintenanceCheckViewModel {
+  if (typeof linkQualityPercent !== 'number' || !Number.isFinite(linkQualityPercent)) {
+    return {
+      label: 'Mesh radio',
+      state: 'unknown',
+      summary: 'Link quality unavailable',
+    };
+  }
+  const rounded = Math.round(linkQualityPercent);
+  if (rounded >= 70) {
+    return { label: 'Mesh radio', state: 'healthy', summary: `${rounded}% stable mesh link` };
+  }
+  if (rounded >= 40) {
+    return { label: 'Mesh radio', state: 'warning', summary: `${rounded}% degraded mesh link` };
+  }
+  return { label: 'Mesh radio', state: 'blocked', summary: `${rounded}% unreliable mesh link` };
+}
+
+function classifyPodState(pod: MaintenancePodSnapshot): { state: DiagnosticState; lifecycleLabel: string } {
+  const lifecycle = String(pod.lifecycleState ?? 'unknown').trim().toLowerCase();
+  if (lifecycle === 'faulted' || lifecycle === 'rejected') {
+    return { state: 'blocked', lifecycleLabel: titleCaseLifecycle(lifecycle) };
+  }
+  if (
+    lifecycle === 'disconnected' ||
+    lifecycle === 'validating' ||
+    lifecycle === 'power_check' ||
+    lifecycle === 'soft_start' ||
+    lifecycle === 'enumerating'
+  ) {
+    return { state: 'warning', lifecycleLabel: titleCaseLifecycle(lifecycle) };
+  }
+  if (lifecycle === 'registered' && pod.connected && pod.powerReady && pod.linkReady) {
+    return { state: 'healthy', lifecycleLabel: 'Registered' };
+  }
+  if (lifecycle === 'detected') {
+    return { state: 'warning', lifecycleLabel: 'Detected' };
+  }
+  return { state: 'unknown', lifecycleLabel: titleCaseLifecycle(lifecycle || 'unknown') || 'Unknown' };
+}
+
+function summarizePods(pods: MaintenancePodSnapshot[]): {
+  summary: MaintenanceCheckViewModel;
+  detail: MaintenancePodViewModel[];
+} {
+  if (pods.length === 0) {
+    return {
+      summary: {
+        label: 'Sensors',
+        state: 'unknown',
+        summary: 'No pod diagnostics reported',
+      },
+      detail: [],
+    };
+  }
+
+  const detail = pods.map((pod) => {
+    const classified = classifyPodState(pod);
+    return {
+      slotId: pod.slotId,
+      podSerial: pod.podSerial,
+      podType: pod.podType,
+      lifecycleLabel: classified.lifecycleLabel,
+      state: classified.state,
+      capabilities: pod.capabilities,
+    };
+  });
+
+  const worstState = detail.reduce<DiagnosticState>(
+    (current, pod) => (DIAGNOSTIC_RANK[pod.state] > DIAGNOSTIC_RANK[current] ? pod.state : current),
+    'healthy'
+  );
+
+  const healthyCount = detail.filter((pod) => pod.state === 'healthy').length;
+  const degradedCount = detail.length - healthyCount;
+
+  return {
+    summary: {
+      label: 'Sensors',
+      state: worstState,
+      summary:
+        degradedCount === 0
+          ? `${healthyCount}/${detail.length} pods ready`
+          : `${degradedCount} pod${degradedCount === 1 ? '' : 's'} need attention`,
+    },
+    detail,
+  };
+}
+
+function summarizeCalibration(diagnostics?: VehicleMaintenanceSnapshot): {
+  summary: MaintenanceCheckViewModel;
+  details: MaintenanceCheckViewModel[];
+} {
+  const detailChecks: MaintenanceCheckViewModel[] = [
+    {
+      label: 'IMU calibration',
+      state: diagnostics?.imuState ?? 'unknown',
+      summary: summarizeDiagnosticState(diagnostics?.imuState ?? 'unknown', 'IMU calibration unavailable', diagnostics?.imuDetail),
+      detail: diagnostics?.imuDetail,
+    },
+    {
+      label: 'Compass calibration',
+      state: diagnostics?.compassState ?? 'unknown',
+      summary: summarizeDiagnosticState(diagnostics?.compassState ?? 'unknown', 'Compass calibration unavailable', diagnostics?.compassDetail),
+      detail: diagnostics?.compassDetail,
+    },
+    {
+      label: 'Accelerometer',
+      state: diagnostics?.accelerometerState ?? 'unknown',
+      summary: summarizeDiagnosticState(
+        diagnostics?.accelerometerState ?? 'unknown',
+        'Accelerometer calibration unavailable',
+        diagnostics?.accelerometerDetail
+      ),
+      detail: diagnostics?.accelerometerDetail,
+    },
+  ];
+
+  const derivedWorstDetail = detailChecks.reduce<DiagnosticState>(
+    (current, detail) => (DIAGNOSTIC_RANK[detail.state] > DIAGNOSTIC_RANK[current] ? detail.state : current),
+    'healthy'
+  );
+  const calibrationState = diagnostics?.calibrationState ?? derivedWorstDetail;
+
+  return {
+    summary: {
+      label: 'Calibration',
+      state: calibrationState,
+      summary: summarizeDiagnosticState(
+        calibrationState,
+        calibrationState === 'healthy'
+          ? 'Calibration checks passed'
+          : calibrationState === 'blocked'
+            ? 'Calibration blocking readiness'
+            : calibrationState === 'warning'
+              ? 'Calibration follow-up required'
+              : 'Calibration unavailable',
+        diagnostics?.calibrationDetail
+      ),
+      detail: diagnostics?.calibrationDetail,
+    },
+    details: detailChecks,
+  };
+}
+
+function summarizeMotorHealth(diagnostics?: VehicleMaintenanceSnapshot): MaintenanceCheckViewModel {
+  const state = diagnostics?.motorHealthState ?? 'unknown';
+  return {
+    label: 'Motor health',
+    state,
+    summary: summarizeDiagnosticState(
+      state,
+      state === 'healthy'
+        ? 'Motor checks passed'
+        : state === 'blocked'
+          ? 'Motor fault blocks dispatch'
+          : state === 'warning'
+            ? 'Motor test follow-up required'
+            : 'Motor diagnostics unavailable',
+      diagnostics?.motorHealthDetail
+    ),
+    detail: diagnostics?.motorHealthDetail,
+  };
+}
+
+function deriveReadiness(checks: MaintenanceCheckViewModel[], isOffline: boolean): {
+  readiness: FleetReadinessState;
+  summary: string;
+} {
+  if (isOffline) {
+    return {
+      readiness: 'blocked',
+      summary: 'Telemetry stale or vehicle offline',
+    };
+  }
+
+  if (checks.some((check) => check.state === 'blocked')) {
+    return {
+      readiness: 'blocked',
+      summary: 'Blocking diagnostic issue present',
+    };
+  }
+  if (checks.some((check) => check.state === 'warning' || check.state === 'unknown')) {
+    return {
+      readiness: 'warning',
+      summary: 'Diagnostics need maintenance review',
+    };
+  }
+  return {
+    readiness: 'ready',
+    summary: 'Ready for deployment',
+  };
+}
+
+export function projectFleetDiagnostics(args: {
+  telemetry: MaintenanceTelemetrySnapshot[];
+  diagnostics: VehicleMaintenanceSnapshot[];
+  pods: MaintenancePodSnapshot[];
+  nowMs?: number;
+}): FleetDiagnosticsViewModel {
+  const { telemetry, diagnostics, pods, nowMs = Date.now() } = args;
+  const telemetryById = new Map(telemetry.map((vehicle) => [vehicle.id, vehicle]));
+  const diagnosticsById = new Map(diagnostics.map((snapshot) => [snapshot.vehicleId, snapshot]));
+  const podGroups = new Map<string, MaintenancePodSnapshot[]>();
+
+  for (const pod of pods) {
+    const list = podGroups.get(pod.vehicleId) ?? [];
+    list.push(pod);
+    podGroups.set(pod.vehicleId, list);
+  }
+
+  const vehicleIds = Array.from(
+    new Set([
+      ...telemetry.map((vehicle) => vehicle.id),
+      ...diagnostics.map((snapshot) => snapshot.vehicleId),
+      ...pods.map((pod) => pod.vehicleId),
+    ])
+  ).sort();
+
+  const vehicles = vehicleIds.map<MaintenanceVehicleViewModel>((vehicleId) => {
+    const vehicle = telemetryById.get(vehicleId);
+    const vehicleDiagnostics = diagnosticsById.get(vehicleId);
+    const vehiclePods = podGroups.get(vehicleId) ?? [];
+    const degraded = deriveVehicleDegradedState({
+      lastUpdate: vehicle?.lastUpdate,
+      missionOnline: vehicle?.missionOnline,
+      deliveryMode: vehicle?.deliveryMode,
+      isRetroactive: vehicle?.isRetroactive,
+      now: nowMs,
+    });
+    const motor = summarizeMotorHealth(vehicleDiagnostics);
+    const podSummary = summarizePods(vehiclePods);
+    const mesh = summarizeLinkQuality(vehicle?.linkQualityPercent);
+    const calibration = summarizeCalibration(vehicleDiagnostics);
+    const readiness = deriveReadiness(
+      [motor, podSummary.summary, mesh, calibration.summary],
+      degraded.offline
+    );
+
+    return {
+      id: vehicleId,
+      name: vehicle?.name ?? vehicleId.replace(/[_-]/g, ' ').toUpperCase(),
+      readiness: readiness.readiness,
+      readinessSummary: readiness.summary,
+      batteryPercent: vehicle?.batteryPercent ?? null,
+      altitudeMeters: vehicle?.altitudeMeters ?? 0,
+      lastContactAgeMs: degraded.lastContactAgeMs,
+      isOffline: degraded.offline,
+      summaryChecks: {
+        motor,
+        sensors: podSummary.summary,
+        mesh,
+        calibration: calibration.summary,
+      },
+      detailChecks: calibration.details,
+      pods: podSummary.detail,
+    };
+  });
+
+  const readyCount = vehicles.filter((vehicle) => vehicle.readiness === 'ready').length;
+  const blockedCount = vehicles.filter((vehicle) => vehicle.readiness === 'blocked').length;
+  const warningCount = vehicles.length - readyCount - blockedCount;
+  const linkReadings = telemetry
+    .map((vehicle) => vehicle.linkQualityPercent)
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+
+  return {
+    vehicles,
+    summary: {
+      readyCount,
+      warningCount,
+      blockedCount,
+      connectedCount: telemetry.filter((vehicle) => {
+        const degraded = deriveVehicleDegradedState({
+          lastUpdate: vehicle.lastUpdate,
+          missionOnline: vehicle.missionOnline,
+          deliveryMode: vehicle.deliveryMode,
+          isRetroactive: vehicle.isRetroactive,
+          now: nowMs,
+        });
+        return !degraded.offline;
+      }).length,
+      averageLinkQuality:
+        linkReadings.length > 0
+          ? Math.round(linkReadings.reduce((sum, value) => sum + value, 0) / linkReadings.length)
+          : null,
+    },
+  };
+}
+
+export function getReadinessBadgeVariant(readiness: FleetReadinessState): 'success' | 'warning' | 'danger' {
+  if (readiness === 'ready') {
+    return 'success';
+  }
+  if (readiness === 'blocked') {
+    return 'danger';
+  }
+  return 'warning';
+}
+
+export function getDiagnosticBadgeVariant(state: DiagnosticState): 'success' | 'warning' | 'danger' | 'outline' {
+  if (state === 'healthy') {
+    return 'success';
+  }
+  if (state === 'blocked') {
+    return 'danger';
+  }
+  if (state === 'warning') {
+    return 'warning';
+  }
+  return 'outline';
+}
+
+export function createDemoFleetDiagnostics(): FleetDiagnosticsViewModel {
+  return projectFleetDiagnostics({
+    nowMs: 10_000,
+    telemetry: [
+      {
+        id: 'scout_1',
+        name: 'SCOUT 1',
+        batteryPercent: 82,
+        altitudeMeters: 0,
+        linkQualityPercent: 87,
+        lastUpdate: 9_000,
+        missionOnline: true,
+      },
+      {
+        id: 'scout_2',
+        name: 'SCOUT 2',
+        batteryPercent: 54,
+        altitudeMeters: 0,
+        linkQualityPercent: 58,
+        lastUpdate: 8_500,
+        missionOnline: true,
+      },
+      {
+        id: 'ranger_1',
+        name: 'RANGER 1',
+        batteryPercent: 67,
+        altitudeMeters: 0,
+        linkQualityPercent: 28,
+        lastUpdate: 2_000,
+        missionOnline: false,
+      },
+    ],
+    diagnostics: [
+      {
+        vehicleId: 'scout_1',
+        motorHealthState: 'healthy',
+        motorHealthDetail: 'ESC and motor vibration checks nominal',
+        calibrationState: 'healthy',
+        calibrationDetail: 'Bench calibration current',
+        imuState: 'healthy',
+        imuDetail: 'Bias drift within threshold',
+        compassState: 'healthy',
+        compassDetail: 'Compass offset validated',
+        accelerometerState: 'healthy',
+        accelerometerDetail: 'Accelerometer alignment nominal',
+      },
+      {
+        vehicleId: 'scout_2',
+        motorHealthState: 'warning',
+        motorHealthDetail: 'Motor 3 current ripple above baseline',
+        calibrationState: 'warning',
+        calibrationDetail: 'Compass calibration expires soon',
+        imuState: 'healthy',
+        imuDetail: 'Bias drift within threshold',
+        compassState: 'warning',
+        compassDetail: 'Recheck before next sortie',
+        accelerometerState: 'healthy',
+        accelerometerDetail: 'Accelerometer alignment nominal',
+      },
+      {
+        vehicleId: 'ranger_1',
+        motorHealthState: 'blocked',
+        motorHealthDetail: 'Motor 2 ESC fault latched during self-test',
+        calibrationState: 'blocked',
+        calibrationDetail: 'IMU calibration invalid after hard reset',
+        imuState: 'blocked',
+        imuDetail: 'Calibration file missing',
+        compassState: 'warning',
+        compassDetail: 'Compass offset stale',
+        accelerometerState: 'warning',
+        accelerometerDetail: 'Accelerometer tolerance trending high',
+      },
+    ],
+    pods: [
+      {
+        vehicleId: 'scout_1',
+        slotId: 'front-left',
+        podSerial: 'THM-204',
+        podType: 'thermal',
+        lifecycleState: 'registered',
+        connected: true,
+        powerReady: true,
+        linkReady: true,
+        capabilities: ['thermal', 'survivor-detection'],
+      },
+      {
+        vehicleId: 'scout_2',
+        slotId: 'belly',
+        podSerial: 'GAS-118',
+        podType: 'hazmat',
+        lifecycleState: 'registered',
+        connected: true,
+        powerReady: true,
+        linkReady: false,
+        capabilities: ['gas', 'hazmat'],
+      },
+      {
+        vehicleId: 'ranger_1',
+        slotId: 'rear-bay',
+        podSerial: 'LDR-551',
+        podType: 'lidar',
+        lifecycleState: 'faulted',
+        connected: false,
+        powerReady: false,
+        linkReady: false,
+        capabilities: ['lidar', 'mapping'],
+        faultDetail: 'Power rail brownout detected',
+      },
+    ],
+  });
+}

--- a/software/viewer/src/lib/maintenanceDiagnostics.ts
+++ b/software/viewer/src/lib/maintenanceDiagnostics.ts
@@ -386,7 +386,17 @@ export function projectFleetDiagnostics(args: {
   const readyCount = vehicles.filter((vehicle) => vehicle.readiness === 'ready').length;
   const blockedCount = vehicles.filter((vehicle) => vehicle.readiness === 'blocked').length;
   const warningCount = vehicles.length - readyCount - blockedCount;
-  const linkReadings = telemetry
+  const connectedTelemetry = telemetry.filter((vehicle) => {
+    const degraded = deriveVehicleDegradedState({
+      lastUpdate: vehicle.lastUpdate,
+      missionOnline: vehicle.missionOnline,
+      deliveryMode: vehicle.deliveryMode,
+      isRetroactive: vehicle.isRetroactive,
+      now: nowMs,
+    });
+    return !degraded.offline;
+  });
+  const linkReadings = connectedTelemetry
     .map((vehicle) => vehicle.linkQualityPercent)
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
 
@@ -396,16 +406,7 @@ export function projectFleetDiagnostics(args: {
       readyCount,
       warningCount,
       blockedCount,
-      connectedCount: telemetry.filter((vehicle) => {
-        const degraded = deriveVehicleDegradedState({
-          lastUpdate: vehicle.lastUpdate,
-          missionOnline: vehicle.missionOnline,
-          deliveryMode: vehicle.deliveryMode,
-          isRetroactive: vehicle.isRetroactive,
-          now: nowMs,
-        });
-        return !degraded.offline;
-      }).length,
+      connectedCount: connectedTelemetry.length,
       averageLinkQuality:
         linkReadings.length > 0
           ? Math.round(linkReadings.reduce((sum, value) => sum + value, 0) / linkReadings.length)

--- a/software/viewer/src/lib/maintenanceDiagnostics.ts
+++ b/software/viewer/src/lib/maintenanceDiagnostics.ts
@@ -144,8 +144,11 @@ function classifyPodState(pod: MaintenancePodSnapshot): { state: DiagnosticState
   ) {
     return { state: 'warning', lifecycleLabel: titleCaseLifecycle(lifecycle) };
   }
-  if (lifecycle === 'registered' && pod.connected && pod.powerReady && pod.linkReady) {
-    return { state: 'healthy', lifecycleLabel: 'Registered' };
+  if (lifecycle === 'registered') {
+    if (pod.connected && pod.powerReady && pod.linkReady) {
+      return { state: 'healthy', lifecycleLabel: 'Registered' };
+    }
+    return { state: 'warning', lifecycleLabel: 'Registered' };
   }
   if (lifecycle === 'detected') {
     return { state: 'warning', lifecycleLabel: 'Detected' };

--- a/software/viewer/src/lib/ros/maintenanceDiagnostics.ts
+++ b/software/viewer/src/lib/ros/maintenanceDiagnostics.ts
@@ -1,0 +1,96 @@
+import type {
+  DiagnosticState,
+  VehicleMaintenanceSnapshot,
+} from '../maintenanceDiagnostics';
+
+interface TimeLike {
+  sec?: unknown;
+  nanosec?: unknown;
+}
+
+const STATE_MAP: Record<number, DiagnosticState> = {
+  0: 'unknown',
+  1: 'healthy',
+  2: 'warning',
+  3: 'blocked',
+};
+
+export interface VehicleMaintenanceDiagnosticsArrayMessage {
+  observedAtMs: number | null;
+  vehicles: VehicleMaintenanceSnapshot[];
+}
+
+function parseState(value: unknown): DiagnosticState {
+  if (typeof value === 'number' && STATE_MAP[value]) {
+    return STATE_MAP[value];
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'healthy' || normalized === 'warning' || normalized === 'blocked' || normalized === 'unknown') {
+      return normalized;
+    }
+  }
+  return 'unknown';
+}
+
+function parseString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseTime(value: unknown): number | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const time = value as TimeLike;
+  const sec = Number(time.sec);
+  const nanosec = Number(time.nanosec);
+  if (!Number.isFinite(sec) || !Number.isFinite(nanosec)) {
+    return null;
+  }
+  return sec * 1000 + nanosec / 1_000_000;
+}
+
+export function parseVehicleMaintenanceDiagnosticsArray(
+  raw: unknown
+): VehicleMaintenanceDiagnosticsArrayMessage {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Invalid maintenance diagnostics data: expected an object');
+  }
+
+  const message = raw as {
+    observed_at?: unknown;
+    observedAt?: unknown;
+    vehicles?: unknown;
+    diagnostics?: unknown;
+  };
+  const vehicles = Array.isArray(message.vehicles)
+    ? message.vehicles
+    : Array.isArray(message.diagnostics)
+      ? message.diagnostics
+      : [];
+
+  return {
+    observedAtMs: parseTime(message.observed_at ?? message.observedAt),
+    vehicles: vehicles.map((entry) => {
+      const vehicle = (entry ?? {}) as Record<string, unknown>;
+      return {
+        vehicleId: String(vehicle.vehicle_id ?? vehicle.vehicleId ?? '').trim(),
+        motorHealthState: parseState(vehicle.motor_health_state ?? vehicle.motorHealthState),
+        motorHealthDetail: parseString(vehicle.motor_health_detail ?? vehicle.motorHealthDetail),
+        calibrationState: parseState(vehicle.calibration_state ?? vehicle.calibrationState),
+        calibrationDetail: parseString(vehicle.calibration_detail ?? vehicle.calibrationDetail),
+        imuState: parseState(vehicle.imu_state ?? vehicle.imuState),
+        imuDetail: parseString(vehicle.imu_detail ?? vehicle.imuDetail),
+        compassState: parseState(vehicle.compass_state ?? vehicle.compassState),
+        compassDetail: parseString(vehicle.compass_detail ?? vehicle.compassDetail),
+        accelerometerState: parseState(vehicle.accelerometer_state ?? vehicle.accelerometerState),
+        accelerometerDetail: parseString(vehicle.accelerometer_detail ?? vehicle.accelerometerDetail),
+        observedAtMs: parseTime(vehicle.observed_at ?? vehicle.observedAt) ?? null,
+      };
+    }).filter((vehicle) => vehicle.vehicleId.length > 0),
+  };
+}

--- a/software/viewer/src/lib/ros/podStatus.ts
+++ b/software/viewer/src/lib/ros/podStatus.ts
@@ -1,0 +1,67 @@
+import type { MaintenancePodSnapshot } from '../maintenanceDiagnostics';
+
+interface TimeLike {
+  sec?: unknown;
+  nanosec?: unknown;
+}
+
+export interface PodStatusArrayMessage {
+  observedAtMs: number | null;
+  pods: MaintenancePodSnapshot[];
+}
+
+function parseTime(value: unknown): number | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const time = value as TimeLike;
+  const sec = Number(time.sec);
+  const nanosec = Number(time.nanosec);
+  if (!Number.isFinite(sec) || !Number.isFinite(nanosec)) {
+    return null;
+  }
+  return sec * 1000 + nanosec / 1_000_000;
+}
+
+function parseBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function parseString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseCapabilities(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean);
+}
+
+export function parsePodStatusArray(raw: unknown): PodStatusArrayMessage {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Invalid pod status data: expected an object');
+  }
+  const message = raw as { observed_at?: unknown; observedAt?: unknown; pods?: unknown };
+  const pods = Array.isArray(message.pods) ? message.pods : [];
+
+  return {
+    observedAtMs: parseTime(message.observed_at ?? message.observedAt),
+    pods: pods.map((entry) => {
+      const pod = (entry ?? {}) as Record<string, unknown>;
+      return {
+        vehicleId: parseString(pod.vehicle_id ?? pod.vehicleId),
+        slotId: parseString(pod.slot_id ?? pod.slotId),
+        podSerial: parseString(pod.pod_serial ?? pod.podSerial),
+        podType: parseString(pod.pod_type ?? pod.podType),
+        lifecycleState: parseString(pod.lifecycle_state_label ?? pod.lifecycleStateLabel ?? pod.lifecycle_state ?? pod.lifecycleState) || 'unknown',
+        connected: parseBoolean(pod.connected),
+        powerReady: parseBoolean(pod.power_ready ?? pod.powerReady),
+        linkReady: parseBoolean(pod.link_ready ?? pod.linkReady),
+        capabilities: parseCapabilities(pod.capabilities),
+        faultDetail: parseString(pod.fault_detail ?? pod.faultDetail) || undefined,
+        rejectionDetail: parseString(pod.rejection_detail ?? pod.rejectionDetail) || undefined,
+      };
+    }).filter((pod) => pod.vehicleId.length > 0),
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated maintenance route with a read-only fleet diagnostics dashboard and route navigation from the operator view
- merge telemetry, pod state, and typed maintenance diagnostics into fleet readiness, mesh, motor, and calibration summaries with expandable vehicle detail
- add focused viewer tests for route wiring, diagnostics projection, expanded detail rendering, and the shared provider seam

Closes #50



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added maintenance dashboard to monitor fleet readiness, system health, and diagnostics.
  * Added navigation controls to switch between operations and maintenance views.
  * Vehicle status cards now display health summaries, battery levels, pod information, and last-contact timestamps.
  * Fleet-level readiness badges and summary metrics show overall system status.

* **Bug Fixes**
  * Improved abort request lifecycle handling during mission phase transitions.

* **Tests**
  * Added comprehensive test coverage for maintenance dashboard routing and vehicle card behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only maintenance fleet diagnostics dashboard at `/maintenance`, extracts shared React providers into `ViewerAppProviders`, and replaces the boolean `abortRequested` flag in `EmergencyStopControl` with a window-based abort lifecycle state machine that correctly scopes pending state to a single mission/phase window.

- **Maintenance dashboard**: New route, page, and `MaintenanceDashboardPage` component that merges live telemetry, pod status, and typed `VehicleMaintenanceDiagnostics` ROS messages into per-vehicle readiness cards with expandable calibration detail rows; falls back to static demo data when ROS is disconnected.
- **Abort lifecycle refactor**: `advanceAbortRequestWindow` + `resolveAbortRequestWindowId` replace the previous `shouldResetAbortRequest` approach; the window id is bumped on mission-identity change or active-phase re-entry, so a pending abort from a prior mission can no longer re-activate when the same phase name appears in a new mission.
- **Provider extraction**: `ViewerAppProviders` consolidates `CoordinateOriginProvider`, `ROSConnectionProvider`, `ZoneProvider`, and `MissionProvider` so both routes share identical context setup without duplicating the provider tree.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are additive or well-contained fixes; the abort lifecycle refactor correctly handles all mission-transition edge cases and the maintenance dashboard is read-only.

The abort lifecycle window logic handles mission-id changes, phase re-entry, error latching, and the active-to-active handoff case — all scenarios that were problematic before. The maintenance dashboard projection layer is a pure function with comprehensive test coverage. The `ViewerAppProviders` extraction preserves context nesting order correctly for all consumers.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/viewer/src/lib/emergencyStopHold.js | Adds window-based abort lifecycle tracking (`advanceAbortRequestWindow`, `resolveAbortRequestWindowId`) that replaces the boolean `abortRequested` flag; properly handles mission-id changes and phase re-entry to prevent stale abort lockout. |
| software/viewer/src/components/mission/EmergencyStopControl.tsx | Replaces `abortRequested` boolean state with an `abortLifecycleReducer` using window IDs tied to mission identity and phase transitions; accepts optional `missionId` prop to force a window bump on mission handoff. |
| software/viewer/src/lib/maintenanceDiagnostics.ts | New pure projection layer that merges telemetry, pod status, and typed maintenance diagnostics into fleet readiness view-models with calibration roll-up logic and worst-state propagation. |
| software/viewer/src/components/maintenance/MaintenanceDashboardPage.tsx | New read-only dashboard that projects live telemetry, pod status, and diagnostics into fleet readiness cards; falls back to static demo data when ROS is disconnected and no vehicles are present. |
| software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx | New vehicle card with expandable calibration detail rows; destructures `detailChecks` array with guard checks, safely tolerating fewer than three entries without crashing. |
| software/viewer/src/hooks/usePodStatus.ts | New hook subscribing to `/device_manager/pods`; stamps payloads with the current ROS connection reference and suppresses stale cache after reconnect. |
| software/viewer/src/hooks/useVehicleMaintenanceDiagnostics.ts | New hook subscribing to `/vehicle/maintenance_diagnostics`; mirrors the connection-stamping pattern from `usePodStatus` for stale-payload safety. |
| software/viewer/src/lib/ros/maintenanceDiagnostics.ts | ROS parser for maintenance diagnostics; handles both snake_case and camelCase field names and maps numeric state constants to typed `DiagnosticState` values. |
| software/viewer/src/app/ViewerAppProviders.tsx | New shared provider seam extracting CoordinateOrigin, ROS connection, Zone, and Mission contexts so both operator and maintenance routes share the same provider tree. |
| software/viewer/src/app/page.tsx | Operator page refactored to use `ViewerAppProviders`; adds `ViewerRouteNav` and passes `missionId` from `useMissionControl` to `EmergencyStopControl`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Op as Operator Page (/)
    participant Maint as Maintenance Page (/maintenance)
    participant VAP as ViewerAppProviders
    participant ROS as ROSConnectionContext
    participant ESC as EmergencyStopControl
    participant ALR as abortLifecycleReducer
    participant Hook as usePodStatus / useVehicleMaintenanceDiagnostics
    participant Proj as projectFleetDiagnostics

    Op->>VAP: wraps with shared providers
    Maint->>VAP: wraps with shared providers
    VAP->>ROS: provides ROS connection

    Op->>ESC: missionId, missionPhase, onAbort
    ESC->>ALR: sync-lifecycle(missionId, missionPhase, abortError)
    ALR->>ALR: advanceAbortRequestWindow → bump id on mission/phase change
    ALR->>ALR: resolveAbortRequestWindowId → latch resolved when inactive/error
    ESC->>ALR: mark-pending(windowId) on hold complete
    ESC->>ALR: clear-for-retry on new hold start

    Maint->>Hook: subscribe to ROS topics
    Hook->>ROS: ROSLIB.Topic subscribe
    Hook-->>Maint: stamped payload (suppresses stale on reconnect)
    Maint->>Proj: projectFleetDiagnostics(telemetry, pods, diagnostics)
    Proj-->>Maint: FleetDiagnosticsViewModel
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `software/viewer/src/components/mission/EmergencyStopControl.tsx`, line 38-43 ([link](https://github.com/aeris-drones/aeris/blob/130888d86abbc9e92a62911e53d4a8b4f31ccc3b/software/viewer/src/components/mission/EmergencyStopControl.tsx#L38-L43)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale abort phase reactivates on the next mission**

   `abortRequested` is derived purely by string equality (`abortRequestedPhase === missionPhase`), but `abortRequestedPhase` is never cleared when a mission ends. `ACTIVE_ABORT_PHASES` contains `'SEARCHING'` and `'TRACKING'`; both are re-entered on every new mission. After one successful abort while in `'SEARCHING'`, `abortRequestedPhase` stays as `'SEARCHING'`. When the next mission reaches `'SEARCHING'`, `abortRequested` becomes `true` again, `isAbortRequestPending` returns `true`, and the button is locked into "ABORT REQUESTED" for the rest of that phase — blocking any real abort action. The previous `shouldResetAbortRequest` effect avoided this by explicitly clearing the flag on any phase that left the active-abort set.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/components/mission/EmergencyStopControl.tsx
   Line: 38-43

   Comment:
   **Stale abort phase reactivates on the next mission**

   `abortRequested` is derived purely by string equality (`abortRequestedPhase === missionPhase`), but `abortRequestedPhase` is never cleared when a mission ends. `ACTIVE_ABORT_PHASES` contains `'SEARCHING'` and `'TRACKING'`; both are re-entered on every new mission. After one successful abort while in `'SEARCHING'`, `abortRequestedPhase` stays as `'SEARCHING'`. When the next mission reaches `'SEARCHING'`, `abortRequested` becomes `true` again, `isAbortRequestPending` returns `true`, and the button is locked into "ABORT REQUESTED" for the rest of that phase — blocking any real abort action. The previous `shouldResetAbortRequest` effect avoided this by explicitly clearing the flag on any phase that left the active-abort set.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx`, line 576-578 ([link](https://github.com/aeris-drones/aeris/blob/130888d86abbc9e92a62911e53d4a8b4f31ccc3b/software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx#L576-L578)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Positional index access into an unbounded array type**

   `vehicle.detailChecks` is typed `MaintenanceCheckViewModel[]`, not a fixed-length tuple. Rendering `detailChecks[0]`, `[1]`, and `[2]` directly means any caller that supplies fewer than three entries would produce `undefined` as the `check` prop, causing a runtime crash in `DetailRow` (`.label`/`.summary`/`.state` on `undefined`). `summarizeCalibration` currently always emits exactly three entries, but that contract isn't enforced by the type. Consider typing `detailChecks` as `[MaintenanceCheckViewModel, MaintenanceCheckViewModel, MaintenanceCheckViewModel]` or using named fields for each check rather than positional indices.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/components/maintenance/MaintenanceVehicleCard.tsx
   Line: 576-578

   Comment:
   **Positional index access into an unbounded array type**

   `vehicle.detailChecks` is typed `MaintenanceCheckViewModel[]`, not a fixed-length tuple. Rendering `detailChecks[0]`, `[1]`, and `[2]` directly means any caller that supplies fewer than three entries would produce `undefined` as the `check` prop, causing a runtime crash in `DetailRow` (`.label`/`.summary`/`.state` on `undefined`). `summarizeCalibration` currently always emits exactly three entries, but that contract isn't enforced by the type. Consider typing `detailChecks` as `[MaintenanceCheckViewModel, MaintenanceCheckViewModel, MaintenanceCheckViewModel]` or using named fields for each check rather than positional indices.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `software/viewer/src/components/mission/EmergencyStopControl.tsx`, line 38-43 ([link](https://github.com/aeris-drones/aeris/blob/130888d86abbc9e92a62911e53d4a8b4f31ccc3b/software/viewer/src/components/mission/EmergencyStopControl.tsx#L38-L43)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale abort phase leaks into the next mission cycle**

   `abortRequestedPhase` is never reset when the mission phase leaves `ACTIVE_ABORT_PHASES` — only in the `onPointerDown` handler. When a mission transitions out of SEARCHING/TRACKING the phase comparison `abortRequestedPhase === missionPhase` correctly resolves to `false`, so `abortPending` drops to `false`. But if a new mission then re-enters that same phase (e.g. SEARCHING again), `abortRequestedPhase === missionPhase` becomes `true` again and `ACTIVE_ABORT_PHASES.has(missionPhase)` is also `true`, making `abortPending = true` without any abort having been requested. Because `onPointerDown` guards on `abortPending`, the operator cannot start a new hold to clear it — the button is stuck in "aborting" state for the new mission.

   The deleted `shouldResetAbortRequest` effect prevented this by explicitly zeroing `abortRequested` the moment the phase left the active set, so the value could never "re-appear" when a new mission revisited the same phase.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/components/mission/EmergencyStopControl.tsx
   Line: 38-43

   Comment:
   **Stale abort phase leaks into the next mission cycle**

   `abortRequestedPhase` is never reset when the mission phase leaves `ACTIVE_ABORT_PHASES` — only in the `onPointerDown` handler. When a mission transitions out of SEARCHING/TRACKING the phase comparison `abortRequestedPhase === missionPhase` correctly resolves to `false`, so `abortPending` drops to `false`. But if a new mission then re-enters that same phase (e.g. SEARCHING again), `abortRequestedPhase === missionPhase` becomes `true` again and `ACTIVE_ABORT_PHASES.has(missionPhase)` is also `true`, making `abortPending = true` without any abort having been requested. Because `onPointerDown` guards on `abortPending`, the operator cannot start a new hold to clear it — the button is stuck in "aborting" state for the new mission.

   The deleted `shouldResetAbortRequest` effect prevented this by explicitly zeroing `abortRequested` the moment the phase left the active set, so the value could never "re-appear" when a new mission revisited the same phase.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["Align maintenance mesh summary with live..."](https://github.com/aeris-drones/aeris/commit/26070667c6385aca9ca981bafb93272acef0b7c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33619751)</sub>

<!-- /greptile_comment -->