### PR TITLE
Add RGB ingest path for Halo

### DIFF
--- a/software/edge/launch/perception_demo.launch.py
+++ b/software/edge/launch/perception_demo.launch.py
@@ -4,8 +4,12 @@ Spawns synthetic sensor publishers (thermal, acoustic, gas) and mesh network
 impairment shims to simulate degraded communication conditions for bench testing.
 """
 
+from pathlib import Path
+
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch.actions import LogInfo
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -17,7 +21,54 @@ def generate_launch_description() -> LaunchDescription:
         perception demonstration, including thermal/acoustic/gas publishers
         and mesh impairment relays.
     """
+    rgb_config = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "aeris_perception"
+        / "config"
+        / "perception_demo_rgb_ingest.yaml"
+    )
+    rgb_source_type = LaunchConfiguration("rgb_source_type")
+    rgb_source_uri = LaunchConfiguration("rgb_source_uri")
+    rgb_source_name = LaunchConfiguration("rgb_source_name")
+    rgb_loop_replay = LaunchConfiguration("rgb_loop_replay")
+
     nodes = [
+        DeclareLaunchArgument(
+            "rgb_source_type",
+            default_value="camera",
+            description="RGB ingest source type: camera, video_file, or replay.",
+        ),
+        DeclareLaunchArgument(
+            "rgb_source_uri",
+            default_value="0",
+            description="RGB ingest camera index or local file path.",
+        ),
+        DeclareLaunchArgument(
+            "rgb_source_name",
+            default_value="halo_front_camera",
+            description="Human-readable RGB source name for metadata.",
+        ),
+        DeclareLaunchArgument(
+            "rgb_loop_replay",
+            default_value="false",
+            description="Whether replay inputs should loop when they reach EOF.",
+        ),
+        Node(
+            package="aeris_perception",
+            executable="rgb_ingest",
+            name="rgb_ingest",
+            output="screen",
+            parameters=[
+                str(rgb_config),
+                {
+                    "source_type": rgb_source_type,
+                    "source_uri": rgb_source_uri,
+                    "source_name": rgb_source_name,
+                    "loop_replay": rgb_loop_replay,
+                },
+            ],
+        ),
         Node(
             package="aeris_perception",
             executable="thermal_hotspot",
@@ -117,11 +168,12 @@ def generate_launch_description() -> LaunchDescription:
         ),
         LogInfo(
             msg=(
-                "Perception demo running with thermal/acoustic/gas pipeline and mesh "
-                "impairments. Verify acoustic output cadence with `ros2 topic hz "
+                "Perception demo running with RGB ingest, thermal/acoustic/gas "
+                "pipeline, and mesh impairments. Verify RGB frames with `ros2 topic "
+                "hz rgb/image_raw`, acoustic output cadence with `ros2 topic hz "
                 "acoustic/bearing`, gas cadence with `ros2 topic hz gas/isopleth`, "
-                "and toggle buffering with `ros2 param set "
-                "/store_forward_tiles link_up false|true`."
+                "and override the RGB path with launch args such as "
+                "`rgb_source_type:=replay rgb_source_uri:=/absolute/path/capture.mp4`."
             )
         ),
     ]

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
@@ -22,15 +22,20 @@ class RgbSourceError(RuntimeError):
 
 
 class CaptureLike(Protocol):
-    def isOpened(self) -> bool: ...
+    def isOpened(self) -> bool:
+        pass
 
-    def read(self) -> tuple[bool, np.ndarray | None]: ...
+    def read(self) -> tuple[bool, np.ndarray | None]:
+        pass
 
-    def release(self) -> None: ...
+    def release(self) -> None:
+        pass
 
-    def get(self, prop_id: int) -> float: ...
+    def get(self, prop_id: int) -> float:
+        pass
 
-    def set(self, prop_id: int, value: float) -> bool: ...
+    def set(self, prop_id: int, value: float) -> bool:
+        pass
 
 
 @dataclass(frozen=True)
@@ -155,6 +160,7 @@ class RgbFrameSource:
             fallback_clock_ns=self._clock_ns
         )
         self._frame_index = 0
+        self._source_frame_index = 0
 
     @property
     def config(self) -> RgbSourceConfig:
@@ -199,6 +205,7 @@ class RgbFrameSource:
             replayed=self._config.normalized_source_type == "replay",
         )
         self._frame_index += 1
+        self._source_frame_index += 1
         return RgbFrame(image_bgr=image, metadata=metadata)
 
     def close(self) -> None:
@@ -209,12 +216,12 @@ class RgbFrameSource:
             return None
 
         capture_position_ms = float(self._capture.get(CAP_PROP_POS_MSEC))
-        if capture_position_ms > 0.0 or self._frame_index == 0:
+        if capture_position_ms > 0.0 or self._source_frame_index == 0:
             return max(0, round(capture_position_ms * 1_000_000.0))
 
         fps = float(self._capture.get(CAP_PROP_FPS))
         if fps > 0.0:
-            return round((self._frame_index / fps) * 1_000_000_000.0)
+            return round((self._source_frame_index / fps) * 1_000_000_000.0)
         return None
 
     def _rewind_or_reopen(self) -> None:
@@ -227,6 +234,7 @@ class RgbFrameSource:
                     f"Unable to reopen replay source '{self._config.source_uri}'"
                 )
             self._capture = replacement
+            self._source_frame_index = 0
             return
 
         rewound = self._capture.set(CAP_PROP_POS_FRAMES, 0.0)
@@ -234,6 +242,7 @@ class RgbFrameSource:
             raise RgbSourceError(
                 f"Unable to rewind replay source '{self._config.source_uri}'"
             )
+        self._source_frame_index = 0
 
 
 def build_rgb_frame_source(

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
@@ -51,10 +51,7 @@ class RgbSourceConfig:
             )
         if not self.frame_id.strip():
             raise RgbSourceError("frame_id must be configured for RGB ingest")
-        if (
-            normalized_type in {"camera", "video_file", "replay"}
-            and not self.source_uri.strip()
-        ):
+        if not self.source_uri.strip():
             raise RgbSourceError(
                 "source_uri must be configured for the selected RGB source"
             )
@@ -213,11 +210,11 @@ class RgbFrameSource:
 
         capture_position_ms = float(self._capture.get(CAP_PROP_POS_MSEC))
         if capture_position_ms > 0.0 or self._frame_index == 0:
-            return max(0, int(round(capture_position_ms * 1_000_000.0)))
+            return max(0, round(capture_position_ms * 1_000_000.0))
 
         fps = float(self._capture.get(CAP_PROP_FPS))
         if fps > 0.0:
-            return int(round((self._frame_index / fps) * 1_000_000_000.0))
+            return round((self._frame_index / fps) * 1_000_000_000.0)
         return None
 
     def _rewind_or_reopen(self) -> None:
@@ -225,6 +222,7 @@ class RgbFrameSource:
             self._capture.release()
             replacement = self._capture_factory(self._config.capture_target)
             if not replacement.isOpened():
+                replacement.release()
                 raise RgbSourceError(
                     f"Unable to reopen replay source '{self._config.source_uri}'"
                 )

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
@@ -1,0 +1,285 @@
+"""RGB ingest contract and source adapters for the Halo perception path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import time
+from typing import Any, Callable, Protocol
+
+import numpy as np
+
+
+CAP_PROP_POS_MSEC = 0
+CAP_PROP_POS_FRAMES = 1
+CAP_PROP_FPS = 5
+
+SUPPORTED_RGB_SOURCE_TYPES = {"camera", "video_file", "replay"}
+
+
+class RgbSourceError(RuntimeError):
+    """Raised when an RGB source cannot be configured or read safely."""
+
+
+class CaptureLike(Protocol):
+    def isOpened(self) -> bool: ...
+
+    def read(self) -> tuple[bool, np.ndarray | None]: ...
+
+    def release(self) -> None: ...
+
+    def get(self, prop_id: int) -> float: ...
+
+    def set(self, prop_id: int, value: float) -> bool: ...
+
+
+@dataclass(frozen=True)
+class RgbSourceConfig:
+    """Configuration for one RGB ingest source."""
+
+    source_type: str
+    source_uri: str
+    frame_id: str
+    source_name: str = ""
+    loop_replay: bool = False
+
+    def __post_init__(self) -> None:
+        normalized_type = self.source_type.strip().lower()
+        if normalized_type not in SUPPORTED_RGB_SOURCE_TYPES:
+            raise RgbSourceError(
+                f"unsupported RGB source type '{self.source_type}'"
+            )
+        if not self.frame_id.strip():
+            raise RgbSourceError("frame_id must be configured for RGB ingest")
+        if (
+            normalized_type in {"camera", "video_file", "replay"}
+            and not self.source_uri.strip()
+        ):
+            raise RgbSourceError(
+                "source_uri must be configured for the selected RGB source"
+            )
+
+    @property
+    def normalized_source_type(self) -> str:
+        return self.source_type.strip().lower()
+
+    @property
+    def capture_target(self) -> int | str:
+        target = self.source_uri.strip()
+        if self.normalized_source_type == "camera" and target.isdigit():
+            return int(target)
+        return target
+
+    @property
+    def effective_source_name(self) -> str:
+        if self.source_name.strip():
+            return self.source_name.strip()
+        target = self.source_uri.strip()
+        if not target:
+            return self.normalized_source_type
+        return Path(target).name or target
+
+
+@dataclass(frozen=True)
+class RgbFrameMetadata:
+    """Metadata carried alongside a decoded RGB frame."""
+
+    source_type: str
+    source_name: str
+    source_uri: str
+    frame_id: str
+    frame_index: int
+    monotonic_timestamp_ns: int
+    source_timestamp_ns: int | None
+    replayed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_type": self.source_type,
+            "source_name": self.source_name,
+            "source_uri": self.source_uri,
+            "frame_id": self.frame_id,
+            "frame_index": self.frame_index,
+            "monotonic_timestamp_ns": self.monotonic_timestamp_ns,
+            "source_timestamp_ns": self.source_timestamp_ns,
+            "replayed": self.replayed,
+        }
+
+
+@dataclass(frozen=True)
+class RgbFrame:
+    """Decoded RGB frame plus ingest metadata for downstream Halo stages."""
+
+    image_bgr: np.ndarray
+    metadata: RgbFrameMetadata
+
+
+class MonotonicTimestampGenerator:
+    """Normalizes candidate timestamps into a strictly monotonic sequence."""
+
+    def __init__(self, *, fallback_clock_ns: Callable[[], int] | None = None) -> None:
+        self._fallback_clock_ns = fallback_clock_ns or time.monotonic_ns
+        self._last_timestamp_ns: int | None = None
+
+    def normalize(self, candidate_ns: int | None) -> int:
+        if candidate_ns is None:
+            candidate_ns = int(self._fallback_clock_ns())
+        else:
+            candidate_ns = int(candidate_ns)
+
+        if self._last_timestamp_ns is None:
+            self._last_timestamp_ns = candidate_ns
+            return candidate_ns
+
+        if candidate_ns <= self._last_timestamp_ns:
+            candidate_ns = self._last_timestamp_ns + 1
+
+        self._last_timestamp_ns = candidate_ns
+        return candidate_ns
+
+
+class RgbFrameSource:
+    """Reads frames from one configured RGB source."""
+
+    def __init__(
+        self,
+        *,
+        config: RgbSourceConfig,
+        capture: CaptureLike,
+        clock_ns: Callable[[], int] | None = None,
+        capture_factory: Callable[[int | str], CaptureLike] | None = None,
+        timestamp_generator: MonotonicTimestampGenerator | None = None,
+    ) -> None:
+        self._config = config
+        self._capture = capture
+        self._clock_ns = clock_ns or time.monotonic_ns
+        self._capture_factory = capture_factory
+        self._timestamp_generator = timestamp_generator or MonotonicTimestampGenerator(
+            fallback_clock_ns=self._clock_ns
+        )
+        self._frame_index = 0
+
+    @property
+    def config(self) -> RgbSourceConfig:
+        return self._config
+
+    def read(self) -> RgbFrame | None:
+        success, image = self._capture.read()
+        if not success or image is None:
+            if (
+                self._config.normalized_source_type == "replay"
+                and self._config.loop_replay
+            ):
+                self._rewind_or_reopen()
+                success, image = self._capture.read()
+                if not success or image is None:
+                    return None
+            else:
+                return None
+
+        if not isinstance(image, np.ndarray):
+            raise RgbSourceError("RGB source returned a non-array frame")
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise RgbSourceError(
+                "RGB source returned a frame without 3-channel BGR shape"
+            )
+
+        source_timestamp_ns = self._resolve_source_timestamp_ns()
+        candidate_timestamp_ns = source_timestamp_ns
+        if self._config.normalized_source_type != "replay":
+            candidate_timestamp_ns = self._clock_ns()
+
+        metadata = RgbFrameMetadata(
+            source_type=self._config.normalized_source_type,
+            source_name=self._config.effective_source_name,
+            source_uri=self._config.source_uri,
+            frame_id=self._config.frame_id,
+            frame_index=self._frame_index,
+            monotonic_timestamp_ns=self._timestamp_generator.normalize(
+                candidate_timestamp_ns
+            ),
+            source_timestamp_ns=source_timestamp_ns,
+            replayed=self._config.normalized_source_type == "replay",
+        )
+        self._frame_index += 1
+        return RgbFrame(image_bgr=image, metadata=metadata)
+
+    def close(self) -> None:
+        self._capture.release()
+
+    def _resolve_source_timestamp_ns(self) -> int | None:
+        if self._config.normalized_source_type != "replay":
+            return None
+
+        capture_position_ms = float(self._capture.get(CAP_PROP_POS_MSEC))
+        if capture_position_ms > 0.0 or self._frame_index == 0:
+            return max(0, int(round(capture_position_ms * 1_000_000.0)))
+
+        fps = float(self._capture.get(CAP_PROP_FPS))
+        if fps > 0.0:
+            return int(round((self._frame_index / fps) * 1_000_000_000.0))
+        return None
+
+    def _rewind_or_reopen(self) -> None:
+        if self._capture_factory is not None:
+            self._capture.release()
+            replacement = self._capture_factory(self._config.capture_target)
+            if not replacement.isOpened():
+                raise RgbSourceError(
+                    f"Unable to reopen replay source '{self._config.source_uri}'"
+                )
+            self._capture = replacement
+            return
+
+        rewound = self._capture.set(CAP_PROP_POS_FRAMES, 0.0)
+        if not rewound:
+            raise RgbSourceError(
+                f"Unable to rewind replay source '{self._config.source_uri}'"
+            )
+
+
+def build_rgb_frame_source(
+    config: RgbSourceConfig,
+    *,
+    capture_factory: Callable[[int | str], CaptureLike] | None = None,
+    path_exists: Callable[[Path], bool] | None = None,
+    clock_ns: Callable[[], int] | None = None,
+) -> RgbFrameSource:
+    """Build and validate an RGB source backed by OpenCV-style capture APIs."""
+
+    if config.normalized_source_type in {"video_file", "replay"}:
+        exists = path_exists or Path.exists
+        source_path = Path(config.source_uri)
+        if not exists(source_path):
+            raise RgbSourceError(
+                f"RGB source path does not exist: '{config.source_uri}'"
+            )
+
+    capture_builder = capture_factory or _build_opencv_capture
+    capture = capture_builder(config.capture_target)
+    if not capture.isOpened():
+        capture.release()
+        raise RgbSourceError(
+            f"Unable to open RGB {config.normalized_source_type} source "
+            f"'{config.source_uri}'"
+        )
+
+    return RgbFrameSource(
+        config=config,
+        capture=capture,
+        clock_ns=clock_ns,
+        capture_factory=(
+            capture_builder if config.normalized_source_type == "replay" else None
+        ),
+    )
+
+
+def _build_opencv_capture(target: int | str) -> CaptureLike:
+    try:
+        import cv2
+    except ImportError as error:  # pragma: no cover - depends on ROS runtime image
+        raise RgbSourceError(
+            "OpenCV is required for RGB ingest but is not installed"
+        ) from error
+
+    return cv2.VideoCapture(target)

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
@@ -133,7 +133,7 @@ class RgbIngestNode(Node):
             self._source_exhausted = True
             self._timer.cancel()
             self.get_logger().error(f"RGB ingest stopped: {error}")
-            raise
+            return
 
         if frame is None:
             if self._source.config.normalized_source_type == "camera":
@@ -187,6 +187,7 @@ def main(args: list[str] | None = None) -> None:
         node = RgbIngestNode()
         rclpy.spin(node)
     except KeyboardInterrupt:
+        # Ctrl+C is expected; cleanup runs in finally.
         pass
     finally:
         if node is not None:

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
@@ -50,6 +50,7 @@ class RgbIngestNode(Node):
         self._loop_replay = bool(
             self.declare_parameter("loop_replay", False).value
         )
+        self._ros_stamp_provider = lambda: self.get_clock().now().to_msg()
 
         if self._publish_rate_hz <= 0.0:
             raise RgbSourceError("publish_rate_hz must be > 0 for RGB ingest")
@@ -135,6 +136,9 @@ class RgbIngestNode(Node):
             raise
 
         if frame is None:
+            if self._source.config.normalized_source_type == "camera":
+                self.get_logger().debug("RGB camera frame read missed; waiting for next frame.")
+                return
             self._source_exhausted = True
             self._timer.cancel()
             self.get_logger().info(
@@ -142,11 +146,14 @@ class RgbIngestNode(Node):
             )
             return
 
-        self._image_publisher.publish(_rgb_frame_to_image_message(frame))
+        self._image_publisher.publish(self._rgb_frame_to_image_message(frame))
         self._metadata_publisher.publish(String(data=_metadata_payload_json(frame)))
 
+    def _rgb_frame_to_image_message(self, frame: RgbFrame) -> Image:
+        return _rgb_frame_to_image_message(frame, self._ros_stamp_provider())
 
-def _rgb_frame_to_image_message(frame: RgbFrame) -> Image:
+
+def _rgb_frame_to_image_message(frame: RgbFrame, ros_stamp) -> Image:
     image = frame.image_bgr
     if image.dtype != np.uint8:
         raise RgbSourceError("RGB ingest frames must be uint8 BGR images")
@@ -154,10 +161,7 @@ def _rgb_frame_to_image_message(frame: RgbFrame) -> Image:
         raise RgbSourceError("RGB ingest frames must use HxWx3 BGR layout")
 
     message = Image()
-    message.header.stamp.sec = frame.metadata.monotonic_timestamp_ns // 1_000_000_000
-    message.header.stamp.nanosec = (
-        frame.metadata.monotonic_timestamp_ns % 1_000_000_000
-    )
+    message.header.stamp = ros_stamp
     message.header.frame_id = frame.metadata.frame_id
     message.height = int(image.shape[0])
     message.width = int(image.shape[1])

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
@@ -1,0 +1,190 @@
+"""ROS 2 node that publishes RGB frames and source metadata for Halo."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable
+
+import numpy as np
+import rclpy
+from rcl_interfaces.msg import SetParametersResult
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import Image
+from std_msgs.msg import String
+
+from .rgb_ingest import (
+    RgbFrame,
+    RgbFrameSource,
+    RgbSourceConfig,
+    RgbSourceError,
+    build_rgb_frame_source,
+)
+
+
+class RgbIngestNode(Node):
+    """Publish RGB frames from a configured live or replay source."""
+
+    def __init__(
+        self,
+        *,
+        parameter_overrides: list[Parameter] | None = None,
+        source_factory: Callable[[RgbSourceConfig], RgbFrameSource] | None = None,
+    ) -> None:
+        super().__init__("rgb_ingest", parameter_overrides=parameter_overrides)
+
+        self._source_factory = source_factory or build_rgb_frame_source
+        self._image_topic = str(
+            self.declare_parameter("image_topic", "rgb/image_raw").value
+        )
+        self._metadata_topic = str(
+            self.declare_parameter("metadata_topic", "rgb/source_metadata").value
+        )
+        self._publish_rate_hz = float(
+            self.declare_parameter("publish_rate_hz", 15.0).value
+        )
+        self._source_type = str(self.declare_parameter("source_type", "camera").value)
+        self._source_uri = str(self.declare_parameter("source_uri", "0").value)
+        self._frame_id = str(self.declare_parameter("frame_id", "halo_rgb").value)
+        self._source_name = str(self.declare_parameter("source_name", "").value)
+        self._loop_replay = bool(
+            self.declare_parameter("loop_replay", False).value
+        )
+
+        if self._publish_rate_hz <= 0.0:
+            raise RgbSourceError("publish_rate_hz must be > 0 for RGB ingest")
+
+        self._source = self._source_factory(self._build_source_config())
+        self._image_publisher = self.create_publisher(Image, self._image_topic, 10)
+        self._metadata_publisher = self.create_publisher(
+            String, self._metadata_topic, 10
+        )
+        self._timer = self.create_timer(
+            1.0 / self._publish_rate_hz, self._publish_next_frame
+        )
+        self._source_exhausted = False
+        self.add_on_set_parameters_callback(self._handle_param_update)
+
+    def destroy_node(self) -> bool:
+        self._source.close()
+        return super().destroy_node()
+
+    def _build_source_config(self) -> RgbSourceConfig:
+        return RgbSourceConfig(
+            source_type=self._source_type,
+            source_uri=self._source_uri,
+            frame_id=self._frame_id,
+            source_name=self._source_name,
+            loop_replay=self._loop_replay,
+        )
+
+    def _handle_param_update(self, params: list[Parameter]) -> SetParametersResult:
+        updated_rate_hz = self._publish_rate_hz
+
+        for parameter in params:
+            try:
+                if parameter.name == "publish_rate_hz":
+                    updated_rate_hz = float(parameter.value)
+                    continue
+                if parameter.name in {
+                    "image_topic",
+                    "metadata_topic",
+                    "source_type",
+                    "source_uri",
+                    "frame_id",
+                    "source_name",
+                    "loop_replay",
+                }:
+                    return SetParametersResult(
+                        successful=False,
+                        reason=(
+                            f"{parameter.name} updates require node restart "
+                            "to rebuild the RGB ingest source or publishers"
+                        ),
+                    )
+            except (TypeError, ValueError):
+                return SetParametersResult(
+                    successful=False,
+                    reason=f"invalid value for '{parameter.name}'",
+                )
+
+        if updated_rate_hz <= 0.0:
+            return SetParametersResult(
+                successful=False, reason="publish_rate_hz must be > 0"
+            )
+
+        if updated_rate_hz != self._publish_rate_hz:
+            self._publish_rate_hz = updated_rate_hz
+            self._timer.cancel()
+            self._timer = self.create_timer(
+                1.0 / self._publish_rate_hz, self._publish_next_frame
+            )
+
+        return SetParametersResult(successful=True)
+
+    def _publish_next_frame(self) -> None:
+        if self._source_exhausted:
+            return
+
+        try:
+            frame = self._source.read()
+        except RgbSourceError as error:
+            self._source_exhausted = True
+            self._timer.cancel()
+            self.get_logger().error(f"RGB ingest stopped: {error}")
+            raise
+
+        if frame is None:
+            self._source_exhausted = True
+            self._timer.cancel()
+            self.get_logger().info(
+                f"RGB {self._source.config.normalized_source_type} source exhausted."
+            )
+            return
+
+        self._image_publisher.publish(_rgb_frame_to_image_message(frame))
+        self._metadata_publisher.publish(String(data=_metadata_payload_json(frame)))
+
+
+def _rgb_frame_to_image_message(frame: RgbFrame) -> Image:
+    image = frame.image_bgr
+    if image.dtype != np.uint8:
+        raise RgbSourceError("RGB ingest frames must be uint8 BGR images")
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise RgbSourceError("RGB ingest frames must use HxWx3 BGR layout")
+
+    message = Image()
+    message.header.stamp.sec = frame.metadata.monotonic_timestamp_ns // 1_000_000_000
+    message.header.stamp.nanosec = (
+        frame.metadata.monotonic_timestamp_ns % 1_000_000_000
+    )
+    message.header.frame_id = frame.metadata.frame_id
+    message.height = int(image.shape[0])
+    message.width = int(image.shape[1])
+    message.encoding = "bgr8"
+    message.is_bigendian = 0
+    message.step = int(image.shape[1] * image.shape[2] * image.itemsize)
+    message.data = image.tobytes()
+    return message
+
+
+def _metadata_payload_json(frame: RgbFrame) -> str:
+    payload = frame.metadata.to_dict()
+    payload["height"] = int(frame.image_bgr.shape[0])
+    payload["width"] = int(frame.image_bgr.shape[1])
+    payload["channels"] = int(frame.image_bgr.shape[2])
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def main(args: list[str] | None = None) -> None:
+    rclpy.init(args=args)
+    node = None
+    try:
+        node = RgbIngestNode()
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()

--- a/software/edge/src/aeris_perception/config/halo_rgb_ingest.example.yaml
+++ b/software/edge/src/aeris_perception/config/halo_rgb_ingest.example.yaml
@@ -1,0 +1,21 @@
+rgb_ingest:
+  ros__parameters:
+    image_topic: rgb/image_raw
+    metadata_topic: rgb/source_metadata
+    publish_rate_hz: 15.0
+    frame_id: halo_rgb_front
+
+    # Live USB/CSI camera example.
+    source_type: camera
+    source_uri: "0"
+    source_name: halo_front_camera
+    loop_replay: false
+
+    # Swap to a local capture file by changing only the source parameters:
+    # source_type: video_file
+    # source_uri: /absolute/path/to/halo-capture.mp4
+    #
+    # Deterministic repeatable replay:
+    # source_type: replay
+    # source_uri: /absolute/path/to/halo-capture.mp4
+    # loop_replay: true

--- a/software/edge/src/aeris_perception/config/perception_demo_rgb_ingest.yaml
+++ b/software/edge/src/aeris_perception/config/perception_demo_rgb_ingest.yaml
@@ -1,0 +1,10 @@
+rgb_ingest:
+  ros__parameters:
+    image_topic: rgb/image_raw
+    metadata_topic: rgb/source_metadata
+    publish_rate_hz: 15.0
+    frame_id: halo_rgb_front
+    source_type: camera
+    source_uri: "0"
+    source_name: halo_front_camera
+    loop_replay: false

--- a/software/edge/src/aeris_perception/package.xml
+++ b/software/edge/src/aeris_perception/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
   <name>aeris_perception</name>
   <version>0.1.0</version>
-  <description>Perception nodes for Halo RGB ingest and hazard cue generation.</description>
+  <description>Perception nodes for Halo RGB ingest and hazard cues.</description>
   <maintainer email="dev@aeris.local">Aeris Developers</maintainer>
   <license>proprietary</license>
 

--- a/software/edge/src/aeris_perception/package.xml
+++ b/software/edge/src/aeris_perception/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
   <name>aeris_perception</name>
   <version>0.1.0</version>
-  <description>Synthetic perception heads (thermal, acoustic, gas).</description>
+  <description>Perception nodes for Halo RGB ingest and hazard cue generation.</description>
   <maintainer email="dev@aeris.local">Aeris Developers</maintainer>
   <license>proprietary</license>
 
@@ -14,6 +14,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>pytest</test_depend>

--- a/software/edge/src/aeris_perception/setup.py
+++ b/software/edge/src/aeris_perception/setup.py
@@ -13,7 +13,10 @@ setup(
         (f"share/{package_name}", ["package.xml"]),
         (
             f"share/{package_name}/config",
-            ["config/halo_rgb_ingest.example.yaml"],
+            [
+                "config/halo_rgb_ingest.example.yaml",
+                "config/perception_demo_rgb_ingest.yaml",
+            ],
         ),
     ],
     install_requires=["setuptools"],

--- a/software/edge/src/aeris_perception/setup.py
+++ b/software/edge/src/aeris_perception/setup.py
@@ -11,16 +11,21 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
         (f"share/{package_name}", ["package.xml"]),
+        (
+            f"share/{package_name}/config",
+            ["config/halo_rgb_ingest.example.yaml"],
+        ),
     ],
     install_requires=["setuptools"],
     zip_safe=True,
     maintainer="Aeris Developers",
     maintainer_email="dev@aeris.local",
-    description="Perception nodes for thermal, acoustic, and gas hazard cues.",
+    description="Perception nodes for Halo RGB ingest and hazard cues.",
     license="proprietary",
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
+            "rgb_ingest = aeris_perception.rgb_ingest_node:main",
             "thermal_hotspot = aeris_perception.thermal_hotspot_node:main",
             "acoustic_bearing = aeris_perception.acoustic_bearing_node:main",
             "acoustic_audio_sim = aeris_perception.acoustic_audio_sim_node:main",

--- a/software/edge/src/aeris_perception/test/test_perception_demo_launch.py
+++ b/software/edge/src/aeris_perception/test/test_perception_demo_launch.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_perception_demo_launch_wires_rgb_ingest_node() -> None:
+    launch_file = (
+        Path(__file__).resolve().parents[3]
+        / "launch"
+        / "perception_demo.launch.py"
+    )
+    content = launch_file.read_text()
+
+    assert 'executable="rgb_ingest"' in content
+    assert "rgb_source_type" in content
+    assert "rgb_source_uri" in content
+    assert "perception_demo_rgb_ingest.yaml" in content

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest.py
@@ -139,7 +139,7 @@ def test_replay_source_uses_capture_timeline_and_loops() -> None:
     )
     second_capture = _FakeCapture(
         [(True, _sample_frame(2))],
-        pos_msec=[40.0],
+        pos_msec=[0.0],
         fps=25.0,
     )
     captures = iter((first_capture, second_capture))
@@ -165,9 +165,38 @@ def test_replay_source_uses_capture_timeline_and_loops() -> None:
     assert first.metadata.source_timestamp_ns == 0
     assert first.metadata.monotonic_timestamp_ns == 0
     assert second.metadata.frame_index == 1
-    assert second.metadata.source_timestamp_ns == 40_000_000
-    assert second.metadata.monotonic_timestamp_ns == 40_000_000
+    assert second.metadata.source_timestamp_ns == 0
+    assert second.metadata.monotonic_timestamp_ns == 1
     assert first_capture.release_calls == 1
+
+
+def test_replay_reopen_failure_releases_replacement_capture() -> None:
+    first_capture = _FakeCapture(
+        [(True, _sample_frame(1)), (False, None)],
+        pos_msec=[0.0, 0.0],
+        fps=25.0,
+    )
+    failed_replacement = _FakeCapture([], opened=False)
+    captures = iter((first_capture, failed_replacement))
+
+    source = build_rgb_frame_source(
+        RgbSourceConfig(
+            source_type="replay",
+            source_uri="/tmp/replay.mp4",
+            frame_id="halo_rgb",
+            loop_replay=True,
+        ),
+        capture_factory=lambda _target: next(captures),
+        path_exists=lambda _path: True,
+    )
+
+    assert source.read() is not None
+
+    with pytest.raises(RgbSourceError, match="Unable to reopen"):
+        source.read()
+
+    assert first_capture.release_calls == 1
+    assert failed_replacement.release_calls == 1
 
 
 def test_build_rgb_frame_source_rejects_missing_file_inputs() -> None:

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest.py
@@ -106,6 +106,31 @@ def test_video_file_source_uses_clock_time_for_monotonic_stamps() -> None:
     assert second.metadata.source_timestamp_ns is None
 
 
+def test_camera_source_returns_none_for_transient_miss_without_exhausting_capture() -> None:
+    capture = _FakeCapture(
+        [(False, None), (True, _sample_frame(33))],
+        opened=True,
+    )
+    source = RgbFrameSource(
+        config=RgbSourceConfig(
+            source_type="camera",
+            source_uri="0",
+            frame_id="halo_rgb",
+        ),
+        capture=capture,
+        clock_ns=lambda: 5_000,
+    )
+
+    missed = source.read()
+    recovered = source.read()
+
+    assert missed is None
+    assert recovered is not None
+    assert recovered.metadata.frame_index == 0
+    assert recovered.metadata.monotonic_timestamp_ns == 5_000
+    assert capture.release_calls == 0
+
+
 def test_replay_source_uses_capture_timeline_and_loops() -> None:
     first_capture = _FakeCapture(
         [(True, _sample_frame(1)), (False, None)],

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aeris_perception.rgb_ingest import (
+    MonotonicTimestampGenerator,
+    RgbFrameSource,
+    RgbSourceConfig,
+    RgbSourceError,
+    build_rgb_frame_source,
+)
+
+
+class _FakeCapture:
+    def __init__(
+        self,
+        reads: list[tuple[bool, np.ndarray | None]],
+        *,
+        opened: bool = True,
+        fps: float = 30.0,
+        pos_msec: list[float] | None = None,
+    ) -> None:
+        self._reads = list(reads)
+        self._opened = opened
+        self._fps = fps
+        self._pos_msec = list(pos_msec or [])
+        self.release_calls = 0
+        self.set_calls: list[tuple[int, float]] = []
+
+    def isOpened(self) -> bool:
+        return self._opened
+
+    def read(self) -> tuple[bool, np.ndarray | None]:
+        if not self._reads:
+            return False, None
+        return self._reads.pop(0)
+
+    def release(self) -> None:
+        self.release_calls += 1
+
+    def get(self, prop_id: int) -> float:
+        if prop_id == 5:
+            return self._fps
+        if prop_id == 0:
+            if self._pos_msec:
+                return self._pos_msec.pop(0)
+            return 0.0
+        return 0.0
+
+    def set(self, prop_id: int, value: float) -> bool:
+        self.set_calls.append((prop_id, value))
+        return True
+
+
+def _sample_frame(fill: int) -> np.ndarray:
+    return np.full((4, 6, 3), fill, dtype=np.uint8)
+
+
+def test_rgb_source_config_requires_uri_for_file_backed_sources() -> None:
+    with pytest.raises(RgbSourceError, match="source_uri"):
+        RgbSourceConfig(source_type="video_file", source_uri="", frame_id="halo_rgb")
+
+    with pytest.raises(RgbSourceError, match="source_uri"):
+        RgbSourceConfig(source_type="replay", source_uri="", frame_id="halo_rgb")
+
+
+def test_rgb_source_config_rejects_unknown_source_types() -> None:
+    with pytest.raises(RgbSourceError, match="unsupported"):
+        RgbSourceConfig(source_type="lidar", source_uri="0", frame_id="halo_rgb")
+
+
+def test_monotonic_timestamp_generator_never_regresses() -> None:
+    generator = MonotonicTimestampGenerator()
+
+    first = generator.normalize(200)
+    second = generator.normalize(200)
+    third = generator.normalize(150)
+
+    assert first == 200
+    assert second == 201
+    assert third == 202
+
+
+def test_video_file_source_uses_clock_time_for_monotonic_stamps() -> None:
+    capture = _FakeCapture([(True, _sample_frame(10)), (True, _sample_frame(20))])
+    clock_values = iter((1_000, 1_000))
+    source = RgbFrameSource(
+        config=RgbSourceConfig(
+            source_type="video_file",
+            source_uri="/tmp/halo.mp4",
+            frame_id="halo_rgb",
+        ),
+        capture=capture,
+        clock_ns=lambda: next(clock_values),
+    )
+
+    first = source.read()
+    second = source.read()
+
+    assert first is not None
+    assert second is not None
+    assert first.metadata.monotonic_timestamp_ns == 1_000
+    assert second.metadata.monotonic_timestamp_ns == 1_001
+    assert first.metadata.source_timestamp_ns is None
+    assert second.metadata.source_timestamp_ns is None
+
+
+def test_replay_source_uses_capture_timeline_and_loops() -> None:
+    first_capture = _FakeCapture(
+        [(True, _sample_frame(1)), (False, None)],
+        pos_msec=[0.0, 0.0],
+        fps=25.0,
+    )
+    second_capture = _FakeCapture(
+        [(True, _sample_frame(2))],
+        pos_msec=[40.0],
+        fps=25.0,
+    )
+    captures = iter((first_capture, second_capture))
+
+    source = build_rgb_frame_source(
+        RgbSourceConfig(
+            source_type="replay",
+            source_uri="/tmp/replay.mp4",
+            frame_id="halo_rgb",
+            loop_replay=True,
+        ),
+        capture_factory=lambda _target: next(captures),
+        path_exists=lambda _path: True,
+        clock_ns=lambda: 9_999,
+    )
+
+    first = source.read()
+    second = source.read()
+
+    assert first is not None
+    assert second is not None
+    assert first.metadata.replayed is True
+    assert first.metadata.source_timestamp_ns == 0
+    assert first.metadata.monotonic_timestamp_ns == 0
+    assert second.metadata.frame_index == 1
+    assert second.metadata.source_timestamp_ns == 40_000_000
+    assert second.metadata.monotonic_timestamp_ns == 40_000_000
+    assert first_capture.release_calls == 1
+
+
+def test_build_rgb_frame_source_rejects_missing_file_inputs() -> None:
+    with pytest.raises(RgbSourceError, match="does not exist"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="replay",
+                source_uri="/tmp/missing.mp4",
+                frame_id="halo_rgb",
+            ),
+            capture_factory=lambda _target: _FakeCapture([]),
+            path_exists=lambda _path: False,
+        )
+
+
+def test_build_rgb_frame_source_rejects_unopenable_capture() -> None:
+    with pytest.raises(RgbSourceError, match="Unable to open"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="camera",
+                source_uri="0",
+                frame_id="halo_rgb",
+            ),
+            capture_factory=lambda _target: _FakeCapture([], opened=False),
+        )

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 rclpy = pytest.importorskip("rclpy")
 pytest.importorskip("sensor_msgs.msg")
+from builtin_interfaces.msg import Time
 from rclpy.parameter import Parameter
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
@@ -23,10 +25,33 @@ class _RecorderPublisher:
         self.messages.append(message)
 
 
+class _FakeTimer:
+    def __init__(self) -> None:
+        self.cancel_calls = 0
+
+    def cancel(self) -> None:
+        self.cancel_calls += 1
+
+
 class _StaticSource:
     def __init__(self, frames: list[RgbFrame]) -> None:
         self._frames = list(frames)
         self.closed = False
+
+    def read(self) -> RgbFrame | None:
+        if not self._frames:
+            return None
+        return self._frames.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _TransientCameraSource:
+    def __init__(self, frames: list[RgbFrame | None]) -> None:
+        self._frames = list(frames)
+        self.closed = False
+        self.config = SimpleNamespace(normalized_source_type="camera")
 
     def read(self) -> RgbFrame | None:
         if not self._frames:
@@ -71,6 +96,7 @@ def test_rgb_ingest_node_publishes_image_and_metadata_payload() -> None:
         node._timer.cancel()
         node._image_publisher = image_recorder
         node._metadata_publisher = metadata_recorder
+        node._ros_stamp_provider = lambda: Time(sec=77, nanosec=88)
 
         node._publish_next_frame()
 
@@ -82,8 +108,8 @@ def test_rgb_ingest_node_publishes_image_and_metadata_payload() -> None:
         assert isinstance(image_message, Image)
         assert isinstance(metadata_message, String)
         assert image_message.header.frame_id == "halo_rgb"
-        assert image_message.header.stamp.sec == 1
-        assert image_message.header.stamp.nanosec == 250_000_000
+        assert image_message.header.stamp.sec == 77
+        assert image_message.header.stamp.nanosec == 88
         assert image_message.height == 3
         assert image_message.width == 5
         assert image_message.encoding == "bgr8"
@@ -96,6 +122,60 @@ def test_rgb_ingest_node_publishes_image_and_metadata_payload() -> None:
         assert payload["height"] == 3
         assert payload["width"] == 5
         assert payload["channels"] == 3
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def test_rgb_ingest_node_keeps_camera_timer_running_after_transient_miss() -> None:
+    rclpy.init()
+    source = _TransientCameraSource(
+        [
+            None,
+            RgbFrame(
+                image_bgr=np.full((2, 4, 3), 9, dtype=np.uint8),
+                metadata=RgbFrameMetadata(
+                    source_type="camera",
+                    source_name="halo_cam",
+                    source_uri="0",
+                    frame_id="halo_rgb",
+                    frame_index=0,
+                    monotonic_timestamp_ns=4_000,
+                    source_timestamp_ns=None,
+                    replayed=False,
+                ),
+            ),
+        ]
+    )
+    node = RgbIngestNode(
+        parameter_overrides=[
+            Parameter("source_type", value="camera"),
+            Parameter("source_uri", value="0"),
+            Parameter("frame_id", value="halo_rgb"),
+        ],
+        source_factory=lambda _config: source,
+    )
+    image_recorder = _RecorderPublisher()
+    metadata_recorder = _RecorderPublisher()
+    fake_timer = _FakeTimer()
+
+    try:
+        node._timer.cancel()
+        node._timer = fake_timer
+        node._image_publisher = image_recorder
+        node._metadata_publisher = metadata_recorder
+        node._ros_stamp_provider = lambda: Time(sec=3, nanosec=14)
+
+        node._publish_next_frame()
+        assert node._source_exhausted is False
+        assert fake_timer.cancel_calls == 0
+        assert image_recorder.messages == []
+
+        node._publish_next_frame()
+        assert len(image_recorder.messages) == 1
+        assert len(metadata_recorder.messages) == 1
+        assert node._source_exhausted is False
+        assert fake_timer.cancel_calls == 0
     finally:
         node.destroy_node()
         rclpy.shutdown()

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+rclpy = pytest.importorskip("rclpy")
+pytest.importorskip("sensor_msgs.msg")
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import Image
+from std_msgs.msg import String
+
+from aeris_perception.rgb_ingest import RgbFrame, RgbFrameMetadata
+from aeris_perception.rgb_ingest_node import RgbIngestNode
+
+
+class _RecorderPublisher:
+    def __init__(self) -> None:
+        self.messages: list[object] = []
+
+    def publish(self, message: object) -> None:
+        self.messages.append(message)
+
+
+class _StaticSource:
+    def __init__(self, frames: list[RgbFrame]) -> None:
+        self._frames = list(frames)
+        self.closed = False
+
+    def read(self) -> RgbFrame | None:
+        if not self._frames:
+            return None
+        return self._frames.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_rgb_ingest_node_publishes_image_and_metadata_payload() -> None:
+    rclpy.init()
+    source = _StaticSource(
+        [
+            RgbFrame(
+                image_bgr=np.full((3, 5, 3), 17, dtype=np.uint8),
+                metadata=RgbFrameMetadata(
+                    source_type="replay",
+                    source_name="halo_replay",
+                    source_uri="/tmp/halo.mp4",
+                    frame_id="halo_rgb",
+                    frame_index=4,
+                    monotonic_timestamp_ns=1_250_000_000,
+                    source_timestamp_ns=1_200_000_000,
+                    replayed=True,
+                ),
+            )
+        ]
+    )
+    node = RgbIngestNode(
+        parameter_overrides=[
+            Parameter("source_type", value="replay"),
+            Parameter("source_uri", value="/tmp/halo.mp4"),
+            Parameter("frame_id", value="halo_rgb"),
+        ],
+        source_factory=lambda _config: source,
+    )
+    image_recorder = _RecorderPublisher()
+    metadata_recorder = _RecorderPublisher()
+
+    try:
+        node._timer.cancel()
+        node._image_publisher = image_recorder
+        node._metadata_publisher = metadata_recorder
+
+        node._publish_next_frame()
+
+        assert len(image_recorder.messages) == 1
+        assert len(metadata_recorder.messages) == 1
+
+        image_message = image_recorder.messages[0]
+        metadata_message = metadata_recorder.messages[0]
+        assert isinstance(image_message, Image)
+        assert isinstance(metadata_message, String)
+        assert image_message.header.frame_id == "halo_rgb"
+        assert image_message.header.stamp.sec == 1
+        assert image_message.header.stamp.nanosec == 250_000_000
+        assert image_message.height == 3
+        assert image_message.width == 5
+        assert image_message.encoding == "bgr8"
+
+        payload = json.loads(metadata_message.data)
+        assert payload["frame_index"] == 4
+        assert payload["monotonic_timestamp_ns"] == 1_250_000_000
+        assert payload["source_timestamp_ns"] == 1_200_000_000
+        assert payload["replayed"] is True
+        assert payload["height"] == 3
+        assert payload["width"] == 5
+        assert payload["channels"] == 3
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
@@ -13,7 +13,7 @@ from rclpy.parameter import Parameter
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
 
-from aeris_perception.rgb_ingest import RgbFrame, RgbFrameMetadata
+from aeris_perception.rgb_ingest import RgbFrame, RgbFrameMetadata, RgbSourceError
 from aeris_perception.rgb_ingest_node import RgbIngestNode
 
 
@@ -37,11 +37,24 @@ class _StaticSource:
     def __init__(self, frames: list[RgbFrame]) -> None:
         self._frames = list(frames)
         self.closed = False
+        self.config = SimpleNamespace(normalized_source_type="replay")
 
     def read(self) -> RgbFrame | None:
         if not self._frames:
             return None
         return self._frames.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ErrorSource:
+    def __init__(self) -> None:
+        self.closed = False
+        self.config = SimpleNamespace(normalized_source_type="replay")
+
+    def read(self) -> RgbFrame | None:
+        raise RgbSourceError("source failed")
 
     def close(self) -> None:
         self.closed = True
@@ -176,6 +189,32 @@ def test_rgb_ingest_node_keeps_camera_timer_running_after_transient_miss() -> No
         assert len(metadata_recorder.messages) == 1
         assert node._source_exhausted is False
         assert fake_timer.cancel_calls == 0
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def test_rgb_ingest_node_stops_without_raising_on_source_error() -> None:
+    rclpy.init()
+    source = _ErrorSource()
+    node = RgbIngestNode(
+        parameter_overrides=[
+            Parameter("source_type", value="replay"),
+            Parameter("source_uri", value="/tmp/halo.mp4"),
+            Parameter("frame_id", value="halo_rgb"),
+        ],
+        source_factory=lambda _config: source,
+    )
+    fake_timer = _FakeTimer()
+
+    try:
+        node._timer.cancel()
+        node._timer = fake_timer
+
+        node._publish_next_frame()
+
+        assert node._source_exhausted is True
+        assert fake_timer.cancel_calls == 1
     finally:
         node.destroy_node()
         rclpy.shutdown()


### PR DESCRIPTION
## Summary
- Add a configurable RGB ingest contract for live camera, local video, and deterministic replay sources.
- Publish RGB frames and source metadata from a new `rgb_ingest` ROS 2 node.
- Include a sample config and focused tests for config validation, invalid sources, monotonic timestamps, replay behavior, and message payload shape.

## Why
This gives the Halo proof path a real sensor/video input layer instead of starting from mock detections. Downstream recognition, confidence scoring, evidence logging, and the GCS demo can now build against one clear frame contract.

Closes #117

## Tests
- `PYTHONPATH=software/edge/src/aeris_perception:software/edge/src/aeris_msgs /tmp/aeris-halo-test/bin/python -m pytest software/edge/src/aeris_perception/test software/edge/src/aeris_msgs/test -q`
- `python3 -m compileall software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py`
- `git diff --cached --check`

Note: `colcon build --symlink-install --packages-select aeris_msgs aeris_perception` was not run because `colcon` is not installed in this shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RGB frame ingest pipeline supporting live camera feeds and video file replay
  * ROS 2 node for publishing image frames with associated metadata
  * Configurable publish rates, output topics, and source identification
  * Automatic replay looping with monotonic timestamp normalization

* **Tests**
  * Comprehensive test coverage for RGB ingest and node functionality

* **Chores**
  * Added OpenCV runtime dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a configurable RGB ingest pipeline for the Halo proof path, providing live camera, local video, and deterministic replay sources as a single frame contract for downstream recognition and evidence logging stages.

- **`rgb_ingest.py`** defines `RgbSourceConfig`, `RgbFrameSource`, and `MonotonicTimestampGenerator` with solid config validation, replay looping (using `_source_frame_index` that is correctly reset on both rewind paths), and an OpenCV capture adapter.
- **`rgb_ingest_node.py`** wires the source into a ROS 2 timer-driven publisher, but has an uncaught `RgbSourceError` that can escape the timer callback from `_rgb_frame_to_image_message`, and leaks a cancelled (but not destroyed) RCL timer handle on every `publish_rate_hz` update.
- **`perception_demo.launch.py`** adds the node to the demo launch description with two issues: the config YAML path is resolved relative to `__file__` (breaks without `--symlink-install`), and the `loop_replay` boolean is passed via `LaunchConfiguration`, which resolves to the string `"false"` and causes `bool("false") == True` in the node.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the timer callback can terminate the spin loop on a non-uint8 frame, and the launch file silently enables replay looping for every launch invocation due to the string-to-bool coercion bug.

Four defects in the node and launch layer need fixing before this can be deployed reliably: an unhandled exception path that kills the ROS spin loop, a timer resource leak on every rate update, a config-path computation that breaks without `--symlink-install`, and a boolean parameter passed as a string that `bool()` misinterprets. The core ingest library (`rgb_ingest.py`) and tests are in good shape.

software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py and software/edge/launch/perception_demo.launch.py both need fixes before deployment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py | New ROS 2 node publishing RGB frames and metadata; has two bugs: `_rgb_frame_to_image_message` can throw an uncaught `RgbSourceError` in the timer callback, and the old timer is leaked (not destroyed) on every `publish_rate_hz` update. |
| software/edge/launch/perception_demo.launch.py | Adds `rgb_ingest` node to the demo launch; config path is resolved relative to `__file__` (breaks without `--symlink-install`), and the `loop_replay` boolean arg is passed as a LaunchConfiguration string, causing `bool("false")` == `True`. |
| software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py | Core ingest contract with config validation, monotonic timestamp generation, replay looping, and OpenCV adapter; logic is sound with `_source_frame_index` correctly reset on both rewind paths. |
| software/edge/src/aeris_perception/test/test_rgb_ingest.py | Well-structured tests covering config validation, monotonic timestamps, camera transient misses, replay looping, and failure paths; all mock objects are correctly shaped. |
| software/edge/src/aeris_perception/test/test_rgb_ingest_node.py | Node-level tests covering publish payload shape, camera transient miss behavior, and source-error shutdown; `_StaticSource` now includes the `config` attribute addressing a previous concern. |
| software/edge/src/aeris_perception/setup.py | Adds `rgb_ingest` entry point and installs config YAML files to `share/aeris_perception/config`; no issues. |
| software/edge/src/aeris_perception/package.xml | Adds `python3-opencv` exec dependency; straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as perception_demo.launch.py
    participant N as RgbIngestNode
    participant S as RgbFrameSource
    participant C as OpenCV VideoCapture
    participant IP as /rgb/image_raw
    participant MP as /rgb/source_metadata

    L->>N: launch with parameters (YAML + LaunchConfiguration overrides)
    N->>S: build_rgb_frame_source(RgbSourceConfig)
    S->>C: VideoCapture(target)
    C-->>S: opened

    loop Timer callback (_publish_next_frame)
        N->>S: read()
        S->>C: capture.read()
        alt success
            C-->>S: (True, np.ndarray BGR)
            S-->>N: RgbFrame(image_bgr, metadata)
            N->>IP: publish(Image)
            N->>MP: publish(String JSON metadata)
        else transient miss (camera)
            C-->>S: (False, None)
            S-->>N: None
            N->>N: log debug, keep timer running
        else EOF (video_file / replay non-loop)
            C-->>S: (False, None)
            S-->>N: None
            N->>N: "cancel timer, set source_exhausted=True"
        else "replay + loop_replay=True"
            C-->>S: (False, None)
            S->>S: _rewind_or_reopen()
            S->>C: VideoCapture(target) [new]
            S->>C: capture.read()
            C-->>S: (True, np.ndarray BGR)
            S-->>N: RgbFrame(image_bgr, metadata)
            N->>IP: publish(Image)
            N->>MP: publish(String JSON metadata)
        else RgbSourceError
            S-->>N: raise RgbSourceError
            N->>N: "cancel timer, log error, set source_exhausted=True"
        end
    end

    N->>S: close() [on destroy_node]
    S->>C: release()
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py:149-150
**Uncaught `RgbSourceError` from `_rgb_frame_to_image_message` crashes the timer callback**

`_rgb_frame_to_image_message` raises `RgbSourceError` on line 159 when `image.dtype != np.uint8`, but this call sits outside the `try/except RgbSourceError` block that guards only `self._source.read()`. If a camera or codec returns a non-uint8 frame (e.g., from a high-dynamic-range source), the exception propagates unhandled from the timer callback, which terminates `rclpy.spin()` since only `KeyboardInterrupt` is caught in `main()`. The shape validation in `rgb_ingest.py` does not check dtype, so this frame path is reachable. Either expand the try/except to cover the publish calls, or move the dtype guard into `RgbFrameSource.read()` where other frame-shape errors are already caught.

### Issue 2 of 4
software/edge/launch/perception_demo.launch.py:24-30
**Config path computed from `__file__` breaks in non-symlink colcon installs**

`Path(__file__).resolve().parents[1] / "src" / "aeris_perception" / "config" / ...` is evaluated at launch time. With `--symlink-install` the symlink resolves back to the source tree, so this works. Without it, the launch file is copied to `install/aeris_perception/share/aeris_perception/launch/`, making `parents[1]` equal to `share/aeris_perception/`, and the resulting config path (`share/aeris_perception/src/aeris_perception/config/...`) does not exist — causing a node startup failure. The standard ROS 2 idiom is `from ament_index_python.packages import get_package_share_directory` followed by `Path(get_package_share_directory("aeris_perception")) / "config" / "perception_demo_rgb_ingest.yaml"`.

### Issue 3 of 4
software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py:117-122
**Old timer is cancelled but never destroyed, leaking RCL resources on rate updates**

`timer.cancel()` stops the timer from firing but does not remove it from the node's internal timer list or call `rcl_timer_fini`. Each `publish_rate_hz` update via `ros2 param set` therefore accumulates an unreleased RCL timer handle. `self.destroy_timer(old_timer)` must be called before reassigning to properly free the handle and remove it from the node's tracked resources.

```suggestion
        if updated_rate_hz != self._publish_rate_hz:
            self._publish_rate_hz = updated_rate_hz
            old_timer = self._timer
            self._timer = self.create_timer(
                1.0 / self._publish_rate_hz, self._publish_next_frame
            )
            self.destroy_timer(old_timer)
```

### Issue 4 of 4
software/edge/launch/perception_demo.launch.py:65-69
**`loop_replay` from `LaunchConfiguration` arrives as the string `"false"`, not boolean `False`**

`LaunchConfiguration` always resolves to a string. When `{"loop_replay": rgb_loop_replay}` is included in `parameters`, launch_ros serializes the resolved string `"false"` into a temporary YAML file as the quoted string `'false'`, which rclpy loads as type `PARAMETER_STRING`. In the node, `bool(self.declare_parameter("loop_replay", False).value)` then evaluates `bool("false")` — which is `True` in Python because the string is non-empty — silently enabling looping for every launch invocation. This overrides the correctly typed `loop_replay: false` from the preceding YAML config file. The fix is to either pass the boolean directly (e.g. `"loop_replay": False`) or add explicit string-to-bool coercion in the node: `val = ...; self._loop_replay = val if isinstance(val, bool) else val.lower() in ("true", "1")`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Handle RGB ingest review edge cases"](https://github.com/aeris-drones/aeris/commit/c3f062ad394c4a0a25f4015ae488ab2890eba839) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34482596)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->