### PR TITLE
Add Halo RGB dataset capture

### DIFF
--- a/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
@@ -1,0 +1,414 @@
+"""RGB frame capture and manifest-backed replay for the Halo proof loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Callable
+
+import numpy as np
+
+from .rgb_ingest import (
+    MonotonicTimestampGenerator,
+    RgbFrame,
+    RgbFrameMetadata,
+    RgbSourceConfig,
+    RgbSourceError,
+)
+
+
+MANIFEST_VERSION = 1
+SUPPORTED_CAPTURE_IMAGE_FORMATS = {"jpeg", "jpg", "png", "ppm"}
+
+
+@dataclass(frozen=True)
+class RgbDatasetCaptureConfig:
+    """Configures manifest-backed frame capture for RGB ingest."""
+
+    output_dir: Path
+    manifest_path: Path
+    image_format: str = "png"
+    capture_reason: str = "continuous_capture"
+
+    def __post_init__(self) -> None:
+        image_format = self.normalized_image_format
+        if image_format not in SUPPORTED_CAPTURE_IMAGE_FORMATS:
+            raise RgbSourceError(
+                f"unsupported capture image format '{self.image_format}'"
+            )
+        if not str(self.capture_reason).strip():
+            raise RgbSourceError(
+                "capture_reason must be configured when capture is enabled"
+            )
+
+    @property
+    def normalized_image_format(self) -> str:
+        return self.image_format.strip().lower()
+
+
+@dataclass(frozen=True)
+class RgbDatasetManifestEntry:
+    """One manifest entry describing a captured RGB frame."""
+
+    relative_image_path: str
+    capture_reason: str
+    metadata: RgbFrameMetadata
+    height: int
+    width: int
+    channels: int
+    label: str | None = None
+    review: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest_version": MANIFEST_VERSION,
+            "relative_image_path": self.relative_image_path,
+            "capture_reason": self.capture_reason,
+            "label": self.label,
+            "review": self.review,
+            "height": self.height,
+            "width": self.width,
+            "channels": self.channels,
+            "metadata": self.metadata.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(
+        cls, payload: dict[str, Any], *, line_number: int
+    ) -> "RgbDatasetManifestEntry":
+        try:
+            manifest_version = int(payload["manifest_version"])
+            if manifest_version != MANIFEST_VERSION:
+                raise RgbSourceError(
+                    f"Malformed RGB dataset manifest at line {line_number}"
+                )
+            metadata_payload = payload["metadata"]
+            metadata = RgbFrameMetadata(
+                source_type=str(metadata_payload["source_type"]),
+                source_name=str(metadata_payload["source_name"]),
+                source_uri=str(metadata_payload["source_uri"]),
+                frame_id=str(metadata_payload["frame_id"]),
+                frame_index=int(metadata_payload["frame_index"]),
+                monotonic_timestamp_ns=int(metadata_payload["monotonic_timestamp_ns"]),
+                source_timestamp_ns=(
+                    None
+                    if metadata_payload["source_timestamp_ns"] is None
+                    else int(metadata_payload["source_timestamp_ns"])
+                ),
+                replayed=bool(metadata_payload["replayed"]),
+            )
+            return cls(
+                relative_image_path=str(payload["relative_image_path"]),
+                capture_reason=str(payload["capture_reason"]),
+                label=payload.get("label"),
+                review=payload.get("review"),
+                height=int(payload["height"]),
+                width=int(payload["width"]),
+                channels=int(payload["channels"]),
+                metadata=metadata,
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise RgbSourceError(
+                f"Malformed RGB dataset manifest at line {line_number}"
+            ) from error
+
+
+class RgbFrameCaptureWriter:
+    """Persists RGB frames plus JSONL manifest entries for replay and evaluation."""
+
+    def __init__(
+        self,
+        config: RgbDatasetCaptureConfig,
+        *,
+        image_writer: Callable[[Path, np.ndarray, str], None] | None = None,
+    ) -> None:
+        self._config = config
+        self._image_writer = image_writer or _write_image_file
+        self._output_dir = Path(config.output_dir)
+        self._manifest_path = Path(config.manifest_path)
+        self._frames_dir = self._output_dir / "frames"
+        self._ensure_output_layout()
+
+    def capture(
+        self,
+        frame: RgbFrame,
+        *,
+        label: str | None = None,
+        review: dict[str, Any] | None = None,
+    ) -> RgbDatasetManifestEntry:
+        _validate_image(frame.image_bgr)
+
+        relative_image_path = Path("frames") / _capture_filename(
+            frame.metadata,
+            image_format=self._config.normalized_image_format,
+        )
+        image_path = self._output_dir / relative_image_path
+        self._image_writer(
+            image_path,
+            frame.image_bgr,
+            self._config.normalized_image_format,
+        )
+
+        entry = RgbDatasetManifestEntry(
+            relative_image_path=os.path.relpath(
+                image_path, start=self._manifest_path.parent
+            ),
+            capture_reason=self._config.capture_reason,
+            metadata=frame.metadata,
+            height=int(frame.image_bgr.shape[0]),
+            width=int(frame.image_bgr.shape[1]),
+            channels=int(frame.image_bgr.shape[2]),
+            label=label,
+            review=review,
+        )
+        with self._manifest_path.open("a", encoding="utf-8") as manifest_file:
+            manifest_file.write(json.dumps(entry.to_dict(), sort_keys=True))
+            manifest_file.write("\n")
+        return entry
+
+    def _ensure_output_layout(self) -> None:
+        if self._output_dir.exists() and not self._output_dir.is_dir():
+            raise RgbSourceError(
+                f"RGB capture output directory is not a directory: '{self._output_dir}'"
+            )
+        if self._manifest_path.exists() and self._manifest_path.is_dir():
+            raise RgbSourceError(
+                f"RGB dataset manifest path is a directory: '{self._manifest_path}'"
+            )
+        try:
+            self._output_dir.mkdir(parents=True, exist_ok=True)
+            self._frames_dir.mkdir(parents=True, exist_ok=True)
+            self._manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            raise RgbSourceError(
+                f"Unable to prepare RGB capture output path '{self._output_dir}'"
+            ) from error
+
+
+class ManifestReplayFrameSource:
+    """Replays captured RGB frames from a manifest-backed image sequence."""
+
+    def __init__(
+        self,
+        *,
+        config: RgbSourceConfig,
+        entries: list[RgbDatasetManifestEntry],
+        manifest_path: Path,
+        image_reader: Callable[[Path], np.ndarray] | None = None,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> None:
+        self._config = config
+        self._entries = list(entries)
+        self._manifest_path = manifest_path
+        self._image_reader = image_reader or _read_image_file
+        self._index = 0
+        self._timestamp_generator = MonotonicTimestampGenerator(
+            fallback_clock_ns=clock_ns
+        )
+
+    @property
+    def config(self) -> RgbSourceConfig:
+        return self._config
+
+    def read(self) -> RgbFrame | None:
+        if not self._entries:
+            return None
+        if self._index >= len(self._entries):
+            if not self._config.loop_replay:
+                return None
+            self._index = 0
+
+        entry = self._entries[self._index]
+        self._index += 1
+
+        image_path = self._resolve_image_path(entry)
+        image = self._image_reader(image_path)
+        _validate_image(image)
+
+        metadata = entry.metadata
+        return RgbFrame(
+            image_bgr=image,
+            metadata=RgbFrameMetadata(
+                source_type=metadata.source_type,
+                source_name=metadata.source_name,
+                source_uri=metadata.source_uri,
+                frame_id=metadata.frame_id,
+                frame_index=metadata.frame_index,
+                monotonic_timestamp_ns=self._timestamp_generator.normalize(
+                    metadata.monotonic_timestamp_ns
+                ),
+                source_timestamp_ns=metadata.source_timestamp_ns,
+                replayed=True,
+            ),
+        )
+
+    def close(self) -> None:
+        return None
+
+    def _resolve_image_path(self, entry: RgbDatasetManifestEntry) -> Path:
+        image_path = (self._manifest_path.parent / entry.relative_image_path).resolve()
+        if not image_path.exists():
+            raise RgbSourceError(
+                f"RGB dataset capture file does not exist: '{image_path}'"
+            )
+        return image_path
+
+
+def build_manifest_replay_frame_source(
+    config: RgbSourceConfig,
+    *,
+    path_exists: Callable[[Path], bool] | None = None,
+    clock_ns: Callable[[], int] | None = None,
+) -> ManifestReplayFrameSource:
+    """Build a manifest-backed RGB replay source."""
+
+    manifest_path = Path(config.source_uri)
+    exists = path_exists or Path.exists
+    if not exists(manifest_path):
+        raise RgbSourceError(
+            f"RGB dataset manifest path does not exist: '{config.source_uri}'"
+        )
+
+    entries = load_rgb_dataset_manifest(manifest_path)
+    for entry in entries:
+        image_path = manifest_path.parent / entry.relative_image_path
+        if not exists(image_path):
+            raise RgbSourceError(
+                f"RGB dataset capture file does not exist: '{image_path}'"
+            )
+
+    return ManifestReplayFrameSource(
+        config=config,
+        entries=entries,
+        manifest_path=manifest_path,
+        clock_ns=clock_ns,
+    )
+
+
+def load_rgb_dataset_manifest(manifest_path: Path) -> list[RgbDatasetManifestEntry]:
+    """Load and validate JSONL manifest entries."""
+
+    entries: list[RgbDatasetManifestEntry] = []
+    try:
+        with manifest_path.open("r", encoding="utf-8") as manifest_file:
+            for line_number, raw_line in enumerate(manifest_file, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise RgbSourceError(
+                        f"Malformed RGB dataset manifest at line {line_number}"
+                    ) from error
+                entries.append(
+                    RgbDatasetManifestEntry.from_dict(
+                        payload, line_number=line_number
+                    )
+                )
+    except OSError as error:
+        raise RgbSourceError(
+            f"Unable to read RGB dataset manifest '{manifest_path}'"
+        ) from error
+
+    return entries
+
+
+def _capture_filename(metadata: RgbFrameMetadata, *, image_format: str) -> str:
+    source_slug = _slugify(metadata.source_name or metadata.frame_id)
+    return (
+        f"{source_slug}_{metadata.frame_index:06d}_"
+        f"{metadata.monotonic_timestamp_ns}.{image_format}"
+    )
+
+
+def _slugify(value: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_-]+", "_", value.strip())
+    return normalized.strip("_") or "frame"
+
+
+def _validate_image(image: np.ndarray) -> None:
+    if image.dtype != np.uint8:
+        raise RgbSourceError("captured RGB frames must be uint8 BGR images")
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise RgbSourceError("captured RGB frames must use HxWx3 BGR layout")
+
+
+def _write_image_file(path: Path, image_bgr: np.ndarray, image_format: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if image_format == "ppm":
+        _write_ppm(path, image_bgr)
+        return
+
+    try:
+        import cv2
+    except ImportError as error:  # pragma: no cover - depends on runtime image
+        raise RgbSourceError(
+            "OpenCV is required for non-PPM RGB capture formats"
+        ) from error
+
+    if not cv2.imwrite(str(path), image_bgr):
+        raise RgbSourceError(f"Unable to write RGB capture image '{path}'")
+
+
+def _read_image_file(path: Path) -> np.ndarray:
+    if path.suffix.lower() == ".ppm":
+        return _read_ppm(path)
+
+    try:
+        import cv2
+    except ImportError as error:  # pragma: no cover - depends on runtime image
+        raise RgbSourceError(
+            "OpenCV is required for non-PPM RGB replay formats"
+        ) from error
+
+    image = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if image is None:
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")
+    return image
+
+
+def _write_ppm(path: Path, image_bgr: np.ndarray) -> None:
+    _validate_image(image_bgr)
+    image_rgb = image_bgr[:, :, ::-1]
+    height, width = image_rgb.shape[:2]
+    header = f"P6\n{width} {height}\n255\n".encode("ascii")
+    try:
+        with path.open("wb") as output_file:
+            output_file.write(header)
+            output_file.write(image_rgb.tobytes())
+    except OSError as error:
+        raise RgbSourceError(f"Unable to write RGB capture image '{path}'") from error
+
+
+def _read_ppm(path: Path) -> np.ndarray:
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'") from error
+
+    parts = data.split(b"\n", 3)
+    if len(parts) != 4 or parts[0] != b"P6":
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")
+
+    try:
+        width_text, height_text = parts[1].split()
+        width = int(width_text)
+        height = int(height_text)
+        max_value = int(parts[2])
+    except ValueError as error:
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'") from error
+
+    if max_value != 255:
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")
+
+    expected_size = width * height * 3
+    payload = parts[3]
+    if len(payload) != expected_size:
+        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")
+
+    image_rgb = np.frombuffer(payload, dtype=np.uint8).reshape((height, width, 3))
+    return image_rgb[:, :, ::-1].copy()

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
@@ -83,7 +83,8 @@ class RgbDatasetManifestEntry:
             manifest_version = int(payload["manifest_version"])
             if manifest_version != MANIFEST_VERSION:
                 raise RgbSourceError(
-                    f"Malformed RGB dataset manifest at line {line_number}"
+                    f"Unsupported RGB dataset manifest version {manifest_version} "
+                    f"(expected {MANIFEST_VERSION}) at line {line_number}"
                 )
             metadata_payload = payload["metadata"]
             metadata = RgbFrameMetadata(
@@ -202,12 +203,14 @@ class ManifestReplayFrameSource:
         entries: list[RgbDatasetManifestEntry],
         manifest_path: Path,
         image_reader: Callable[[Path], np.ndarray] | None = None,
+        path_exists: Callable[[Path], bool] | None = None,
         clock_ns: Callable[[], int] | None = None,
     ) -> None:
         self._config = config
         self._entries = list(entries)
         self._manifest_path = manifest_path
         self._image_reader = image_reader or _read_image_file
+        self._path_exists = path_exists or Path.exists
         self._index = 0
         self._timestamp_generator = MonotonicTimestampGenerator(
             fallback_clock_ns=clock_ns
@@ -254,7 +257,7 @@ class ManifestReplayFrameSource:
 
     def _resolve_image_path(self, entry: RgbDatasetManifestEntry) -> Path:
         image_path = (self._manifest_path.parent / entry.relative_image_path).resolve()
-        if not image_path.exists():
+        if not self._path_exists(image_path):
             raise RgbSourceError(
                 f"RGB dataset capture file does not exist: '{image_path}'"
             )
@@ -292,6 +295,7 @@ def build_manifest_replay_frame_source(
         config=config,
         entries=entries,
         manifest_path=manifest_path,
+        path_exists=exists,
         clock_ns=clock_ns,
     )
 

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py
@@ -146,6 +146,10 @@ class RgbFrameCaptureWriter:
             image_format=self._config.normalized_image_format,
         )
         image_path = self._output_dir / relative_image_path
+        if image_path.exists():
+            raise RgbSourceError(
+                f"RGB capture image already exists: '{image_path}'"
+            )
         self._image_writer(
             image_path,
             frame.image_bgr,
@@ -235,7 +239,7 @@ class ManifestReplayFrameSource:
                 source_type=metadata.source_type,
                 source_name=metadata.source_name,
                 source_uri=metadata.source_uri,
-                frame_id=metadata.frame_id,
+                frame_id=self._config.frame_id,
                 frame_index=metadata.frame_index,
                 monotonic_timestamp_ns=self._timestamp_generator.normalize(
                     metadata.monotonic_timestamp_ns
@@ -273,6 +277,10 @@ def build_manifest_replay_frame_source(
         )
 
     entries = load_rgb_dataset_manifest(manifest_path)
+    if not entries:
+        raise RgbSourceError(
+            f"RGB dataset manifest has no capture entries: '{config.source_uri}'"
+        )
     for entry in entries:
         image_path = manifest_path.parent / entry.relative_image_path
         if not exists(image_path):

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py
@@ -14,7 +14,7 @@ CAP_PROP_POS_MSEC = 0
 CAP_PROP_POS_FRAMES = 1
 CAP_PROP_FPS = 5
 
-SUPPORTED_RGB_SOURCE_TYPES = {"camera", "video_file", "replay"}
+SUPPORTED_RGB_SOURCE_TYPES = {"camera", "video_file", "replay", "manifest_replay"}
 
 
 class RgbSourceError(RuntimeError):
@@ -35,6 +35,18 @@ class CaptureLike(Protocol):
         pass
 
     def set(self, prop_id: int, value: float) -> bool:
+        pass
+
+
+class RgbReadableSource(Protocol):
+    @property
+    def config(self) -> "RgbSourceConfig":
+        pass
+
+    def read(self) -> "RgbFrame | None":
+        pass
+
+    def close(self) -> None:
         pass
 
 
@@ -251,8 +263,17 @@ def build_rgb_frame_source(
     capture_factory: Callable[[int | str], CaptureLike] | None = None,
     path_exists: Callable[[Path], bool] | None = None,
     clock_ns: Callable[[], int] | None = None,
-) -> RgbFrameSource:
+) -> RgbReadableSource:
     """Build and validate an RGB source backed by OpenCV-style capture APIs."""
+
+    if config.normalized_source_type == "manifest_replay":
+        from .rgb_dataset import build_manifest_replay_frame_source
+
+        return build_manifest_replay_frame_source(
+            config,
+            path_exists=path_exists,
+            clock_ns=clock_ns,
+        )
 
     if config.normalized_source_type in {"video_file", "replay"}:
         exists = path_exists or Path.exists

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
@@ -200,10 +200,8 @@ class RgbIngestNode(Node):
             try:
                 self._capture_writer.capture(frame)
             except RgbSourceError as error:
-                self._source_exhausted = True
-                self._timer.cancel()
-                self.get_logger().error(f"RGB capture stopped: {error}")
-                return
+                self._capture_writer = None
+                self.get_logger().error(f"RGB capture disabled: {error}")
 
         self._image_publisher.publish(self._rgb_frame_to_image_message(frame))
         self._metadata_publisher.publish(String(data=_metadata_payload_json(frame)))

--- a/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Callable
 
 import numpy as np
@@ -13,9 +14,10 @@ from rclpy.parameter import Parameter
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
 
+from .rgb_dataset import RgbDatasetCaptureConfig, RgbFrameCaptureWriter
 from .rgb_ingest import (
     RgbFrame,
-    RgbFrameSource,
+    RgbReadableSource,
     RgbSourceConfig,
     RgbSourceError,
     build_rgb_frame_source,
@@ -29,11 +31,15 @@ class RgbIngestNode(Node):
         self,
         *,
         parameter_overrides: list[Parameter] | None = None,
-        source_factory: Callable[[RgbSourceConfig], RgbFrameSource] | None = None,
+        source_factory: Callable[[RgbSourceConfig], RgbReadableSource] | None = None,
+        capture_writer_factory: (
+            Callable[[RgbDatasetCaptureConfig], RgbFrameCaptureWriter] | None
+        ) = None,
     ) -> None:
         super().__init__("rgb_ingest", parameter_overrides=parameter_overrides)
 
         self._source_factory = source_factory or build_rgb_frame_source
+        self._capture_writer_factory = capture_writer_factory or RgbFrameCaptureWriter
         self._image_topic = str(
             self.declare_parameter("image_topic", "rgb/image_raw").value
         )
@@ -50,12 +56,28 @@ class RgbIngestNode(Node):
         self._loop_replay = bool(
             self.declare_parameter("loop_replay", False).value
         )
+        self._capture_enabled = bool(
+            self.declare_parameter("capture_enabled", False).value
+        )
+        self._capture_output_dir = str(
+            self.declare_parameter("capture_output_dir", "").value
+        )
+        self._capture_manifest_path = str(
+            self.declare_parameter("capture_manifest_path", "").value
+        )
+        self._capture_image_format = str(
+            self.declare_parameter("capture_image_format", "png").value
+        )
+        self._capture_reason = str(
+            self.declare_parameter("capture_reason", "continuous_capture").value
+        )
         self._ros_stamp_provider = lambda: self.get_clock().now().to_msg()
 
         if self._publish_rate_hz <= 0.0:
             raise RgbSourceError("publish_rate_hz must be > 0 for RGB ingest")
 
         self._source = self._source_factory(self._build_source_config())
+        self._capture_writer = self._build_capture_writer()
         self._image_publisher = self.create_publisher(Image, self._image_topic, 10)
         self._metadata_publisher = self.create_publisher(
             String, self._metadata_topic, 10
@@ -79,6 +101,29 @@ class RgbIngestNode(Node):
             loop_replay=self._loop_replay,
         )
 
+    def _build_capture_writer(self) -> RgbFrameCaptureWriter | None:
+        if not self._capture_enabled:
+            return None
+
+        output_dir = self._capture_output_dir.strip()
+        if not output_dir:
+            raise RgbSourceError(
+                "capture_output_dir must be configured when RGB capture is enabled"
+            )
+
+        manifest_path = self._capture_manifest_path.strip()
+        if not manifest_path:
+            manifest_path = str(Path(output_dir) / "manifest.jsonl")
+
+        return self._capture_writer_factory(
+            RgbDatasetCaptureConfig(
+                output_dir=output_dir,
+                manifest_path=manifest_path,
+                image_format=self._capture_image_format,
+                capture_reason=self._capture_reason,
+            )
+        )
+
     def _handle_param_update(self, params: list[Parameter]) -> SetParametersResult:
         updated_rate_hz = self._publish_rate_hz
 
@@ -95,6 +140,11 @@ class RgbIngestNode(Node):
                     "frame_id",
                     "source_name",
                     "loop_replay",
+                    "capture_enabled",
+                    "capture_output_dir",
+                    "capture_manifest_path",
+                    "capture_image_format",
+                    "capture_reason",
                 }:
                     return SetParametersResult(
                         successful=False,
@@ -145,6 +195,15 @@ class RgbIngestNode(Node):
                 f"RGB {self._source.config.normalized_source_type} source exhausted."
             )
             return
+
+        if self._capture_writer is not None:
+            try:
+                self._capture_writer.capture(frame)
+            except RgbSourceError as error:
+                self._source_exhausted = True
+                self._timer.cancel()
+                self.get_logger().error(f"RGB capture stopped: {error}")
+                return
 
         self._image_publisher.publish(self._rgb_frame_to_image_message(frame))
         self._metadata_publisher.publish(String(data=_metadata_payload_json(frame)))

--- a/software/edge/src/aeris_perception/config/halo_rgb_ingest.example.yaml
+++ b/software/edge/src/aeris_perception/config/halo_rgb_ingest.example.yaml
@@ -10,6 +10,11 @@ rgb_ingest:
     source_uri: "0"
     source_name: halo_front_camera
     loop_replay: false
+    capture_enabled: false
+    capture_output_dir: /absolute/path/to/halo-captures
+    capture_manifest_path: /absolute/path/to/halo-captures/manifest.jsonl
+    capture_image_format: png
+    capture_reason: continuous_capture
 
     # Swap to a local capture file by changing only the source parameters:
     # source_type: video_file
@@ -18,4 +23,9 @@ rgb_ingest:
     # Deterministic repeatable replay:
     # source_type: replay
     # source_uri: /absolute/path/to/halo-capture.mp4
+    # loop_replay: true
+    #
+    # Manifest-backed frame replay for repeatable evaluation:
+    # source_type: manifest_replay
+    # source_uri: /absolute/path/to/halo-captures/manifest.jsonl
     # loop_replay: true

--- a/software/edge/src/aeris_perception/config/perception_demo_rgb_ingest.yaml
+++ b/software/edge/src/aeris_perception/config/perception_demo_rgb_ingest.yaml
@@ -8,3 +8,8 @@ rgb_ingest:
     source_uri: "0"
     source_name: halo_front_camera
     loop_replay: false
+    capture_enabled: false
+    capture_output_dir: ""
+    capture_manifest_path: ""
+    capture_image_format: png
+    capture_reason: continuous_capture

--- a/software/edge/src/aeris_perception/test/test_rgb_dataset.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_dataset.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from aeris_perception.rgb_ingest import RgbFrame, RgbFrameMetadata, RgbSourceConfig
+
+
+def _sample_frame(fill: int, *, frame_index: int = 0) -> RgbFrame:
+    return RgbFrame(
+        image_bgr=np.full((3, 4, 3), fill, dtype=np.uint8),
+        metadata=RgbFrameMetadata(
+            source_type="camera",
+            source_name="halo_front_camera",
+            source_uri="0",
+            frame_id="halo_rgb_front",
+            frame_index=frame_index,
+            monotonic_timestamp_ns=1_000_000_000 + frame_index,
+            source_timestamp_ns=None,
+            replayed=False,
+        ),
+    )
+
+
+def test_capture_writer_saves_frame_and_manifest_entry(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+
+    output_dir = tmp_path / "capture"
+    manifest_path = output_dir / "manifest.jsonl"
+    writer = RgbFrameCaptureWriter(
+        RgbDatasetCaptureConfig(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            image_format="ppm",
+            capture_reason="continuous_capture",
+        )
+    )
+
+    saved_entry = writer.capture(_sample_frame(17))
+
+    assert saved_entry.capture_reason == "continuous_capture"
+    assert saved_entry.label is None
+    assert saved_entry.review is None
+    assert saved_entry.height == 3
+    assert saved_entry.width == 4
+    assert saved_entry.channels == 3
+
+    saved_image = output_dir / saved_entry.relative_image_path
+    assert saved_image.exists()
+
+    manifest_lines = manifest_path.read_text(encoding="utf-8").splitlines()
+    assert len(manifest_lines) == 1
+
+    manifest_record = json.loads(manifest_lines[0])
+    assert manifest_record["capture_reason"] == "continuous_capture"
+    assert manifest_record["label"] is None
+    assert manifest_record["review"] is None
+    assert manifest_record["height"] == 3
+    assert manifest_record["width"] == 4
+    assert manifest_record["channels"] == 3
+    assert manifest_record["metadata"]["frame_id"] == "halo_rgb_front"
+    assert manifest_record["metadata"]["source_name"] == "halo_front_camera"
+
+
+def test_capture_manifest_path_can_live_outside_output_dir(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+    from aeris_perception.rgb_ingest import build_rgb_frame_source
+
+    output_dir = tmp_path / "capture"
+    manifest_path = tmp_path / "manifests" / "halo.jsonl"
+    writer = RgbFrameCaptureWriter(
+        RgbDatasetCaptureConfig(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            image_format="ppm",
+            capture_reason="continuous_capture",
+        )
+    )
+    frame = _sample_frame(19)
+
+    saved_entry = writer.capture(frame)
+    replay_source = build_rgb_frame_source(
+        RgbSourceConfig(
+            source_type="manifest_replay",
+            source_uri=str(manifest_path),
+            frame_id="halo_rgb_front",
+        )
+    )
+    replayed = replay_source.read()
+
+    assert saved_entry.relative_image_path.startswith("../capture/frames/")
+    assert replayed is not None
+    assert np.array_equal(replayed.image_bgr, frame.image_bgr)
+
+
+def test_manifest_replay_rebuilds_frame_sequence(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+    from aeris_perception.rgb_ingest import build_rgb_frame_source
+
+    output_dir = tmp_path / "capture"
+    manifest_path = output_dir / "manifest.jsonl"
+    writer = RgbFrameCaptureWriter(
+        RgbDatasetCaptureConfig(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            image_format="ppm",
+            capture_reason="continuous_capture",
+        )
+    )
+    first_frame = _sample_frame(10, frame_index=0)
+    second_frame = _sample_frame(20, frame_index=1)
+    writer.capture(first_frame)
+    writer.capture(second_frame)
+
+    replay_source = build_rgb_frame_source(
+        RgbSourceConfig(
+            source_type="manifest_replay",
+            source_uri=str(manifest_path),
+            frame_id="halo_rgb_front",
+            loop_replay=False,
+        )
+    )
+
+    replayed_first = replay_source.read()
+    replayed_second = replay_source.read()
+    exhausted = replay_source.read()
+
+    assert replayed_first is not None
+    assert replayed_second is not None
+    assert np.array_equal(replayed_first.image_bgr, first_frame.image_bgr)
+    assert np.array_equal(replayed_second.image_bgr, second_frame.image_bgr)
+    assert replayed_first.metadata.frame_index == 0
+    assert replayed_second.metadata.frame_index == 1
+    assert replayed_first.metadata.replayed is True
+    assert replayed_second.metadata.replayed is True
+    assert exhausted is None
+
+
+def test_capture_writer_rejects_non_directory_output_path(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+    from aeris_perception.rgb_ingest import RgbSourceError
+
+    output_dir = tmp_path / "not_a_directory"
+    output_dir.write_text("halo", encoding="utf-8")
+
+    with pytest.raises(RgbSourceError, match="output directory"):
+        RgbFrameCaptureWriter(
+            RgbDatasetCaptureConfig(
+                output_dir=output_dir,
+                manifest_path=tmp_path / "manifest.jsonl",
+                image_format="ppm",
+                capture_reason="continuous_capture",
+            )
+        )
+
+
+def test_manifest_replay_rejects_missing_capture_file(tmp_path) -> None:
+    from aeris_perception.rgb_ingest import RgbSourceError, build_rgb_frame_source
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "manifest_version": 1,
+                "relative_image_path": "frames/missing.ppm",
+                "capture_reason": "continuous_capture",
+                "label": None,
+                "review": None,
+                "height": 3,
+                "width": 4,
+                "channels": 3,
+                "metadata": _sample_frame(5).metadata.to_dict(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RgbSourceError, match="capture file does not exist"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="manifest_replay",
+                source_uri=str(manifest_path),
+                frame_id="halo_rgb_front",
+            )
+        )
+
+
+def test_manifest_replay_rejects_malformed_manifest(tmp_path) -> None:
+    from aeris_perception.rgb_ingest import RgbSourceError, build_rgb_frame_source
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    manifest_path.write_text("{not-json}\n", encoding="utf-8")
+
+    with pytest.raises(RgbSourceError, match="Malformed RGB dataset manifest"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="manifest_replay",
+                source_uri=str(manifest_path),
+                frame_id="halo_rgb_front",
+            )
+        )

--- a/software/edge/src/aeris_perception/test/test_rgb_dataset.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_dataset.py
@@ -276,6 +276,70 @@ def test_manifest_replay_rejects_empty_manifest(tmp_path) -> None:
         )
 
 
+def test_manifest_replay_rejects_unsupported_manifest_version(tmp_path) -> None:
+    from aeris_perception.rgb_ingest import RgbSourceError, build_rgb_frame_source
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "manifest_version": 999,
+                "relative_image_path": "frames/frame.ppm",
+                "capture_reason": "continuous_capture",
+                "label": None,
+                "review": None,
+                "height": 3,
+                "width": 4,
+                "channels": 3,
+                "metadata": _sample_frame(5).metadata.to_dict(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RgbSourceError, match="Unsupported RGB dataset manifest"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="manifest_replay",
+                source_uri=str(manifest_path),
+                frame_id="halo_rgb_front",
+            )
+        )
+
+
+def test_manifest_replay_uses_injected_path_check_on_read(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        ManifestReplayFrameSource,
+        RgbDatasetManifestEntry,
+    )
+    from aeris_perception.rgb_ingest import RgbSourceError
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    entry = RgbDatasetManifestEntry(
+        relative_image_path="frames/frame.ppm",
+        capture_reason="continuous_capture",
+        metadata=_sample_frame(5).metadata,
+        height=3,
+        width=4,
+        channels=3,
+    )
+    source = ManifestReplayFrameSource(
+        config=RgbSourceConfig(
+            source_type="manifest_replay",
+            source_uri=str(manifest_path),
+            frame_id="halo_rgb_front",
+        ),
+        entries=[entry],
+        manifest_path=manifest_path,
+        path_exists=lambda _path: False,
+        image_reader=lambda _path: _sample_frame(7).image_bgr,
+    )
+
+    with pytest.raises(RgbSourceError, match="capture file does not exist"):
+        source.read()
+
+
 def test_manifest_replay_rejects_malformed_manifest(tmp_path) -> None:
     from aeris_perception.rgb_ingest import RgbSourceError, build_rgb_frame_source
 

--- a/software/edge/src/aeris_perception/test/test_rgb_dataset.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_dataset.py
@@ -142,9 +142,69 @@ def test_manifest_replay_rebuilds_frame_sequence(tmp_path) -> None:
     assert np.array_equal(replayed_second.image_bgr, second_frame.image_bgr)
     assert replayed_first.metadata.frame_index == 0
     assert replayed_second.metadata.frame_index == 1
+    assert replayed_first.metadata.frame_id == "halo_rgb_front"
     assert replayed_first.metadata.replayed is True
     assert replayed_second.metadata.replayed is True
     assert exhausted is None
+
+
+def test_manifest_replay_uses_configured_frame_id(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+    from aeris_perception.rgb_ingest import build_rgb_frame_source
+
+    output_dir = tmp_path / "capture"
+    manifest_path = output_dir / "manifest.jsonl"
+    writer = RgbFrameCaptureWriter(
+        RgbDatasetCaptureConfig(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            image_format="ppm",
+            capture_reason="continuous_capture",
+        )
+    )
+    writer.capture(_sample_frame(10, frame_index=0))
+
+    replay_source = build_rgb_frame_source(
+        RgbSourceConfig(
+            source_type="manifest_replay",
+            source_uri=str(manifest_path),
+            frame_id="halo_replay_frame",
+            loop_replay=False,
+        )
+    )
+
+    replayed = replay_source.read()
+
+    assert replayed is not None
+    assert replayed.metadata.frame_id == "halo_replay_frame"
+
+
+def test_capture_writer_rejects_existing_capture_path(tmp_path) -> None:
+    from aeris_perception.rgb_dataset import (
+        RgbDatasetCaptureConfig,
+        RgbFrameCaptureWriter,
+    )
+    from aeris_perception.rgb_ingest import RgbSourceError
+
+    output_dir = tmp_path / "capture"
+    manifest_path = output_dir / "manifest.jsonl"
+    writer = RgbFrameCaptureWriter(
+        RgbDatasetCaptureConfig(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            image_format="ppm",
+            capture_reason="continuous_capture",
+        )
+    )
+    frame = _sample_frame(10, frame_index=0)
+
+    writer.capture(frame)
+
+    with pytest.raises(RgbSourceError, match="already exists"):
+        writer.capture(frame)
 
 
 def test_capture_writer_rejects_non_directory_output_path(tmp_path) -> None:
@@ -191,6 +251,22 @@ def test_manifest_replay_rejects_missing_capture_file(tmp_path) -> None:
     )
 
     with pytest.raises(RgbSourceError, match="capture file does not exist"):
+        build_rgb_frame_source(
+            RgbSourceConfig(
+                source_type="manifest_replay",
+                source_uri=str(manifest_path),
+                frame_id="halo_rgb_front",
+            )
+        )
+
+
+def test_manifest_replay_rejects_empty_manifest(tmp_path) -> None:
+    from aeris_perception.rgb_ingest import RgbSourceError, build_rgb_frame_source
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    manifest_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(RgbSourceError, match="no capture entries"):
         build_rgb_frame_source(
             RgbSourceConfig(
                 source_type="manifest_replay",

--- a/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
+++ b/software/edge/src/aeris_perception/test/test_rgb_ingest_node.py
@@ -33,6 +33,17 @@ class _FakeTimer:
         self.cancel_calls += 1
 
 
+class _RecorderCaptureWriter:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.frames: list[RgbFrame] = []
+
+    def capture(self, frame: RgbFrame) -> None:
+        if self.fail:
+            raise RgbSourceError("capture failed")
+        self.frames.append(frame)
+
+
 class _StaticSource:
     def __init__(self, frames: list[RgbFrame]) -> None:
         self._frames = list(frames)
@@ -46,6 +57,22 @@ class _StaticSource:
 
     def close(self) -> None:
         self.closed = True
+
+
+def _sample_rgb_frame(*, frame_id: str = "halo_rgb") -> RgbFrame:
+    return RgbFrame(
+        image_bgr=np.full((2, 4, 3), 9, dtype=np.uint8),
+        metadata=RgbFrameMetadata(
+            source_type="camera",
+            source_name="halo_cam",
+            source_uri="0",
+            frame_id=frame_id,
+            frame_index=0,
+            monotonic_timestamp_ns=4_000,
+            source_timestamp_ns=None,
+            replayed=False,
+        ),
+    )
 
 
 class _ErrorSource:
@@ -145,19 +172,7 @@ def test_rgb_ingest_node_keeps_camera_timer_running_after_transient_miss() -> No
     source = _TransientCameraSource(
         [
             None,
-            RgbFrame(
-                image_bgr=np.full((2, 4, 3), 9, dtype=np.uint8),
-                metadata=RgbFrameMetadata(
-                    source_type="camera",
-                    source_name="halo_cam",
-                    source_uri="0",
-                    frame_id="halo_rgb",
-                    frame_index=0,
-                    monotonic_timestamp_ns=4_000,
-                    source_timestamp_ns=None,
-                    replayed=False,
-                ),
-            ),
+            _sample_rgb_frame(),
         ]
     )
     node = RgbIngestNode(
@@ -189,6 +204,79 @@ def test_rgb_ingest_node_keeps_camera_timer_running_after_transient_miss() -> No
         assert len(metadata_recorder.messages) == 1
         assert node._source_exhausted is False
         assert fake_timer.cancel_calls == 0
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def test_rgb_ingest_node_capture_writer_receives_published_frame() -> None:
+    rclpy.init()
+    frame = _sample_rgb_frame()
+    source = _StaticSource([frame])
+    capture_writer = _RecorderCaptureWriter()
+    node = RgbIngestNode(
+        parameter_overrides=[
+            Parameter("source_type", value="camera"),
+            Parameter("source_uri", value="0"),
+            Parameter("frame_id", value="halo_rgb"),
+            Parameter("capture_enabled", value=True),
+            Parameter("capture_output_dir", value="/tmp/halo-capture"),
+        ],
+        source_factory=lambda _config: source,
+        capture_writer_factory=lambda _config: capture_writer,
+    )
+    image_recorder = _RecorderPublisher()
+    metadata_recorder = _RecorderPublisher()
+
+    try:
+        node._timer.cancel()
+        node._image_publisher = image_recorder
+        node._metadata_publisher = metadata_recorder
+        node._ros_stamp_provider = lambda: Time(sec=3, nanosec=14)
+
+        node._publish_next_frame()
+
+        assert capture_writer.frames == [frame]
+        assert len(image_recorder.messages) == 1
+        assert len(metadata_recorder.messages) == 1
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def test_rgb_ingest_node_capture_failure_does_not_stop_publishing() -> None:
+    rclpy.init()
+    source = _StaticSource([_sample_rgb_frame()])
+    capture_writer = _RecorderCaptureWriter(fail=True)
+    node = RgbIngestNode(
+        parameter_overrides=[
+            Parameter("source_type", value="camera"),
+            Parameter("source_uri", value="0"),
+            Parameter("frame_id", value="halo_rgb"),
+            Parameter("capture_enabled", value=True),
+            Parameter("capture_output_dir", value="/tmp/halo-capture"),
+        ],
+        source_factory=lambda _config: source,
+        capture_writer_factory=lambda _config: capture_writer,
+    )
+    image_recorder = _RecorderPublisher()
+    metadata_recorder = _RecorderPublisher()
+    fake_timer = _FakeTimer()
+
+    try:
+        node._timer.cancel()
+        node._timer = fake_timer
+        node._image_publisher = image_recorder
+        node._metadata_publisher = metadata_recorder
+        node._ros_stamp_provider = lambda: Time(sec=3, nanosec=14)
+
+        node._publish_next_frame()
+
+        assert node._source_exhausted is False
+        assert node._capture_writer is None
+        assert fake_timer.cancel_calls == 0
+        assert len(image_recorder.messages) == 1
+        assert len(metadata_recorder.messages) == 1
     finally:
         node.destroy_node()
         rclpy.shutdown()


### PR DESCRIPTION
## Summary
- Add RGB frame capture that writes ordinary image files plus JSONL manifest entries.
- Add manifest-backed replay as a configurable RGB source for repeatable evaluation runs.
- Extend RGB ingest config with capture settings and add tests for manifest write/read/replay behavior.

## Why
Recognition work needs a repeatable data surface, not one-off screenshots. This gives Halo a clean way to capture what the RGB ingest path saw and replay the same sequence for evaluation.

Closes #119

## Tests
- `PYTHONPATH=software/edge/src/aeris_perception:software/edge/src/aeris_msgs /tmp/aeris-halo-test/bin/python -m pytest software/edge/src/aeris_perception/test software/edge/src/aeris_msgs/test -q`
- `python3 -m compileall software/edge/src/aeris_perception/aeris_perception`
- `git diff --cached --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds manifest-backed RGB frame capture (`RgbFrameCaptureWriter`) and a `ManifestReplayFrameSource` to the Halo perception stack, giving the recognition pipeline a repeatable data surface for evaluation runs. The node gains opt-in capture parameters, and capture failures are correctly isolated from the primary publish loop.

- **`rgb_dataset.py`**: New module handles writing images + JSONL manifest entries and replaying them via `ManifestReplayFrameSource`; includes a zero-dependency PPM codec for test environments without OpenCV.
- **`rgb_ingest.py` / `rgb_ingest_node.py`**: `build_rgb_frame_source` is extended with a `manifest_replay` dispatch path; the node wires up the optional `RgbFrameCaptureWriter` and correctly degrades capture-only on I/O errors without stopping the publishers.
- **Tests**: New test suite covers round-trip capture/replay, injected-path-check behaviour, version rejection, empty manifest, and the capture-failure-does-not-stop-publishing contract.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the PPM dimension guard; all other paths are well-tested and the capture-failure isolation fix is correct.

The only concrete defect is in `_read_ppm`: after the header-parsing `try/except ValueError` block, a PPM file with negative width or height passes the `expected_size` byte-count check (since the product of two negatives is positive) but then causes `np.reshape` to raise a bare `ValueError`. That exception escapes the `except RgbSourceError` guard in `_publish_next_frame`, bypassing the node's normal source-exhausted shutdown path. Everything else — the capture/replay logic, the node wiring, the `path_exists` injection fix, and the capture-failure degradation — looks correct.

software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py — specifically the `_read_ppm` function around the `reshape` call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py | New file implementing frame capture (JSONL manifest + image files) and ManifestReplayFrameSource. Logic is solid overall; one bug: _read_ppm does not guard against non-positive dimensions before reshape, allowing a ValueError to escape the RgbSourceError boundary. |
| software/edge/src/aeris_perception/aeris_perception/rgb_ingest.py | Adds RgbReadableSource protocol and manifest_replay source type dispatch; existing paths are unchanged and new dispatch is clean. |
| software/edge/src/aeris_perception/aeris_perception/rgb_ingest_node.py | Adds capture_writer lifecycle to the node; capture failures now degrade only the capture path and leave the primary publish loop intact. Parameters are correctly gated against live updates. |
| software/edge/src/aeris_perception/test/test_rgb_dataset.py | Good coverage of write/read round-trips, path-outside-output-dir layout, per-read injected path_exists, version rejection, empty manifest, and malformed JSON. |
| software/edge/src/aeris_perception/test/test_rgb_ingest_node.py | New tests verify capture writer receives frames and that capture failure does not stop publishing; existing test refactored to use _sample_rgb_frame helper. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer
    participant RgbIngestNode
    participant FrameSource
    participant CaptureWriter
    participant Publishers

    Timer->>RgbIngestNode: _publish_next_frame()
    RgbIngestNode->>FrameSource: read()
    alt manifest_replay source
        FrameSource->>FrameSource: _resolve_image_path(entry)
        FrameSource->>FrameSource: _read_image_file(path)
    end
    FrameSource-->>RgbIngestNode: "RgbFrame | None"

    alt frame is None
        RgbIngestNode->>Timer: cancel() [source exhausted]
    else frame available
        opt capture_writer is not None
            RgbIngestNode->>CaptureWriter: capture(frame)
            alt capture fails (RgbSourceError)
                RgbIngestNode->>RgbIngestNode: "_capture_writer = None"
            end
        end
        RgbIngestNode->>Publishers: publish image + metadata
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/edge/src/aeris_perception/aeris_perception/rgb_dataset.py:417-426
**Uncaught `ValueError` from `reshape` when PPM header has negative dimensions**

After the `try/except ValueError` block (which only covers header parsing), the `reshape` call on line 425 can raise a `ValueError` that is never caught. If `width` and `height` are both negative (e.g., `-1`), their product is positive, so `expected_size` passes the `len(payload)` check, but `np.frombuffer(...).reshape((-1, -1, 3))` raises `ValueError`. In `_publish_next_frame`, `self._source.read()` is wrapped only with `except RgbSourceError`, so this `ValueError` escapes the timer callback entirely — bypassing the normal source-exhausted shutdown path and potentially causing confusing ROS2 timer errors.

```suggestion
    if max_value != 255:
        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")

    if width <= 0 or height <= 0:
        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")

    expected_size = width * height * 3
    payload = parts[3]
    if len(payload) != expected_size:
        raise RgbSourceError(f"Unable to read RGB capture image '{path}'")

    image_rgb = np.frombuffer(payload, dtype=np.uint8).reshape((height, width, 3))
    return image_rgb[:, :, ::-1].copy()
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Tighten Halo manifest replay validation"](https://github.com/aeris-drones/aeris/commit/5c93696f7b30e9d3401e8da2636d28dcf1754c45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34486920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->