### PR TITLE
Define Halo confidence event contract

### DIFF
--- a/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
@@ -1,0 +1,387 @@
+"""Canonical Halo confidence event contract for RGB recognition output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import TYPE_CHECKING, Any, Mapping
+
+if TYPE_CHECKING:
+    from .rgb_recognition_baseline import RecognitionCandidate
+
+
+_HIGH_CONFIDENCE_MIN = 0.85
+_MEDIUM_CONFIDENCE_MIN = 0.60
+_LOW_CONFIDENCE_MIN = 0.30
+
+
+@dataclass(frozen=True)
+class HaloConfidenceEvent:
+    """Stable event payload shared between Halo perception and the viewer."""
+
+    event_id: str
+    source_id: str
+    source_name: str
+    source_uri: str | None
+    frame_id: str
+    frame_index: int
+    timestamp_ns: int
+    label: str
+    detection_type: str
+    confidence: float
+    confidence_level: str
+    recognition: dict[str, Any]
+    region: dict[str, int] | None = None
+    location_hint: str | dict[str, Any] | None = None
+    evidence_ref: str | None = None
+    evidence_uri: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "event_id": self.event_id,
+            "source_id": self.source_id,
+            "source_name": self.source_name,
+            "frame_id": self.frame_id,
+            "frame_index": self.frame_index,
+            "timestamp_ns": self.timestamp_ns,
+            "label": self.label,
+            "detection_type": self.detection_type,
+            "confidence": _round_float(self.confidence),
+            "confidence_level": self.confidence_level,
+            "recognition": _serialize_recognition(self.recognition),
+        }
+        if self.source_uri is not None:
+            payload["source_uri"] = self.source_uri
+        if self.region is not None:
+            payload["region"] = dict(self.region)
+        if self.location_hint is not None:
+            payload["location_hint"] = _serialize_location_hint(self.location_hint)
+        if self.evidence_ref is not None:
+            payload["evidence_ref"] = self.evidence_ref
+        if self.evidence_uri is not None:
+            payload["evidence_uri"] = self.evidence_uri
+        return payload
+
+
+def halo_confidence_event_from_candidate(
+    candidate: RecognitionCandidate,
+    *,
+    location_hint: str | Mapping[str, Any] | None = None,
+    evidence_ref: str | None = None,
+    evidence_uri: str | None = None,
+) -> HaloConfidenceEvent:
+    """Convert a baseline recognition candidate into the canonical Halo event."""
+
+    source_name = _require_non_empty_string(candidate.source_name, "source_name")
+    source_id = f"{_require_non_empty_string(candidate.source_type, 'source_type')}:{source_name}"
+    detection_type = _require_non_empty_string(candidate.detection_type, "detection_type")
+    frame_id = _require_non_empty_string(candidate.frame_id, "frame_id")
+    region = _normalize_region(candidate.region)
+    confidence = _clamp01(candidate.confidence)
+
+    return HaloConfidenceEvent(
+        event_id=_build_event_id(
+            source_id=source_id,
+            frame_id=frame_id,
+            frame_index=int(candidate.frame_index),
+            timestamp_ns=int(candidate.monotonic_timestamp_ns),
+            detection_type=detection_type,
+            region=region,
+        ),
+        source_id=source_id,
+        source_name=source_name,
+        source_uri=_optional_string(candidate.source_uri),
+        frame_id=frame_id,
+        frame_index=int(candidate.frame_index),
+        timestamp_ns=int(candidate.monotonic_timestamp_ns),
+        label=_humanize_detection_type(detection_type),
+        detection_type=detection_type,
+        confidence=confidence,
+        confidence_level=confidence_level_for_score(confidence),
+        region=region,
+        location_hint=_normalize_location_hint(location_hint),
+        evidence_ref=_optional_string(evidence_ref),
+        evidence_uri=_optional_string(evidence_uri),
+        recognition=_normalize_recognition(
+            {
+                "baseline_name": candidate.baseline_name,
+                "baseline_version": candidate.baseline_version,
+                "latency_ms": candidate.latency_ms,
+                "source_timestamp_ns": candidate.source_timestamp_ns,
+                "confidence_components": candidate.confidence_components,
+            }
+        ),
+    )
+
+
+def serialize_halo_confidence_event(event: HaloConfidenceEvent) -> dict[str, Any]:
+    """Serialize a Halo confidence event into a JSON-safe dictionary."""
+
+    return event.to_dict()
+
+
+def parse_halo_confidence_event(payload: Mapping[str, Any]) -> HaloConfidenceEvent:
+    """Parse and validate an inbound Halo confidence event payload."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("Halo confidence event payload must be a mapping")
+
+    source_id = _require_mapping_string(payload, "source_id")
+    source_name = _require_mapping_string(payload, "source_name")
+    frame_id = _require_mapping_string(payload, "frame_id")
+    frame_index = _require_mapping_int(payload, "frame_index", minimum=0)
+    timestamp_ns = _require_mapping_int(payload, "timestamp_ns", minimum=0)
+    detection_type = _optional_string(payload.get("detection_type"))
+    label = _optional_string(payload.get("label"))
+    if detection_type is None and label is None:
+        raise ValueError("Halo confidence event requires detection_type or label")
+    resolved_detection_type = detection_type or _slugify_label(label or "")
+    resolved_label = label or _humanize_detection_type(resolved_detection_type)
+    confidence = _clamp01(_require_mapping_float(payload, "confidence"))
+    recognition = _normalize_recognition(payload.get("recognition"))
+    region = _normalize_region(payload.get("region"))
+
+    return HaloConfidenceEvent(
+        event_id=_optional_string(payload.get("event_id"))
+        or _build_event_id(
+            source_id=source_id,
+            frame_id=frame_id,
+            frame_index=frame_index,
+            timestamp_ns=timestamp_ns,
+            detection_type=resolved_detection_type,
+            region=region,
+        ),
+        source_id=source_id,
+        source_name=source_name,
+        source_uri=_optional_string(payload.get("source_uri")),
+        frame_id=frame_id,
+        frame_index=frame_index,
+        timestamp_ns=timestamp_ns,
+        label=resolved_label,
+        detection_type=resolved_detection_type,
+        confidence=confidence,
+        confidence_level=_normalize_confidence_level(
+            payload.get("confidence_level"), confidence
+        ),
+        region=region,
+        location_hint=_normalize_location_hint(payload.get("location_hint")),
+        evidence_ref=_optional_string(payload.get("evidence_ref")),
+        evidence_uri=_optional_string(payload.get("evidence_uri")),
+        recognition=recognition,
+    )
+
+
+def confidence_level_for_score(confidence: float) -> str:
+    """Map a bounded confidence score onto the Halo display tiers."""
+
+    score = _clamp01(confidence)
+    if score >= _HIGH_CONFIDENCE_MIN:
+        return "HIGH"
+    if score >= _MEDIUM_CONFIDENCE_MIN:
+        return "MEDIUM"
+    if score >= _LOW_CONFIDENCE_MIN:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _build_event_id(
+    *,
+    source_id: str,
+    frame_id: str,
+    frame_index: int,
+    timestamp_ns: int,
+    detection_type: str,
+    region: Mapping[str, int] | None,
+) -> str:
+    region_key = (
+        f"{region['x']}:{region['y']}:{region['width']}:{region['height']}"
+        if region is not None
+        else "none"
+    )
+    return (
+        "halo-confidence-"
+        f"{source_id}:{frame_id}:{frame_index}:{timestamp_ns}:{detection_type}:{region_key}"
+    )
+
+
+def _normalize_confidence_level(raw_level: Any, confidence: float) -> str:
+    level = _optional_string(raw_level)
+    if level is None:
+        return confidence_level_for_score(confidence)
+    normalized = level.upper()
+    if normalized in {"HIGH", "MEDIUM", "LOW", "UNKNOWN"}:
+        return normalized
+    return confidence_level_for_score(confidence)
+
+
+def _normalize_recognition(raw_value: Any) -> dict[str, Any]:
+    if not isinstance(raw_value, Mapping):
+        raise ValueError("recognition must be an object")
+
+    baseline_name = _require_non_empty_string(raw_value.get("baseline_name"), "baseline_name")
+    baseline_version = _require_non_empty_string(
+        raw_value.get("baseline_version"), "baseline_version"
+    )
+    payload: dict[str, Any] = {
+        "baseline_name": baseline_name,
+        "baseline_version": baseline_version,
+    }
+
+    latency_ms = raw_value.get("latency_ms")
+    if latency_ms is not None:
+        payload["latency_ms"] = _round_float(_require_finite_float(latency_ms, "latency_ms"))
+
+    source_timestamp_ns = raw_value.get("source_timestamp_ns")
+    if source_timestamp_ns is not None:
+        payload["source_timestamp_ns"] = _require_int(
+            source_timestamp_ns, "source_timestamp_ns", minimum=0
+        )
+
+    components = raw_value.get("confidence_components")
+    if components is not None:
+        if not isinstance(components, Mapping):
+            raise ValueError("confidence_components must be an object")
+        normalized_components: dict[str, float] = {}
+        for key, value in components.items():
+            component_name = _require_non_empty_string(key, "confidence_components key")
+            normalized_components[component_name] = _round_float(
+                _clamp01(_require_finite_float(value, component_name))
+            )
+        payload["confidence_components"] = normalized_components
+
+    return payload
+
+
+def _serialize_recognition(recognition: Mapping[str, Any]) -> dict[str, Any]:
+    payload = {
+        "baseline_name": recognition["baseline_name"],
+        "baseline_version": recognition["baseline_version"],
+    }
+    if "latency_ms" in recognition:
+        payload["latency_ms"] = _round_float(float(recognition["latency_ms"]))
+    if "source_timestamp_ns" in recognition:
+        payload["source_timestamp_ns"] = int(recognition["source_timestamp_ns"])
+    if "confidence_components" in recognition:
+        payload["confidence_components"] = {
+            str(key): _round_float(float(value))
+            for key, value in recognition["confidence_components"].items()
+        }
+    return payload
+
+
+def _normalize_region(raw_value: Any) -> dict[str, int] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, Mapping):
+        raise ValueError("region must be an object")
+
+    region = {
+        axis: _require_int(raw_value.get(axis), axis, minimum=0)
+        for axis in ("x", "y")
+    }
+    for dimension in ("width", "height"):
+        region[dimension] = _require_int(raw_value.get(dimension), dimension, minimum=1)
+    return region
+
+
+def _normalize_location_hint(raw_value: Any) -> str | dict[str, Any] | None:
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        return _require_non_empty_string(raw_value, "location_hint")
+    if not isinstance(raw_value, Mapping):
+        raise ValueError("location_hint must be a string or object")
+
+    payload: dict[str, Any] = {}
+    label = raw_value.get("label")
+    if label is not None:
+        payload["label"] = _require_non_empty_string(label, "location_hint.label")
+    for axis in ("x", "y", "z"):
+        axis_value = raw_value.get(axis)
+        if axis_value is None:
+            continue
+        payload[axis] = _require_finite_float(axis_value, f"location_hint.{axis}")
+    if not payload:
+        raise ValueError("location_hint must include a label or coordinates")
+    return payload
+
+
+def _serialize_location_hint(location_hint: str | Mapping[str, Any]) -> str | dict[str, Any]:
+    if isinstance(location_hint, str):
+        return location_hint
+    payload: dict[str, Any] = {}
+    if "label" in location_hint:
+        payload["label"] = str(location_hint["label"])
+    for axis in ("x", "y", "z"):
+        if axis in location_hint:
+            payload[axis] = float(location_hint[axis])
+    return payload
+
+
+def _slugify_label(label: str) -> str:
+    normalized = "_".join(label.strip().lower().split())
+    return _require_non_empty_string(normalized, "label")
+
+
+def _humanize_detection_type(detection_type: str) -> str:
+    parts = [segment for segment in detection_type.strip().split("_") if segment]
+    if not parts:
+        raise ValueError("detection_type must not be empty")
+    return " ".join(segment.capitalize() for segment in parts)
+
+
+def _require_mapping_string(payload: Mapping[str, Any], key: str) -> str:
+    return _require_non_empty_string(payload.get(key), key)
+
+
+def _require_mapping_int(payload: Mapping[str, Any], key: str, *, minimum: int) -> int:
+    return _require_int(payload.get(key), key, minimum=minimum)
+
+
+def _require_mapping_float(payload: Mapping[str, Any], key: str) -> float:
+    return _require_finite_float(payload.get(key), key)
+
+
+def _require_non_empty_string(raw_value: Any, field_name: str) -> str:
+    if not isinstance(raw_value, str) or raw_value.strip() == "":
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return raw_value.strip()
+
+
+def _optional_string(raw_value: Any) -> str | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, str):
+        raise ValueError("optional string field must be a string when provided")
+    stripped = raw_value.strip()
+    return stripped or None
+
+
+def _require_int(raw_value: Any, field_name: str, *, minimum: int) -> int:
+    if isinstance(raw_value, bool):
+        raise ValueError(f"{field_name} must be an integer")
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if value < minimum:
+        raise ValueError(f"{field_name} must be >= {minimum}")
+    return value
+
+
+def _require_finite_float(raw_value: Any, field_name: str) -> float:
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be numeric") from exc
+    if not math.isfinite(value):
+        raise ValueError(f"{field_name} must be numeric")
+    return value
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _round_float(value: float) -> float:
+    return round(float(value), 6)

--- a/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
+import re
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 _HIGH_CONFIDENCE_MIN = 0.85
 _MEDIUM_CONFIDENCE_MIN = 0.60
 _LOW_CONFIDENCE_MIN = 0.30
+_INTEGER_PATTERN = re.compile(r"^[+-]?\d+$")
 
 
 @dataclass(frozen=True)
@@ -43,7 +45,7 @@ class HaloConfidenceEvent:
             "source_name": self.source_name,
             "frame_id": self.frame_id,
             "frame_index": self.frame_index,
-            "timestamp_ns": self.timestamp_ns,
+            "timestamp_ns": str(self.timestamp_ns),
             "label": self.label,
             "detection_type": self.detection_type,
             "confidence": _round_float(self.confidence),
@@ -260,7 +262,7 @@ def _serialize_recognition(recognition: Mapping[str, Any]) -> dict[str, Any]:
     if "latency_ms" in recognition:
         payload["latency_ms"] = _round_float(float(recognition["latency_ms"]))
     if "source_timestamp_ns" in recognition:
-        payload["source_timestamp_ns"] = int(recognition["source_timestamp_ns"])
+        payload["source_timestamp_ns"] = str(recognition["source_timestamp_ns"])
     if "confidence_components" in recognition:
         payload["confidence_components"] = {
             str(key): _round_float(float(value))
@@ -362,15 +364,11 @@ def _require_int(raw_value: Any, field_name: str, *, minimum: int) -> int:
         raise ValueError(f"{field_name} must be an integer")
     if isinstance(raw_value, int):
         value = raw_value
-    elif isinstance(raw_value, float):
-        if not math.isfinite(raw_value) or not raw_value.is_integer():
-            raise ValueError(f"{field_name} must be an integer")
-        value = int(raw_value)
     elif isinstance(raw_value, str):
-        try:
-            value = int(raw_value)
-        except ValueError as exc:
-            raise ValueError(f"{field_name} must be an integer") from exc
+        stripped = raw_value.strip()
+        if not _INTEGER_PATTERN.fullmatch(stripped):
+            raise ValueError(f"{field_name} must be an integer")
+        value = int(stripped)
     else:
         raise ValueError(f"{field_name} must be an integer")
 
@@ -380,6 +378,8 @@ def _require_int(raw_value: Any, field_name: str, *, minimum: int) -> int:
 
 
 def _require_finite_float(raw_value: Any, field_name: str) -> float:
+    if isinstance(raw_value, bool):
+        raise ValueError(f"{field_name} must be numeric")
     try:
         value = float(raw_value)
     except (TypeError, ValueError) as exc:

--- a/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
@@ -90,7 +90,7 @@ def halo_confidence_event_from_candidate(
         ),
         source_id=source_id,
         source_name=source_name,
-        source_uri=_optional_string(candidate.source_uri),
+        source_uri=_optional_string(candidate.source_uri, "source_uri"),
         frame_id=frame_id,
         frame_index=int(candidate.frame_index),
         timestamp_ns=int(candidate.monotonic_timestamp_ns),
@@ -100,8 +100,8 @@ def halo_confidence_event_from_candidate(
         confidence_level=confidence_level_for_score(confidence),
         region=region,
         location_hint=_normalize_location_hint(location_hint),
-        evidence_ref=_optional_string(evidence_ref),
-        evidence_uri=_optional_string(evidence_uri),
+        evidence_ref=_optional_string(evidence_ref, "evidence_ref"),
+        evidence_uri=_optional_string(evidence_uri, "evidence_uri"),
         recognition=_normalize_recognition(
             {
                 "baseline_name": candidate.baseline_name,
@@ -131,8 +131,8 @@ def parse_halo_confidence_event(payload: Mapping[str, Any]) -> HaloConfidenceEve
     frame_id = _require_mapping_string(payload, "frame_id")
     frame_index = _require_mapping_int(payload, "frame_index", minimum=0)
     timestamp_ns = _require_mapping_int(payload, "timestamp_ns", minimum=0)
-    detection_type = _optional_string(payload.get("detection_type"))
-    label = _optional_string(payload.get("label"))
+    detection_type = _optional_string(payload.get("detection_type"), "detection_type")
+    label = _optional_string(payload.get("label"), "label")
     if detection_type is None and label is None:
         raise ValueError("Halo confidence event requires detection_type or label")
     resolved_detection_type = detection_type or _slugify_label(label or "")
@@ -142,7 +142,7 @@ def parse_halo_confidence_event(payload: Mapping[str, Any]) -> HaloConfidenceEve
     region = _normalize_region(payload.get("region"))
 
     return HaloConfidenceEvent(
-        event_id=_optional_string(payload.get("event_id"))
+        event_id=_optional_string(payload.get("event_id"), "event_id")
         or _build_event_id(
             source_id=source_id,
             frame_id=frame_id,
@@ -153,7 +153,7 @@ def parse_halo_confidence_event(payload: Mapping[str, Any]) -> HaloConfidenceEve
         ),
         source_id=source_id,
         source_name=source_name,
-        source_uri=_optional_string(payload.get("source_uri")),
+        source_uri=_optional_string(payload.get("source_uri"), "source_uri"),
         frame_id=frame_id,
         frame_index=frame_index,
         timestamp_ns=timestamp_ns,
@@ -165,8 +165,8 @@ def parse_halo_confidence_event(payload: Mapping[str, Any]) -> HaloConfidenceEve
         ),
         region=region,
         location_hint=_normalize_location_hint(payload.get("location_hint")),
-        evidence_ref=_optional_string(payload.get("evidence_ref")),
-        evidence_uri=_optional_string(payload.get("evidence_uri")),
+        evidence_ref=_optional_string(payload.get("evidence_ref"), "evidence_ref"),
+        evidence_uri=_optional_string(payload.get("evidence_uri"), "evidence_uri"),
         recognition=recognition,
     )
 
@@ -205,7 +205,7 @@ def _build_event_id(
 
 
 def _normalize_confidence_level(raw_level: Any, confidence: float) -> str:
-    level = _optional_string(raw_level)
+    level = _optional_string(raw_level, "confidence_level")
     if level is None:
         return confidence_level_for_score(confidence)
     normalized = level.upper()
@@ -348,11 +348,11 @@ def _require_non_empty_string(raw_value: Any, field_name: str) -> str:
     return raw_value.strip()
 
 
-def _optional_string(raw_value: Any) -> str | None:
+def _optional_string(raw_value: Any, field_name: str) -> str | None:
     if raw_value is None:
         return None
     if not isinstance(raw_value, str):
-        raise ValueError("optional string field must be a string when provided")
+        raise ValueError(f"{field_name} must be a string when provided")
     stripped = raw_value.strip()
     return stripped or None
 

--- a/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py
@@ -360,10 +360,20 @@ def _optional_string(raw_value: Any, field_name: str) -> str | None:
 def _require_int(raw_value: Any, field_name: str, *, minimum: int) -> int:
     if isinstance(raw_value, bool):
         raise ValueError(f"{field_name} must be an integer")
-    try:
+    if isinstance(raw_value, int):
+        value = raw_value
+    elif isinstance(raw_value, float):
+        if not math.isfinite(raw_value) or not raw_value.is_integer():
+            raise ValueError(f"{field_name} must be an integer")
         value = int(raw_value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{field_name} must be an integer") from exc
+    elif isinstance(raw_value, str):
+        try:
+            value = int(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be an integer") from exc
+    else:
+        raise ValueError(f"{field_name} must be an integer")
+
     if value < minimum:
         raise ValueError(f"{field_name} must be >= {minimum}")
     return value

--- a/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
@@ -92,7 +92,7 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
         "source_uri": "rtsp://halo/front",
         "frame_id": "halo_rgb_front",
         "frame_index": 21,
-        "timestamp_ns": 999_000_321,
+        "timestamp_ns": "999000321",
         "label": "Possible Survivor",
         "detection_type": "candidate_human_presence",
         "confidence": 0.88,
@@ -104,6 +104,7 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
         "recognition": {
             "baseline_name": "halo_rgb_region_baseline",
             "baseline_version": "0.1.0",
+            "source_timestamp_ns": "998000321",
             "confidence_components": {"brightness": 0.91},
         },
     }
@@ -194,6 +195,22 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
                 "source_id": "camera:halo_front_camera",
                 "source_name": "halo_front_camera",
                 "frame_id": "halo_rgb_front",
+                "frame_index": "1.0",
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "frame_index",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
                 "frame_index": 1,
                 "timestamp_ns": 10.2,
                 "detection_type": "candidate_human_presence",
@@ -221,6 +238,22 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
                 },
             },
             "x",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": True,
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "confidence",
         ),
     ],
 )

--- a/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
@@ -173,6 +173,55 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
             },
             "source_uri",
         ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1.9,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "frame_index",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10.2,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "timestamp_ns",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "region": {"x": 1.4, "y": 2, "width": 3, "height": 4},
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "x",
+        ),
     ],
 )
 def test_parse_halo_confidence_event_rejects_invalid_payloads(

--- a/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
@@ -156,6 +156,23 @@ def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> N
             },
             "width",
         ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "source_uri": 123,
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "source_uri",
+        ),
     ],
 )
 def test_parse_halo_confidence_event_rejects_invalid_payloads(

--- a/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
+++ b/software/edge/src/aeris_perception/test/test_halo_confidence_event.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aeris_perception.halo_confidence_event import (
+    halo_confidence_event_from_candidate,
+    parse_halo_confidence_event,
+)
+
+
+def _candidate(**overrides: object) -> SimpleNamespace:
+    payload = {
+        "source_type": "camera",
+        "source_name": "halo_front_camera",
+        "source_uri": "/captures/front.mp4",
+        "frame_id": "halo_rgb_front",
+        "frame_index": 17,
+        "monotonic_timestamp_ns": 1_717_200_123_456_789,
+        "source_timestamp_ns": 1_717_200_123_000_000,
+        "detection_type": "candidate_human_presence",
+        "confidence": 0.72,
+        "region": {"x": 44, "y": 18, "width": 32, "height": 56},
+        "baseline_name": "halo_rgb_region_baseline",
+        "baseline_version": "0.1.0",
+        "latency_ms": 8.4,
+        "confidence_components": {
+            "brightness": 0.74,
+            "verticality": 0.66,
+            "size": 0.59,
+            "fill": 0.92,
+        },
+    }
+    payload.update(overrides)
+    return SimpleNamespace(**payload)
+
+
+def test_halo_confidence_event_from_candidate_preserves_halo_metadata() -> None:
+    event = halo_confidence_event_from_candidate(_candidate())
+
+    assert event.event_id.startswith("halo-confidence-")
+    assert event.source_id == "camera:halo_front_camera"
+    assert event.source_name == "halo_front_camera"
+    assert event.source_uri == "/captures/front.mp4"
+    assert event.frame_id == "halo_rgb_front"
+    assert event.frame_index == 17
+    assert event.timestamp_ns == 1_717_200_123_456_789
+    assert event.label == "Candidate Human Presence"
+    assert event.detection_type == "candidate_human_presence"
+    assert event.confidence == pytest.approx(0.72)
+    assert event.confidence_level == "MEDIUM"
+    assert event.region == {"x": 44, "y": 18, "width": 32, "height": 56}
+    assert event.recognition["baseline_name"] == "halo_rgb_region_baseline"
+    assert event.recognition["baseline_version"] == "0.1.0"
+    assert event.recognition["confidence_components"]["fill"] == pytest.approx(0.92)
+
+
+def test_parse_halo_confidence_event_derives_defaults_and_clamps_confidence() -> None:
+    event = parse_halo_confidence_event(
+        {
+            "source_id": "camera:halo_front_camera",
+            "source_name": "halo_front_camera",
+            "frame_id": "halo_rgb_front",
+            "frame_index": 8,
+            "timestamp_ns": 123_456_789,
+            "detection_type": "candidate_human_presence",
+            "confidence": 1.4,
+            "recognition": {
+                "baseline_name": "halo_rgb_region_baseline",
+                "baseline_version": "0.1.0",
+            },
+        }
+    )
+
+    assert event.event_id.startswith("halo-confidence-")
+    assert event.label == "Candidate Human Presence"
+    assert event.confidence == 1.0
+    assert event.confidence_level == "HIGH"
+    assert event.source_uri is None
+    assert event.region is None
+    assert event.location_hint is None
+    assert event.evidence_ref is None
+    assert event.evidence_uri is None
+
+
+def test_parse_halo_confidence_event_round_trip_preserves_optional_fields() -> None:
+    payload = {
+        "event_id": "halo-confidence-explicit",
+        "source_id": "camera:halo_front_camera",
+        "source_name": "halo_front_camera",
+        "source_uri": "rtsp://halo/front",
+        "frame_id": "halo_rgb_front",
+        "frame_index": 21,
+        "timestamp_ns": 999_000_321,
+        "label": "Possible Survivor",
+        "detection_type": "candidate_human_presence",
+        "confidence": 0.88,
+        "confidence_level": "HIGH",
+        "region": {"x": 11, "y": 15, "width": 20, "height": 28},
+        "location_hint": {"label": "Zone E-2", "x": 12.5, "y": 0.0, "z": -6.0},
+        "evidence_ref": "evidence-017",
+        "evidence_uri": "file:///tmp/halo/evidence-017.json",
+        "recognition": {
+            "baseline_name": "halo_rgb_region_baseline",
+            "baseline_version": "0.1.0",
+            "confidence_components": {"brightness": 0.91},
+        },
+    }
+
+    event = parse_halo_confidence_event(payload)
+
+    assert event.to_dict() == payload
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        (
+            {
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+            },
+            "source_id",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+            },
+            "frame_id",
+        ),
+        (
+            {
+                "source_id": "camera:halo_front_camera",
+                "source_name": "halo_front_camera",
+                "frame_id": "halo_rgb_front",
+                "frame_index": 1,
+                "timestamp_ns": 10,
+                "detection_type": "candidate_human_presence",
+                "confidence": 0.5,
+                "region": {"x": 1, "y": 2, "width": 0, "height": 3},
+                "recognition": {
+                    "baseline_name": "halo_rgb_region_baseline",
+                    "baseline_version": "0.1.0",
+                },
+            },
+            "width",
+        ),
+    ],
+)
+def test_parse_halo_confidence_event_rejects_invalid_payloads(
+    payload: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_halo_confidence_event(payload)

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
@@ -1,0 +1,51 @@
+export interface HaloRecognitionMetadata {
+  baseline_name: string;
+  baseline_version: string;
+  latency_ms?: number;
+  source_timestamp_ns?: number;
+  confidence_components?: Record<string, number>;
+}
+
+export interface HaloEventRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface HaloEventLocationHint {
+  label?: string;
+  x?: number;
+  y?: number;
+  z?: number;
+}
+
+export interface NormalizedHaloConfidenceDetection {
+  id: string;
+  sensorType: "rgb";
+  confidence: number;
+  confidenceLevel: "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN";
+  timestamp: number;
+  status: "new";
+  vehicleId: string;
+  vehicleName: string;
+  position: [number, number, number];
+  sourceModalities: ["rgb"];
+  sector: string;
+  signatureType: string;
+  frameId: string;
+  frameIndex: number;
+  timestampNs: number;
+  sourceUri?: string;
+  label: string;
+  detectionType: string;
+  region?: HaloEventRegion;
+  locationHint?: string | HaloEventLocationHint;
+  evidenceRef?: string;
+  evidenceUri?: string;
+  recognition: HaloRecognitionMetadata;
+}
+
+export function normalizeHaloConfidenceEventMessage(
+  rawMessage: unknown
+): NormalizedHaloConfidenceDetection;

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
@@ -47,5 +47,6 @@ export interface NormalizedHaloConfidenceDetection {
 }
 
 export function normalizeHaloConfidenceEventMessage(
-  rawMessage: unknown
+  rawMessage: unknown,
+  options?: { nowMs?: number }
 ): NormalizedHaloConfidenceDetection;

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
@@ -2,7 +2,7 @@ export interface HaloRecognitionMetadata {
   baseline_name: string;
   baseline_version: string;
   latency_ms?: number;
-  source_timestamp_ns?: number;
+  source_timestamp_ns?: string;
   confidence_components?: Record<string, number>;
 }
 
@@ -25,6 +25,7 @@ export interface NormalizedHaloConfidenceDetection {
   sensorType: "rgb";
   confidence: number;
   confidenceLevel: "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN";
+  /** Unix timestamp in milliseconds for viewer ordering and Date APIs. */
   timestamp: number;
   status: "new";
   vehicleId: string;
@@ -35,7 +36,8 @@ export interface NormalizedHaloConfidenceDetection {
   signatureType: string;
   frameId: string;
   frameIndex: number;
-  timestampNs: number;
+  /** Raw nanosecond timestamp preserved as text to avoid JavaScript precision loss. */
+  timestampNs: string;
   sourceUri?: string;
   label: string;
   detectionType: string;

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -34,18 +34,50 @@ function optionalString(rawValue, fieldName) {
   return normalized === "" ? undefined : normalized;
 }
 
-function requireInt(rawValue, fieldName, minimum = 0) {
-  if (typeof rawValue === "boolean") {
+function parseIntegerText(rawValue, fieldName) {
+  if (typeof rawValue === "boolean" || rawValue === null || rawValue === undefined) {
     throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer`);
   }
-  const value = Number(rawValue);
-  if (!Number.isInteger(value) || value < minimum) {
-    throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer >= ${minimum}`);
+  if (typeof rawValue === "bigint") {
+    return rawValue.toString();
+  }
+  if (typeof rawValue === "number") {
+    if (!Number.isSafeInteger(rawValue)) {
+      throw new Error(`Invalid Halo confidence event: ${fieldName} must be a safe integer or string`);
+    }
+    return String(rawValue);
+  }
+  if (typeof rawValue === "string") {
+    const normalized = rawValue.trim();
+    if (/^[+-]?\d+$/.test(normalized)) {
+      return normalized;
+    }
+  }
+  throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer`);
+}
+
+function requireInt(rawValue, fieldName, minimum = 0) {
+  const text = parseIntegerText(rawValue, fieldName);
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be a safe integer >= ${minimum}`);
   }
   return value;
 }
 
+function requireBigInt(rawValue, fieldName, minimum = 0n) {
+  const text = parseIntegerText(rawValue, fieldName);
+  const value = BigInt(text);
+  if (value < minimum) {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer >= ${minimum}`);
+  }
+  return { value, text };
+}
+
 function requireFiniteNumber(rawValue, fieldName) {
+  if (rawValue === null || rawValue === undefined || typeof rawValue === "boolean") {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be numeric`);
+  }
   const value = Number(rawValue);
   if (!Number.isFinite(value)) {
     throw new Error(`Invalid Halo confidence event: ${fieldName} must be numeric`);
@@ -61,20 +93,20 @@ function humanizeDetectionType(detectionType) {
     .join(" ");
 }
 
-function buildEventId({ sourceId, frameId, frameIndex, timestampNs, detectionType, region }) {
+function buildEventId({ sourceId, frameId, frameIndex, timestampNsText, detectionType, region }) {
   const regionKey = region
     ? `${region.x}:${region.y}:${region.width}:${region.height}`
     : "none";
-  return `halo-confidence-${sourceId}:${frameId}:${frameIndex}:${timestampNs}:${detectionType}:${regionKey}`;
+  return `halo-confidence-${sourceId}:${frameId}:${frameIndex}:${timestampNsText}:${detectionType}:${regionKey}`;
 }
 
 function isEpochNanoseconds(value) {
-  return Number.isFinite(value) && value >= 946_684_800_000_000_000;
+  return value >= 946_684_800_000_000_000n;
 }
 
 function deriveDisplayTimestampMs(timestampNs, options) {
   if (isEpochNanoseconds(timestampNs)) {
-    return Math.floor(timestampNs / 1_000_000);
+    return Number(timestampNs / 1_000_000n);
   }
   return Number.isFinite(options.nowMs) ? Number(options.nowMs) : Date.now();
 }
@@ -146,11 +178,11 @@ function parseRecognition(rawValue) {
     normalized.latency_ms = requireFiniteNumber(recognition.latency_ms, "recognition.latency_ms");
   }
   if (recognition.source_timestamp_ns !== undefined) {
-    normalized.source_timestamp_ns = requireInt(
+    normalized.source_timestamp_ns = requireBigInt(
       recognition.source_timestamp_ns,
       "recognition.source_timestamp_ns",
-      0
-    );
+      0n
+    ).text;
   }
   if (recognition.confidence_components !== undefined) {
     const components = requireObject(
@@ -193,7 +225,11 @@ export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
   const sourceName = requireString(message.source_name, "source_name");
   const frameId = requireString(message.frame_id, "frame_id");
   const frameIndex = requireInt(message.frame_index, "frame_index", 0);
-  const timestampNs = requireInt(message.timestamp_ns, "timestamp_ns", 0);
+  const { value: timestampNs, text: timestampNsText } = requireBigInt(
+    message.timestamp_ns,
+    "timestamp_ns",
+    0n
+  );
   const detectionType = optionalString(message.detection_type, "detection_type");
   const label = optionalString(message.label, "label");
   if (!detectionType && !label) {
@@ -216,7 +252,7 @@ export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
       sourceId,
       frameId,
       frameIndex,
-      timestampNs,
+      timestampNsText,
       detectionType: resolvedDetectionType,
       region,
     }),
@@ -233,7 +269,7 @@ export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
     signatureType: resolvedLabel,
     frameId,
     frameIndex,
-    timestampNs,
+    timestampNs: timestampNsText,
     sourceUri: optionalString(message.source_uri, "source_uri"),
     label: resolvedLabel,
     detectionType: resolvedDetectionType,

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -35,6 +35,9 @@ function optionalString(rawValue, fieldName) {
 }
 
 function requireInt(rawValue, fieldName, minimum = 0) {
+  if (typeof rawValue === "boolean") {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer`);
+  }
   const value = Number(rawValue);
   if (!Number.isInteger(value) || value < minimum) {
     throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer >= ${minimum}`);
@@ -209,7 +212,7 @@ export function normalizeHaloConfidenceEventMessage(rawMessage) {
     sensorType: "rgb",
     confidence,
     confidenceLevel: normalizeConfidenceLevel(message.confidence_level, confidence),
-    timestamp: Math.floor(timestampNs / 1_000),
+    timestamp: Math.floor(timestampNs / 1_000_000),
     status: "new",
     vehicleId: sourceId,
     vehicleName: sourceName,

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -1,0 +1,232 @@
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function requireObject(rawValue, fieldName) {
+  if (!rawValue || typeof rawValue !== "object" || Array.isArray(rawValue)) {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be an object`);
+  }
+  return rawValue;
+}
+
+function requireString(rawValue, fieldName) {
+  if (typeof rawValue !== "string" || rawValue.trim() === "") {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be a non-empty string`);
+  }
+  return rawValue.trim();
+}
+
+function optionalString(rawValue, fieldName) {
+  if (rawValue === undefined || rawValue === null) {
+    return undefined;
+  }
+  if (typeof rawValue !== "string") {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be a string`);
+  }
+  const normalized = rawValue.trim();
+  return normalized === "" ? undefined : normalized;
+}
+
+function requireInt(rawValue, fieldName, minimum = 0) {
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer >= ${minimum}`);
+  }
+  return value;
+}
+
+function requireFiniteNumber(rawValue, fieldName) {
+  const value = Number(rawValue);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid Halo confidence event: ${fieldName} must be numeric`);
+  }
+  return value;
+}
+
+function humanizeDetectionType(detectionType) {
+  return detectionType
+    .split("_")
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function buildEventId({ sourceId, frameId, frameIndex, timestampNs, detectionType, region }) {
+  const regionKey = region
+    ? `${region.x}:${region.y}:${region.width}:${region.height}`
+    : "none";
+  return `halo-confidence-${sourceId}:${frameId}:${frameIndex}:${timestampNs}:${detectionType}:${regionKey}`;
+}
+
+function normalizeConfidenceLevel(rawLevel, confidence) {
+  const level = typeof rawLevel === "string" ? rawLevel.trim().toUpperCase() : "";
+  if (level === "HIGH" || level === "MEDIUM" || level === "LOW" || level === "UNKNOWN") {
+    return level;
+  }
+  if (confidence >= 0.85) {
+    return "HIGH";
+  }
+  if (confidence >= 0.6) {
+    return "MEDIUM";
+  }
+  if (confidence >= 0.3) {
+    return "LOW";
+  }
+  return "UNKNOWN";
+}
+
+function parseRegion(rawValue) {
+  if (rawValue === undefined || rawValue === null) {
+    return undefined;
+  }
+
+  const region = requireObject(rawValue, "region");
+  const normalized = {
+    x: requireInt(region.x, "region.x", 0),
+    y: requireInt(region.y, "region.y", 0),
+    width: requireInt(region.width, "region.width", 1),
+    height: requireInt(region.height, "region.height", 1),
+  };
+  return normalized;
+}
+
+function parseLocationHint(rawValue) {
+  if (rawValue === undefined || rawValue === null) {
+    return undefined;
+  }
+  if (typeof rawValue === "string") {
+    return requireString(rawValue, "location_hint");
+  }
+
+  const locationHint = requireObject(rawValue, "location_hint");
+  const normalized = {};
+  if (locationHint.label !== undefined) {
+    normalized.label = requireString(locationHint.label, "location_hint.label");
+  }
+  for (const axis of ["x", "y", "z"]) {
+    if (locationHint[axis] !== undefined) {
+      normalized[axis] = requireFiniteNumber(locationHint[axis], `location_hint.${axis}`);
+    }
+  }
+  if (Object.keys(normalized).length === 0) {
+    throw new Error("Invalid Halo confidence event: location_hint must include a label or coordinates");
+  }
+  return normalized;
+}
+
+function parseRecognition(rawValue) {
+  const recognition = requireObject(rawValue, "recognition");
+  const normalized = {
+    baseline_name: requireString(recognition.baseline_name, "recognition.baseline_name"),
+    baseline_version: requireString(recognition.baseline_version, "recognition.baseline_version"),
+  };
+
+  if (recognition.latency_ms !== undefined) {
+    normalized.latency_ms = requireFiniteNumber(recognition.latency_ms, "recognition.latency_ms");
+  }
+  if (recognition.source_timestamp_ns !== undefined) {
+    normalized.source_timestamp_ns = requireInt(
+      recognition.source_timestamp_ns,
+      "recognition.source_timestamp_ns",
+      0
+    );
+  }
+  if (recognition.confidence_components !== undefined) {
+    const components = requireObject(
+      recognition.confidence_components,
+      "recognition.confidence_components"
+    );
+    normalized.confidence_components = Object.fromEntries(
+      Object.entries(components).map(([key, value]) => [
+        requireString(key, "recognition.confidence_components key"),
+        clamp01(requireFiniteNumber(value, `recognition.confidence_components.${key}`)),
+      ])
+    );
+  }
+  return normalized;
+}
+
+function parsePositionFromLocationHint(locationHint) {
+  if (!locationHint || typeof locationHint === "string") {
+    return [0, 0, 0];
+  }
+  const x = isFiniteNumber(locationHint.x) ? locationHint.x : 0;
+  const y = isFiniteNumber(locationHint.y) ? locationHint.y : 0;
+  const z = isFiniteNumber(locationHint.z) ? locationHint.z : 0;
+  return [x, y, z];
+}
+
+function deriveSector(locationHint, frameId) {
+  if (typeof locationHint === "string") {
+    return locationHint;
+  }
+  if (locationHint && typeof locationHint.label === "string") {
+    return locationHint.label;
+  }
+  return frameId;
+}
+
+export function normalizeHaloConfidenceEventMessage(rawMessage) {
+  const message = requireObject(rawMessage, "payload");
+  const sourceId = requireString(message.source_id, "source_id");
+  const sourceName = requireString(message.source_name, "source_name");
+  const frameId = requireString(message.frame_id, "frame_id");
+  const frameIndex = requireInt(message.frame_index, "frame_index", 0);
+  const timestampNs = requireInt(message.timestamp_ns, "timestamp_ns", 0);
+  const detectionType = optionalString(message.detection_type, "detection_type");
+  const label = optionalString(message.label, "label");
+  if (!detectionType && !label) {
+    throw new Error("Invalid Halo confidence event: detection_type or label is required");
+  }
+
+  const resolvedDetectionType = detectionType ?? requireString(
+    label.toLowerCase().replace(/\s+/g, "_"),
+    "label"
+  );
+  const resolvedLabel = label ?? humanizeDetectionType(resolvedDetectionType);
+  const confidence = clamp01(requireFiniteNumber(message.confidence, "confidence"));
+  const region = parseRegion(message.region);
+  const locationHint = parseLocationHint(message.location_hint);
+  const recognition = parseRecognition(message.recognition);
+  const position = parsePositionFromLocationHint(locationHint);
+
+  return {
+    id: optionalString(message.event_id, "event_id") ?? buildEventId({
+      sourceId,
+      frameId,
+      frameIndex,
+      timestampNs,
+      detectionType: resolvedDetectionType,
+      region,
+    }),
+    sensorType: "rgb",
+    confidence,
+    confidenceLevel: normalizeConfidenceLevel(message.confidence_level, confidence),
+    timestamp: Math.floor(timestampNs / 1_000),
+    status: "new",
+    vehicleId: sourceId,
+    vehicleName: sourceName,
+    position,
+    sourceModalities: ["rgb"],
+    sector: deriveSector(locationHint, frameId),
+    signatureType: resolvedLabel,
+    frameId,
+    frameIndex,
+    timestampNs,
+    sourceUri: optionalString(message.source_uri, "source_uri"),
+    label: resolvedLabel,
+    detectionType: resolvedDetectionType,
+    region,
+    locationHint,
+    evidenceRef: optionalString(message.evidence_ref, "evidence_ref"),
+    evidenceUri: optionalString(message.evidence_uri, "evidence_uri"),
+    recognition,
+  };
+}

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -68,6 +68,17 @@ function buildEventId({ sourceId, frameId, frameIndex, timestampNs, detectionTyp
   return `halo-confidence-${sourceId}:${frameId}:${frameIndex}:${timestampNs}:${detectionType}:${regionKey}`;
 }
 
+function isEpochNanoseconds(value) {
+  return Number.isFinite(value) && value >= 946_684_800_000_000_000;
+}
+
+function deriveDisplayTimestampMs(timestampNs, options) {
+  if (isEpochNanoseconds(timestampNs)) {
+    return Math.floor(timestampNs / 1_000_000);
+  }
+  return Number.isFinite(options.nowMs) ? Number(options.nowMs) : Date.now();
+}
+
 function normalizeConfidenceLevel(rawLevel, confidence) {
   const level = typeof rawLevel === "string" ? rawLevel.trim().toUpperCase() : "";
   if (level === "HIGH" || level === "MEDIUM" || level === "LOW" || level === "UNKNOWN") {
@@ -176,7 +187,7 @@ function deriveSector(locationHint, frameId) {
   return frameId;
 }
 
-export function normalizeHaloConfidenceEventMessage(rawMessage) {
+export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
   const message = requireObject(rawMessage, "payload");
   const sourceId = requireString(message.source_id, "source_id");
   const sourceName = requireString(message.source_name, "source_name");
@@ -212,7 +223,7 @@ export function normalizeHaloConfidenceEventMessage(rawMessage) {
     sensorType: "rgb",
     confidence,
     confidenceLevel: normalizeConfidenceLevel(message.confidence_level, confidence),
-    timestamp: Math.floor(timestampNs / 1_000_000),
+    timestamp: deriveDisplayTimestampMs(timestampNs, options),
     status: "new",
     vehicleId: sourceId,
     vehicleName: sourceName,

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -33,7 +33,7 @@ test("normalizeHaloConfidenceEventMessage maps the canonical event into a displa
   assert.equal(detection.sensorType, "rgb");
   assert.equal(detection.confidence, 0.72);
   assert.equal(detection.confidenceLevel, "MEDIUM");
-  assert.equal(detection.timestamp, 1_717_200_123_456);
+  assert.equal(detection.timestamp, 1_717_200_123);
   assert.deepEqual(detection.position, [12.5, 0, -6]);
   assert.deepEqual(detection.sourceModalities, ["rgb"]);
   assert.equal(detection.vehicleId, "camera:halo_front_camera");
@@ -117,5 +117,39 @@ test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
       },
     }),
     /region/
+  );
+
+  assert.throws(
+    () => normalizeHaloConfidenceEventMessage({
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: true,
+      timestamp_ns: 10,
+      detection_type: "candidate_human_presence",
+      confidence: 0.5,
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    }),
+    /frame_index/
+  );
+
+  assert.throws(
+    () => normalizeHaloConfidenceEventMessage({
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: 1,
+      timestamp_ns: false,
+      detection_type: "candidate_human_presence",
+      confidence: 0.5,
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    }),
+    /timestamp_ns/
   );
 });

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeHaloConfidenceEventMessage } from "./haloConfidenceEvents.js";
+
+test("normalizeHaloConfidenceEventMessage maps the canonical event into a display-friendly model", () => {
+  const event = {
+    event_id: "halo-confidence-001",
+    source_id: "camera:halo_front_camera",
+    source_name: "halo_front_camera",
+    source_uri: "rtsp://halo/front",
+    frame_id: "halo_rgb_front",
+    frame_index: 21,
+    timestamp_ns: 1_717_200_123_456_789,
+    label: "Possible Survivor",
+    detection_type: "candidate_human_presence",
+    confidence: 0.72,
+    confidence_level: "MEDIUM",
+    region: { x: 11, y: 15, width: 20, height: 28 },
+    location_hint: { label: "Zone E-2", x: 12.5, y: 0.0, z: -6.0 },
+    evidence_ref: "evidence-017",
+    evidence_uri: "file:///tmp/halo/evidence-017.json",
+    recognition: {
+      baseline_name: "halo_rgb_region_baseline",
+      baseline_version: "0.1.0",
+      confidence_components: { brightness: 0.91, fill: 0.87 },
+    },
+  };
+
+  const detection = normalizeHaloConfidenceEventMessage(event);
+
+  assert.equal(detection.id, "halo-confidence-001");
+  assert.equal(detection.sensorType, "rgb");
+  assert.equal(detection.confidence, 0.72);
+  assert.equal(detection.confidenceLevel, "MEDIUM");
+  assert.equal(detection.timestamp, 1_717_200_123_456);
+  assert.deepEqual(detection.position, [12.5, 0, -6]);
+  assert.deepEqual(detection.sourceModalities, ["rgb"]);
+  assert.equal(detection.vehicleId, "camera:halo_front_camera");
+  assert.equal(detection.vehicleName, "halo_front_camera");
+  assert.equal(detection.sector, "Zone E-2");
+  assert.equal(detection.signatureType, "Possible Survivor");
+  assert.deepEqual(detection.region, { x: 11, y: 15, width: 20, height: 28 });
+  assert.equal(detection.evidenceRef, "evidence-017");
+  assert.equal(detection.evidenceUri, "file:///tmp/halo/evidence-017.json");
+  assert.equal(detection.recognition.baseline_name, "halo_rgb_region_baseline");
+});
+
+test("normalizeHaloConfidenceEventMessage derives defaults and preserves optional field absence", () => {
+  const detection = normalizeHaloConfidenceEventMessage({
+    source_id: "camera:halo_front_camera",
+    source_name: "halo_front_camera",
+    frame_id: "halo_rgb_front",
+    frame_index: 4,
+    timestamp_ns: 123_456_789,
+    detection_type: "candidate_human_presence",
+    confidence: 1.4,
+    recognition: {
+      baseline_name: "halo_rgb_region_baseline",
+      baseline_version: "0.1.0",
+    },
+  });
+
+  assert.ok(detection.id.startsWith("halo-confidence-"));
+  assert.equal(detection.confidence, 1);
+  assert.equal(detection.confidenceLevel, "HIGH");
+  assert.deepEqual(detection.position, [0, 0, 0]);
+  assert.equal(detection.sector, "halo_rgb_front");
+  assert.equal(detection.signatureType, "Candidate Human Presence");
+  assert.equal(detection.region, undefined);
+  assert.equal(detection.locationHint, undefined);
+  assert.equal(detection.evidenceRef, undefined);
+  assert.equal(detection.evidenceUri, undefined);
+});
+
+test("normalizeHaloConfidenceEventMessage supports string location hints", () => {
+  const detection = normalizeHaloConfidenceEventMessage({
+    source_id: "camera:halo_rear_camera",
+    source_name: "halo_rear_camera",
+    frame_id: "halo_rgb_rear",
+    frame_index: 9,
+    timestamp_ns: 999_000_321,
+    label: "Candidate Human Presence",
+    detection_type: "candidate_human_presence",
+    confidence: 0.31,
+    location_hint: "Zone W-1",
+    recognition: {
+      baseline_name: "halo_rgb_region_baseline",
+      baseline_version: "0.1.0",
+    },
+  });
+
+  assert.equal(detection.sector, "Zone W-1");
+  assert.deepEqual(detection.position, [0, 0, 0]);
+  assert.equal(detection.confidenceLevel, "LOW");
+});
+
+test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
+  assert.throws(
+    () => normalizeHaloConfidenceEventMessage({ confidence: 0.4 }),
+    /source_id/
+  );
+
+  assert.throws(
+    () => normalizeHaloConfidenceEventMessage({
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: 1,
+      timestamp_ns: 10,
+      detection_type: "candidate_human_presence",
+      confidence: 0.5,
+      region: { x: 1, y: 2, width: -2, height: 10 },
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    }),
+    /region/
+  );
+});

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -11,7 +11,7 @@ test("normalizeHaloConfidenceEventMessage maps the canonical event into a displa
     source_uri: "rtsp://halo/front",
     frame_id: "halo_rgb_front",
     frame_index: 21,
-    timestamp_ns: 1_717_200_123_456_789_000,
+    timestamp_ns: "1717200123456789000",
     label: "Possible Survivor",
     detection_type: "candidate_human_presence",
     confidence: 0.72,
@@ -34,6 +34,7 @@ test("normalizeHaloConfidenceEventMessage maps the canonical event into a displa
   assert.equal(detection.confidence, 0.72);
   assert.equal(detection.confidenceLevel, "MEDIUM");
   assert.equal(detection.timestamp, 1_717_200_123_456);
+  assert.equal(detection.timestampNs, "1717200123456789000");
   assert.deepEqual(detection.position, [12.5, 0, -6]);
   assert.deepEqual(detection.sourceModalities, ["rgb"]);
   assert.equal(detection.vehicleId, "camera:halo_front_camera");
@@ -52,7 +53,7 @@ test("normalizeHaloConfidenceEventMessage derives defaults and preserves optiona
     source_name: "halo_front_camera",
     frame_id: "halo_rgb_front",
     frame_index: 4,
-    timestamp_ns: 123_456_789,
+    timestamp_ns: "123456789",
     detection_type: "candidate_human_presence",
     confidence: 1.4,
     recognition: {
@@ -65,7 +66,7 @@ test("normalizeHaloConfidenceEventMessage derives defaults and preserves optiona
   assert.equal(detection.confidence, 1);
   assert.equal(detection.confidenceLevel, "HIGH");
   assert.equal(detection.timestamp, 1_800_000);
-  assert.equal(detection.timestampNs, 123_456_789);
+  assert.equal(detection.timestampNs, "123456789");
   assert.deepEqual(detection.position, [0, 0, 0]);
   assert.equal(detection.sector, "halo_rgb_front");
   assert.equal(detection.signatureType, "Candidate Human Presence");
@@ -81,7 +82,7 @@ test("normalizeHaloConfidenceEventMessage supports string location hints", () =>
     source_name: "halo_rear_camera",
     frame_id: "halo_rgb_rear",
     frame_index: 9,
-    timestamp_ns: 999_000_321,
+    timestamp_ns: "999000321",
     label: "Candidate Human Presence",
     detection_type: "candidate_human_presence",
     confidence: 0.31,
@@ -97,6 +98,33 @@ test("normalizeHaloConfidenceEventMessage supports string location hints", () =>
   assert.equal(detection.confidenceLevel, "LOW");
 });
 
+test("normalizeHaloConfidenceEventMessage derives detection type from a label-only payload", () => {
+  const detection = normalizeHaloConfidenceEventMessage({
+    source_id: "camera:halo_side_camera",
+    source_name: "halo_side_camera",
+    frame_id: "halo_rgb_side",
+    frame_index: 3,
+    timestamp_ns: "1000000000",
+    label: "Candidate Human Presence",
+    confidence: 0.62,
+    location_hint: { label: "Zone S-1", x: 1, y: 2, z: 3 },
+    recognition: {
+      baseline_name: "halo_rgb_region_baseline",
+      baseline_version: "0.1.0",
+      source_timestamp_ns: "900000000",
+    },
+  }, { nowMs: 2_000_000 });
+
+  assert.equal(detection.detectionType, "candidate_human_presence");
+  assert.equal(detection.label, "Candidate Human Presence");
+  assert.equal(detection.signatureType, "Candidate Human Presence");
+  assert.equal(detection.confidenceLevel, "MEDIUM");
+  assert.equal(detection.timestamp, 2_000_000);
+  assert.equal(detection.recognition.source_timestamp_ns, "900000000");
+  assert.deepEqual(detection.position, [1, 2, 3]);
+  assert.equal(detection.sector, "Zone S-1");
+});
+
 test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
   assert.throws(
     () => normalizeHaloConfidenceEventMessage({ confidence: 0.4 }),
@@ -109,7 +137,7 @@ test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
       source_name: "halo_front_camera",
       frame_id: "halo_rgb_front",
       frame_index: 1,
-      timestamp_ns: 10,
+      timestamp_ns: "10",
       detection_type: "candidate_human_presence",
       confidence: 0.5,
       region: { x: 1, y: 2, width: -2, height: 10 },
@@ -127,7 +155,7 @@ test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
       source_name: "halo_front_camera",
       frame_id: "halo_rgb_front",
       frame_index: true,
-      timestamp_ns: 10,
+      timestamp_ns: "10",
       detection_type: "candidate_human_presence",
       confidence: 0.5,
       recognition: {
@@ -153,5 +181,22 @@ test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
       },
     }),
     /timestamp_ns/
+  );
+
+  assert.throws(
+    () => normalizeHaloConfidenceEventMessage({
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: 1,
+      timestamp_ns: "10",
+      detection_type: "candidate_human_presence",
+      confidence: null,
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    }),
+    /confidence/
   );
 });

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -11,7 +11,7 @@ test("normalizeHaloConfidenceEventMessage maps the canonical event into a displa
     source_uri: "rtsp://halo/front",
     frame_id: "halo_rgb_front",
     frame_index: 21,
-    timestamp_ns: 1_717_200_123_456_789,
+    timestamp_ns: 1_717_200_123_456_789_000,
     label: "Possible Survivor",
     detection_type: "candidate_human_presence",
     confidence: 0.72,
@@ -33,7 +33,7 @@ test("normalizeHaloConfidenceEventMessage maps the canonical event into a displa
   assert.equal(detection.sensorType, "rgb");
   assert.equal(detection.confidence, 0.72);
   assert.equal(detection.confidenceLevel, "MEDIUM");
-  assert.equal(detection.timestamp, 1_717_200_123);
+  assert.equal(detection.timestamp, 1_717_200_123_456);
   assert.deepEqual(detection.position, [12.5, 0, -6]);
   assert.deepEqual(detection.sourceModalities, ["rgb"]);
   assert.equal(detection.vehicleId, "camera:halo_front_camera");
@@ -59,11 +59,13 @@ test("normalizeHaloConfidenceEventMessage derives defaults and preserves optiona
       baseline_name: "halo_rgb_region_baseline",
       baseline_version: "0.1.0",
     },
-  });
+  }, { nowMs: 1_800_000 });
 
   assert.ok(detection.id.startsWith("halo-confidence-"));
   assert.equal(detection.confidence, 1);
   assert.equal(detection.confidenceLevel, "HIGH");
+  assert.equal(detection.timestamp, 1_800_000);
+  assert.equal(detection.timestampNs, 123_456_789);
   assert.deepEqual(detection.position, [0, 0, 0]);
   assert.equal(detection.sector, "halo_rgb_front");
   assert.equal(detection.signatureType, "Candidate Human Presence");


### PR DESCRIPTION
## Summary
- add a canonical Halo confidence event contract and candidate conversion helper in perception
- add viewer normalization for Halo confidence events, including optional region, location, evidence, and recognition metadata handling
- add backend and viewer tests covering defaults, invalid payloads, confidence bounds, and contract compatibility

## Validation
- `PYTHONPATH=software/edge/src/aeris_perception:software/edge/src/aeris_msgs python3 -m pytest software/edge/src/aeris_perception/test/test_halo_confidence_event.py software/edge/src/aeris_msgs/test -q`
- `cd software/viewer && node --test src/lib/ros/*.test.mjs src/lib/*.test.mjs`
- `python3 -m compileall software/edge/src/aeris_perception/aeris_perception`

## Notes
- the broader perception pytest command currently stops during collection in this environment because `numpy` is not installed locally: `PYTHONPATH=software/edge/src/aeris_perception:software/edge/src/aeris_msgs python3 -m pytest software/edge/src/aeris_perception/test software/edge/src/aeris_msgs/test -q`

Closes #123



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Halo confidence event framework for RGB recognition outputs with confidence tiering and structured detection metadata
  * Implemented event normalization and validation pipelines for improved data consistency across components

* **Tests**
  * Added comprehensive test coverage for event parsing, serialization, and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aeris-Drones/aeris/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the canonical Halo confidence event contract: a Python dataclass with parser/serializer/candidate-converter in `aeris_perception`, a matching JavaScript normalizer with TypeScript declarations in the viewer, and test suites for both. Several previously flagged issues (bool coercion, ns→ms timestamp, null `requireFiniteNumber`, field-name in `_optional_string` errors) have been addressed.

- **Python backend** (`halo_confidence_event.py`): well-guarded validators (bool rejection, finite-float, string-from-int), clean round-trip via `to_dict`/`parse_halo_confidence_event`, and a candidate-conversion helper.
- **Viewer normalizer** (`haloConfidenceEvents.js`): BigInt precision-safe timestamp handling, confidence-level tiering, and display-timestamp derivation with monotonic-clock fallback.
- **Remaining asymmetry**: the three optional recognition sub-fields (`latency_ms`, `source_timestamp_ns`, `confidence_components`) use `!== undefined` guards in `parseRecognition`, so a `null` value throws in JS but is silently accepted in Python — a payload valid on the backend is rejected by the viewer.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the null-guard asymmetry in parseRecognition; all other logic is consistent between Python and JavaScript.

The viewer's parseRecognition uses `!== undefined` for three optional fields, so a null value (valid and silently ignored on the backend) causes the viewer to throw. A backend payload with, e.g., `latency_ms: null` would break the viewer's normalizer, yet pass Python validation without error.

software/viewer/src/lib/ros/haloConfidenceEvents.js — the `parseRecognition` function's optional-field guards need `!= null` instead of `!== undefined`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_perception/aeris_perception/halo_confidence_event.py | New canonical Halo confidence event contract with dataclass, parser, serializer, and candidate converter. Validators are thorough (bool guard, finite-float, int-from-string), round-trip and optional-field handling look correct. |
| software/viewer/src/lib/ros/haloConfidenceEvents.js | New viewer normalizer for Halo confidence events. Previous issues (bool coercion, ns→ms conversion, requireFiniteNumber null) addressed, but three optional recognition sub-field guards use `!== undefined` instead of `!= null`, causing JS to throw on null values that Python silently accepts. |
| software/viewer/src/lib/ros/haloConfidenceEvents.d.ts | TypeScript declaration file for the viewer normalizer. Types accurately reflect optional fields; `timestampNs` correctly typed as `string` to avoid precision loss. |
| software/edge/src/aeris_perception/test/test_halo_confidence_event.py | Comprehensive pytest coverage: candidate conversion, round-trip, clamping, and a parametrized invalid-payload suite. All previously discussed edge cases (bool confidence, float frame_index, non-string source_uri) are covered. |
| software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs | Node test-runner tests for canonical mapping, defaults, string location hints, label-only derivation, and invalid payload rejection. Covers boolean frame_index/timestamp_ns and null confidence cases added in this PR. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as RecognitionCandidate
    participant P as halo_confidence_event.py
    participant M as ROS Message (JSON)
    participant J as haloConfidenceEvents.js
    participant V as Viewer UI

    C->>P: halo_confidence_event_from_candidate(candidate)
    P->>P: "validate fields (_require_*, _clamp01)"
    P->>P: build HaloConfidenceEvent dataclass
    P->>M: serialize_halo_confidence_event() → dict
    Note over M: timestamp_ns as string,<br/>source_timestamp_ns as string

    M->>J: normalizeHaloConfidenceEventMessage(rawMessage)
    J->>J: requireString / requireBigInt / requireFiniteNumber
    J->>J: deriveDisplayTimestampMs (ns→ms, monotonic fallback)
    J->>J: parseRegion / parseLocationHint / parseRecognition
    J->>V: NormalizedHaloConfidenceDetection
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `software/viewer/src/lib/ros/haloConfidenceEvents.js`, line 752-758 ([link](https://github.com/aeris-drones/aeris/blob/daf8848eae26def5d905f50173098358eadbbb66/software/viewer/src/lib/ros/haloConfidenceEvents.js#L752-L758)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`requireFiniteNumber` silently accepts `null`, producing `0` for required fields**

   `Number(null) === 0` which is finite, so `requireFiniteNumber(null, "confidence")` returns `0` without throwing. A message with `confidence: null` would then produce a normalized detection with `confidence = 0` — no error, wrong data. The Python counterpart correctly rejects `None` (`float(None)` raises `TypeError`, caught and re-raised as `ValueError`). The same silent-zero path also affects `recognition.latency_ms` and `recognition.source_timestamp_ns` via the `!== undefined` guards (since `null !== undefined` is `true`), where Python skips null optional fields entirely (`if latency_ms is not None:`). Adding a `rawValue === null` guard before the `Number()` call (or using `rawValue == null` to cover both) would align with Python's behavior.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/lib/ros/haloConfidenceEvents.js
   Line: 752-758

   Comment:
   **`requireFiniteNumber` silently accepts `null`, producing `0` for required fields**

   `Number(null) === 0` which is finite, so `requireFiniteNumber(null, "confidence")` returns `0` without throwing. A message with `confidence: null` would then produce a normalized detection with `confidence = 0` — no error, wrong data. The Python counterpart correctly rejects `None` (`float(None)` raises `TypeError`, caught and re-raised as `ValueError`). The same silent-zero path also affects `recognition.latency_ms` and `recognition.source_timestamp_ns` via the `!== undefined` guards (since `null !== undefined` is `true`), where Python skips null optional fields entirely (`if latency_ms is not None:`). Adding a `rawValue === null` guard before the `Number()` call (or using `rawValue == null` to cover both) would align with Python's behavior.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `software/viewer/src/lib/ros/haloConfidenceEvents.js`, line 916-937 ([link](https://github.com/aeris-drones/aeris/blob/f21fb9cd305dbd47dac5eefbd98ee806be126959/software/viewer/src/lib/ros/haloConfidenceEvents.js#L916-L937)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`null` optional recognition fields throw instead of being skipped**

   All three optional-field guards inside `parseRecognition` use `!== undefined`, so a `null` value for `latency_ms`, `source_timestamp_ns`, or `confidence_components` passes the guard and is then handed to `requireFiniteNumber`/`requireBigInt`/`requireObject`, which all throw for `null`. Python's `_normalize_recognition` uses `if latency_ms is not None:`, which silently skips `null`/`None` for all three fields. A backend payload containing `recognition: { …, latency_ms: null }` is therefore valid on the Python side and raises in the viewer, breaking the contract. Change each guard to `!= null` (or `!== undefined && !== null`) to match Python's behaviour.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: software/viewer/src/lib/ros/haloConfidenceEvents.js
   Line: 916-937

   Comment:
   **`null` optional recognition fields throw instead of being skipped**

   All three optional-field guards inside `parseRecognition` use `!== undefined`, so a `null` value for `latency_ms`, `source_timestamp_ns`, or `confidence_components` passes the guard and is then handed to `requireFiniteNumber`/`requireBigInt`/`requireObject`, which all throw for `null`. Python's `_normalize_recognition` uses `if latency_ms is not None:`, which silently skips `null`/`None` for all three fields. A backend payload containing `recognition: { …, latency_ms: null }` is therefore valid on the Python side and raises in the viewer, breaking the contract. Change each guard to `!= null` (or `!== undefined && !== null`) to match Python's behaviour.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/viewer/src/lib/ros/haloConfidenceEvents.js:916-937
**`null` optional recognition fields throw instead of being skipped**

All three optional-field guards inside `parseRecognition` use `!== undefined`, so a `null` value for `latency_ms`, `source_timestamp_ns`, or `confidence_components` passes the guard and is then handed to `requireFiniteNumber`/`requireBigInt`/`requireObject`, which all throw for `null`. Python's `_normalize_recognition` uses `if latency_ms is not None:`, which silently skips `null`/`None` for all three fields. A backend payload containing `recognition: { …, latency_ms: null }` is therefore valid on the Python side and raises in the viewer, breaking the contract. Change each guard to `!= null` (or `!== undefined && !== null`) to match Python's behaviour.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Preserve Halo event timestamp precision"](https://github.com/aeris-drones/aeris/commit/f21fb9cd305dbd47dac5eefbd98ee806be126959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34496848)</sub>

<!-- /greptile_comment -->