### PR TITLE
Log Halo detection evidence events

### DIFF
--- a/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import fcntl
 import json
 from pathlib import Path
 import time
-from typing import Any, Mapping
+from typing import Any, IO, Mapping
 
 from .halo_confidence_event import (
     HaloConfidenceEvent,
@@ -68,94 +69,101 @@ def append_halo_evidence_log_record(
 
     resolved_log_path = Path(log_path).expanduser().resolve()
     resolved_evidence_path = _normalize_evidence_path(evidence_path)
-    existing_records = (
-        _read_halo_evidence_log(
-            resolved_log_path,
-            validate_evidence_paths=False,
-        )
-        if resolved_log_path.exists()
-        else []
-    )
     _require_evidence_handle(
         evidence_path=resolved_evidence_path,
         evidence_ref=event.evidence_ref,
         evidence_uri=event.evidence_uri,
     )
-
-    record = HaloEvidenceLogRecord(
-        schema_version=HALO_EVIDENCE_LOG_SCHEMA_VERSION,
-        sequence=len(existing_records),
-        recorded_at_ns=_require_int(
-            time.time_ns() if recorded_at_ns is None else recorded_at_ns,
-            "recorded_at_ns",
-            minimum=0,
-        ),
-        run_id=_require_non_empty_string(run_id, "run_id"),
-        mode=_normalize_mode(mode),
-        event=event,
-        evidence_path=resolved_evidence_path,
-        evidence_ref=event.evidence_ref,
-        evidence_uri=event.evidence_uri,
-    )
-
     resolved_log_path.parent.mkdir(parents=True, exist_ok=True)
-    with resolved_log_path.open("a", encoding="utf-8") as log_file:
-        log_file.write(json.dumps(record.to_dict(), sort_keys=True))
-        log_file.write("\n")
 
-    return record
+    with resolved_log_path.open("a+", encoding="utf-8") as log_file:
+        fcntl.flock(log_file.fileno(), fcntl.LOCK_EX)
+        try:
+            log_file.seek(0)
+            existing_records = _read_halo_evidence_log_file(
+                log_file,
+                validate_evidence_paths=False,
+            )
+            record = HaloEvidenceLogRecord(
+                schema_version=HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                sequence=len(existing_records),
+                recorded_at_ns=_require_int(
+                    time.time_ns() if recorded_at_ns is None else recorded_at_ns,
+                    "recorded_at_ns",
+                    minimum=0,
+                ),
+                run_id=_require_non_empty_string(run_id, "run_id"),
+                mode=_normalize_mode(mode),
+                event=event,
+                evidence_path=resolved_evidence_path,
+                evidence_ref=event.evidence_ref,
+                evidence_uri=event.evidence_uri,
+            )
+            log_file.seek(0, 2)
+            log_file.write(json.dumps(record.to_dict(), sort_keys=True))
+            log_file.write("\n")
+            log_file.flush()
+        finally:
+            fcntl.flock(log_file.fileno(), fcntl.LOCK_UN)
+
+        return record
 
 
 def read_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
     """Load Halo evidence log records in persisted order."""
 
     resolved_log_path = Path(log_path).expanduser().resolve()
-    return _read_halo_evidence_log(
-        resolved_log_path,
-        validate_evidence_paths=True,
-    )
+    with resolved_log_path.open("r", encoding="utf-8") as log_file:
+        return _read_halo_evidence_log_file(
+            log_file,
+            validate_evidence_paths=True,
+        )
 
 
-def _read_halo_evidence_log(
-    resolved_log_path: Path,
+def _read_halo_evidence_log_file(
+    log_file: IO[str],
     *,
     validate_evidence_paths: bool,
 ) -> list[HaloEvidenceLogRecord]:
     records: list[HaloEvidenceLogRecord] = []
-    with resolved_log_path.open("r", encoding="utf-8") as log_file:
-        for line_number, line in enumerate(log_file, start=1):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                raw_payload = json.loads(stripped)
-            except json.JSONDecodeError as error:
-                raise HaloEvidenceLogError(
-                    f"Malformed Halo evidence log record at line {line_number}"
-                ) from error
-            record = _parse_halo_evidence_log_record(
-                raw_payload,
-                line_number=line_number,
-                validate_evidence_path=validate_evidence_paths,
+    for line_number, line in enumerate(log_file, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            raw_payload = json.loads(stripped)
+        except json.JSONDecodeError as error:
+            raise HaloEvidenceLogError(
+                f"Malformed Halo evidence log record at line {line_number}"
+            ) from error
+        record = _parse_halo_evidence_log_record(
+            raw_payload,
+            line_number=line_number,
+            validate_evidence_path=validate_evidence_paths,
+        )
+        if not records and record.sequence != 0:
+            raise HaloEvidenceLogError(
+                "Halo evidence log must start at sequence 0 "
+                f"at line {line_number}"
             )
-            if not records and record.sequence != 0:
-                raise HaloEvidenceLogError(
-                    "Halo evidence log must start at sequence 0 "
-                    f"at line {line_number}"
-                )
-            if records and record.sequence != records[-1].sequence + 1:
-                raise HaloEvidenceLogError(
-                    "Halo evidence log sequence must increase by 1 in persisted order "
-                    f"at line {line_number}"
-                )
-            records.append(record)
+        if records and record.sequence != records[-1].sequence + 1:
+            raise HaloEvidenceLogError(
+                "Halo evidence log sequence must increase by 1 in persisted order "
+                f"at line {line_number}"
+            )
+        records.append(record)
     return records
 
 
 def replay_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
     """Replay persisted Halo evidence events without rerunning recognition."""
 
-    return read_halo_evidence_log(log_path)
+    resolved_log_path = Path(log_path).expanduser().resolve()
+    with resolved_log_path.open("r", encoding="utf-8") as log_file:
+        return _read_halo_evidence_log_file(
+            log_file,
+            validate_evidence_paths=False,
+        )
 
 
 def _parse_halo_evidence_log_record(

--- a/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
@@ -69,9 +69,17 @@ def append_halo_evidence_log_record(
     resolved_log_path = Path(log_path).expanduser().resolve()
     resolved_evidence_path = _normalize_evidence_path(evidence_path)
     existing_records = (
-        read_halo_evidence_log(resolved_log_path)
+        _read_halo_evidence_log(
+            resolved_log_path,
+            validate_evidence_paths=False,
+        )
         if resolved_log_path.exists()
         else []
+    )
+    _require_evidence_handle(
+        evidence_path=resolved_evidence_path,
+        evidence_ref=event.evidence_ref,
+        evidence_uri=event.evidence_uri,
     )
 
     record = HaloEvidenceLogRecord(
@@ -102,6 +110,17 @@ def read_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
     """Load Halo evidence log records in persisted order."""
 
     resolved_log_path = Path(log_path).expanduser().resolve()
+    return _read_halo_evidence_log(
+        resolved_log_path,
+        validate_evidence_paths=True,
+    )
+
+
+def _read_halo_evidence_log(
+    resolved_log_path: Path,
+    *,
+    validate_evidence_paths: bool,
+) -> list[HaloEvidenceLogRecord]:
     records: list[HaloEvidenceLogRecord] = []
     with resolved_log_path.open("r", encoding="utf-8") as log_file:
         for line_number, line in enumerate(log_file, start=1):
@@ -117,7 +136,13 @@ def read_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
             record = _parse_halo_evidence_log_record(
                 raw_payload,
                 line_number=line_number,
+                validate_evidence_path=validate_evidence_paths,
             )
+            if not records and record.sequence != 0:
+                raise HaloEvidenceLogError(
+                    "Halo evidence log must start at sequence 0 "
+                    f"at line {line_number}"
+                )
             if records and record.sequence != records[-1].sequence + 1:
                 raise HaloEvidenceLogError(
                     "Halo evidence log sequence must increase by 1 in persisted order "
@@ -137,6 +162,7 @@ def _parse_halo_evidence_log_record(
     payload: Any,
     *,
     line_number: int,
+    validate_evidence_path: bool,
 ) -> HaloEvidenceLogRecord:
     if not isinstance(payload, Mapping):
         raise HaloEvidenceLogError(
@@ -150,8 +176,16 @@ def _parse_halo_evidence_log_record(
             f"{schema_version} at line {line_number}"
         )
 
-    event = parse_halo_confidence_event(_require_mapping_object(payload, "event"))
-    evidence_path = _normalize_evidence_path(payload.get("evidence_path"))
+    try:
+        event = parse_halo_confidence_event(_require_mapping_object(payload, "event"))
+    except ValueError as error:
+        raise HaloEvidenceLogError(
+            f"Malformed Halo confidence event in evidence log at line {line_number}: {error}"
+        ) from error
+    evidence_path = _normalize_evidence_path(
+        payload.get("evidence_path"),
+        validate_exists=validate_evidence_path,
+    )
     evidence_ref = _optional_string(payload.get("evidence_ref"), "evidence_ref")
     evidence_uri = _optional_string(payload.get("evidence_uri"), "evidence_uri")
 
@@ -185,7 +219,11 @@ def _parse_halo_evidence_log_record(
     )
 
 
-def _normalize_evidence_path(raw_value: Any) -> str | None:
+def _normalize_evidence_path(
+    raw_value: Any,
+    *,
+    validate_exists: bool = True,
+) -> str | None:
     if raw_value is None:
         return None
     if isinstance(raw_value, Path):
@@ -199,11 +237,11 @@ def _normalize_evidence_path(raw_value: Any) -> str | None:
         return None
 
     resolved_path = Path(evidence_path).expanduser().resolve()
-    if not resolved_path.exists():
+    if validate_exists and not resolved_path.exists():
         raise HaloEvidenceLogError(
             f"Halo evidence path does not exist: '{resolved_path}'"
         )
-    if not resolved_path.is_file():
+    if validate_exists and not resolved_path.is_file():
         raise HaloEvidenceLogError(
             f"Halo evidence path is not a file: '{resolved_path}'"
         )
@@ -214,10 +252,24 @@ def _normalize_mode(raw_value: Any) -> str:
     mode = _require_non_empty_string(raw_value, "mode").lower()
     if mode not in SUPPORTED_HALO_EVIDENCE_LOG_MODES:
         supported_modes = ", ".join(sorted(SUPPORTED_HALO_EVIDENCE_LOG_MODES))
-        raise HaloEvidenceLogError(
-            f"mode must be one of {supported_modes}"
-        )
+        raise HaloEvidenceLogError(f"mode must be one of {supported_modes}")
     return mode
+
+
+def _require_evidence_handle(
+    *,
+    evidence_path: str | None,
+    evidence_ref: str | None,
+    evidence_uri: str | None,
+) -> None:
+    if (
+        evidence_path is None
+        and evidence_ref is None
+        and evidence_uri is None
+    ):
+        raise HaloEvidenceLogError(
+            "Halo evidence log record requires at least one evidence handle"
+        )
 
 
 def _require_mapping_object(

--- a/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py
@@ -1,0 +1,273 @@
+"""Append-only Halo evidence log records for replayable confidence events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import time
+from typing import Any, Mapping
+
+from .halo_confidence_event import (
+    HaloConfidenceEvent,
+    parse_halo_confidence_event,
+    serialize_halo_confidence_event,
+)
+
+
+HALO_EVIDENCE_LOG_SCHEMA_VERSION = 1
+SUPPORTED_HALO_EVIDENCE_LOG_MODES = {"live", "replay", "evaluation"}
+
+
+class HaloEvidenceLogError(ValueError):
+    """Raised when a Halo evidence log record cannot be written or replayed."""
+
+
+@dataclass(frozen=True)
+class HaloEvidenceLogRecord:
+    """One persisted Halo evidence event plus replay metadata."""
+
+    schema_version: int
+    sequence: int
+    recorded_at_ns: int
+    run_id: str
+    mode: str
+    event: HaloConfidenceEvent
+    evidence_path: str | None = None
+    evidence_ref: str | None = None
+    evidence_uri: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "sequence": self.sequence,
+            "recorded_at_ns": str(self.recorded_at_ns),
+            "run_id": self.run_id,
+            "mode": self.mode,
+            "event": serialize_halo_confidence_event(self.event),
+        }
+        if self.evidence_path is not None:
+            payload["evidence_path"] = self.evidence_path
+        if self.evidence_ref is not None:
+            payload["evidence_ref"] = self.evidence_ref
+        if self.evidence_uri is not None:
+            payload["evidence_uri"] = self.evidence_uri
+        return payload
+
+
+def append_halo_evidence_log_record(
+    log_path: Path | str,
+    event: HaloConfidenceEvent,
+    *,
+    run_id: str,
+    mode: str,
+    evidence_path: Path | str | None = None,
+    recorded_at_ns: int | None = None,
+) -> HaloEvidenceLogRecord:
+    """Append one Halo evidence record to a JSONL log."""
+
+    resolved_log_path = Path(log_path).expanduser().resolve()
+    resolved_evidence_path = _normalize_evidence_path(evidence_path)
+    existing_records = (
+        read_halo_evidence_log(resolved_log_path)
+        if resolved_log_path.exists()
+        else []
+    )
+
+    record = HaloEvidenceLogRecord(
+        schema_version=HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+        sequence=len(existing_records),
+        recorded_at_ns=_require_int(
+            time.time_ns() if recorded_at_ns is None else recorded_at_ns,
+            "recorded_at_ns",
+            minimum=0,
+        ),
+        run_id=_require_non_empty_string(run_id, "run_id"),
+        mode=_normalize_mode(mode),
+        event=event,
+        evidence_path=resolved_evidence_path,
+        evidence_ref=event.evidence_ref,
+        evidence_uri=event.evidence_uri,
+    )
+
+    resolved_log_path.parent.mkdir(parents=True, exist_ok=True)
+    with resolved_log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record.to_dict(), sort_keys=True))
+        log_file.write("\n")
+
+    return record
+
+
+def read_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
+    """Load Halo evidence log records in persisted order."""
+
+    resolved_log_path = Path(log_path).expanduser().resolve()
+    records: list[HaloEvidenceLogRecord] = []
+    with resolved_log_path.open("r", encoding="utf-8") as log_file:
+        for line_number, line in enumerate(log_file, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                raw_payload = json.loads(stripped)
+            except json.JSONDecodeError as error:
+                raise HaloEvidenceLogError(
+                    f"Malformed Halo evidence log record at line {line_number}"
+                ) from error
+            record = _parse_halo_evidence_log_record(
+                raw_payload,
+                line_number=line_number,
+            )
+            if records and record.sequence != records[-1].sequence + 1:
+                raise HaloEvidenceLogError(
+                    "Halo evidence log sequence must increase by 1 in persisted order "
+                    f"at line {line_number}"
+                )
+            records.append(record)
+    return records
+
+
+def replay_halo_evidence_log(log_path: Path | str) -> list[HaloEvidenceLogRecord]:
+    """Replay persisted Halo evidence events without rerunning recognition."""
+
+    return read_halo_evidence_log(log_path)
+
+
+def _parse_halo_evidence_log_record(
+    payload: Any,
+    *,
+    line_number: int,
+) -> HaloEvidenceLogRecord:
+    if not isinstance(payload, Mapping):
+        raise HaloEvidenceLogError(
+            f"Halo evidence log record at line {line_number} must be an object"
+        )
+
+    schema_version = _require_mapping_int(payload, "schema_version", minimum=1)
+    if schema_version != HALO_EVIDENCE_LOG_SCHEMA_VERSION:
+        raise HaloEvidenceLogError(
+            "Unsupported Halo evidence log schema version "
+            f"{schema_version} at line {line_number}"
+        )
+
+    event = parse_halo_confidence_event(_require_mapping_object(payload, "event"))
+    evidence_path = _normalize_evidence_path(payload.get("evidence_path"))
+    evidence_ref = _optional_string(payload.get("evidence_ref"), "evidence_ref")
+    evidence_uri = _optional_string(payload.get("evidence_uri"), "evidence_uri")
+
+    if (
+        evidence_ref is not None
+        and event.evidence_ref is not None
+        and evidence_ref != event.evidence_ref
+    ):
+        raise HaloEvidenceLogError(
+            f"Halo evidence log evidence_ref mismatch at line {line_number}"
+        )
+    if (
+        evidence_uri is not None
+        and event.evidence_uri is not None
+        and evidence_uri != event.evidence_uri
+    ):
+        raise HaloEvidenceLogError(
+            f"Halo evidence log evidence_uri mismatch at line {line_number}"
+        )
+
+    return HaloEvidenceLogRecord(
+        schema_version=schema_version,
+        sequence=_require_mapping_int(payload, "sequence", minimum=0),
+        recorded_at_ns=_require_mapping_int(payload, "recorded_at_ns", minimum=0),
+        run_id=_require_mapping_string(payload, "run_id"),
+        mode=_normalize_mode(payload.get("mode")),
+        event=event,
+        evidence_path=evidence_path,
+        evidence_ref=evidence_ref or event.evidence_ref,
+        evidence_uri=evidence_uri or event.evidence_uri,
+    )
+
+
+def _normalize_evidence_path(raw_value: Any) -> str | None:
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, Path):
+        evidence_path = str(raw_value)
+    elif isinstance(raw_value, str):
+        evidence_path = raw_value
+    else:
+        raise HaloEvidenceLogError("evidence_path must be a string")
+    evidence_path = evidence_path.strip()
+    if not evidence_path:
+        return None
+
+    resolved_path = Path(evidence_path).expanduser().resolve()
+    if not resolved_path.exists():
+        raise HaloEvidenceLogError(
+            f"Halo evidence path does not exist: '{resolved_path}'"
+        )
+    if not resolved_path.is_file():
+        raise HaloEvidenceLogError(
+            f"Halo evidence path is not a file: '{resolved_path}'"
+        )
+    return str(resolved_path)
+
+
+def _normalize_mode(raw_value: Any) -> str:
+    mode = _require_non_empty_string(raw_value, "mode").lower()
+    if mode not in SUPPORTED_HALO_EVIDENCE_LOG_MODES:
+        supported_modes = ", ".join(sorted(SUPPORTED_HALO_EVIDENCE_LOG_MODES))
+        raise HaloEvidenceLogError(
+            f"mode must be one of {supported_modes}"
+        )
+    return mode
+
+
+def _require_mapping_object(
+    payload: Mapping[str, Any],
+    field_name: str,
+) -> Mapping[str, Any]:
+    raw_value = payload.get(field_name)
+    if not isinstance(raw_value, Mapping):
+        raise HaloEvidenceLogError(f"{field_name} must be an object")
+    return raw_value
+
+
+def _require_mapping_string(payload: Mapping[str, Any], field_name: str) -> str:
+    return _require_non_empty_string(payload.get(field_name), field_name)
+
+
+def _require_mapping_int(
+    payload: Mapping[str, Any], field_name: str, *, minimum: int = 0
+) -> int:
+    return _require_int(payload.get(field_name), field_name, minimum=minimum)
+
+
+def _require_non_empty_string(raw_value: Any, field_name: str) -> str:
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        raise HaloEvidenceLogError(f"{field_name} must be a non-empty string")
+    return raw_value.strip()
+
+
+def _optional_string(raw_value: Any, field_name: str) -> str | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, str):
+        raise HaloEvidenceLogError(f"{field_name} must be a string")
+    normalized = raw_value.strip()
+    return normalized or None
+
+
+def _require_int(raw_value: Any, field_name: str, *, minimum: int = 0) -> int:
+    if isinstance(raw_value, bool):
+        raise HaloEvidenceLogError(f"{field_name} must be an integer")
+    if isinstance(raw_value, int):
+        value = raw_value
+    elif isinstance(raw_value, str) and raw_value.strip():
+        try:
+            value = int(raw_value.strip())
+        except ValueError as error:
+            raise HaloEvidenceLogError(f"{field_name} must be an integer") from error
+    else:
+        raise HaloEvidenceLogError(f"{field_name} must be an integer")
+
+    if value < minimum:
+        raise HaloEvidenceLogError(f"{field_name} must be >= {minimum}")
+    return value

--- a/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aeris_perception.halo_confidence_event import (
+    HaloConfidenceEvent,
+    parse_halo_confidence_event,
+)
+from aeris_perception.halo_evidence_log import (
+    HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+    HaloEvidenceLogError,
+    append_halo_evidence_log_record,
+    read_halo_evidence_log,
+    replay_halo_evidence_log,
+)
+
+
+def _event(
+    *,
+    event_id: str = "halo-confidence-001",
+    frame_index: int = 17,
+    timestamp_ns: str = "1717200123456789",
+    evidence_ref: str | None = "capture-017",
+    evidence_uri: str | None = "file:///tmp/halo/capture-017.png",
+) -> HaloConfidenceEvent:
+    event: HaloConfidenceEvent = parse_halo_confidence_event(
+        {
+            "event_id": event_id,
+            "source_id": "camera:halo_front_camera",
+            "source_name": "halo_front_camera",
+            "source_uri": "rtsp://halo/front",
+            "frame_id": "halo_rgb_front",
+            "frame_index": frame_index,
+            "timestamp_ns": timestamp_ns,
+            "label": "Candidate Human Presence",
+            "detection_type": "candidate_human_presence",
+            "confidence": 0.72,
+            "confidence_level": "MEDIUM",
+            "region": {"x": 11, "y": 15, "width": 20, "height": 28},
+            "recognition": {
+                "baseline_name": "halo_rgb_region_baseline",
+                "baseline_version": "0.1.0",
+                "source_timestamp_ns": "1717200123000000",
+                "confidence_components": {"brightness": 0.91, "fill": 0.87},
+            },
+            "evidence_ref": evidence_ref,
+            "evidence_uri": evidence_uri,
+        }
+    )
+    return event
+
+
+def test_append_halo_evidence_log_record_persists_canonical_event_jsonl(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "logs" / "halo_evidence.jsonl"
+    evidence_path = tmp_path / "captures" / "frame-017.png"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"png")
+
+    record = append_halo_evidence_log_record(
+        log_path,
+        _event(),
+        run_id="halo-demo-run",
+        mode="evaluation",
+        evidence_path=evidence_path,
+        recorded_at_ns=1_717_200_555_000_000_001,
+    )
+
+    assert record.schema_version == HALO_EVIDENCE_LOG_SCHEMA_VERSION
+    assert record.sequence == 0
+    assert record.recorded_at_ns == 1_717_200_555_000_000_001
+    assert record.run_id == "halo-demo-run"
+    assert record.mode == "evaluation"
+    assert record.evidence_path == str(evidence_path.resolve())
+    assert record.evidence_ref == "capture-017"
+    assert record.evidence_uri == "file:///tmp/halo/capture-017.png"
+    assert record.event.timestamp_ns == 1_717_200_123_456_789
+
+    raw_records = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert raw_records == [
+        {
+            "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+            "sequence": 0,
+            "recorded_at_ns": "1717200555000000001",
+            "run_id": "halo-demo-run",
+            "mode": "evaluation",
+            "event": record.event.to_dict(),
+            "evidence_path": str(evidence_path.resolve()),
+            "evidence_ref": "capture-017",
+            "evidence_uri": "file:///tmp/halo/capture-017.png",
+        }
+    ]
+
+
+def test_append_halo_evidence_log_record_increments_sequence_and_replays_in_file_order(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    first_evidence = tmp_path / "captures" / "frame-001.png"
+    second_evidence = tmp_path / "captures" / "frame-002.png"
+    first_evidence.parent.mkdir(parents=True)
+    first_evidence.write_bytes(b"frame-1")
+    second_evidence.write_bytes(b"frame-2")
+
+    append_halo_evidence_log_record(
+        log_path,
+        _event(event_id="halo-confidence-001", frame_index=9, timestamp_ns="300"),
+        run_id="halo-live-run",
+        mode="live",
+        evidence_path=first_evidence,
+        recorded_at_ns=900,
+    )
+    append_halo_evidence_log_record(
+        log_path,
+        _event(event_id="halo-confidence-002", frame_index=4, timestamp_ns="100"),
+        run_id="halo-live-run",
+        mode="replay",
+        evidence_path=second_evidence,
+        recorded_at_ns=950,
+    )
+
+    records = read_halo_evidence_log(log_path)
+    replay_records = replay_halo_evidence_log(log_path)
+
+    assert [record.sequence for record in records] == [0, 1]
+    assert [record.event.event_id for record in records] == [
+        "halo-confidence-001",
+        "halo-confidence-002",
+    ]
+    assert [record.event.timestamp_ns for record in replay_records] == [300, 100]
+
+
+def test_append_halo_evidence_log_record_rejects_missing_local_evidence_path(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    missing_path = tmp_path / "captures" / "missing.png"
+
+    with pytest.raises(HaloEvidenceLogError, match="does not exist"):
+        append_halo_evidence_log_record(
+            log_path,
+            _event(),
+            run_id="halo-demo-run",
+            mode="evaluation",
+            evidence_path=missing_path,
+        )
+
+
+def test_read_halo_evidence_log_rejects_unsupported_schema_version(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    evidence_path = tmp_path / "captures" / "frame-017.png"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"png")
+    payload = {
+        "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION + 1,
+        "sequence": 0,
+        "recorded_at_ns": "1717200555000000001",
+        "run_id": "halo-demo-run",
+        "mode": "evaluation",
+        "event": _event().to_dict(),
+        "evidence_path": str(evidence_path.resolve()),
+    }
+    log_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(
+        HaloEvidenceLogError,
+        match="Unsupported Halo evidence log schema version",
+    ):
+        read_halo_evidence_log(log_path)
+
+
+def test_read_halo_evidence_log_rejects_missing_evidence_on_replay(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    payload = {
+        "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+        "sequence": 0,
+        "recorded_at_ns": "1717200555000000001",
+        "run_id": "halo-demo-run",
+        "mode": "evaluation",
+        "event": _event().to_dict(),
+        "evidence_path": str((tmp_path / "captures" / "deleted.png").resolve()),
+    }
+    log_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(HaloEvidenceLogError, match="does not exist"):
+        replay_halo_evidence_log(log_path)
+
+
+def test_read_halo_evidence_log_rejects_partial_record_payload(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                "sequence": 0,
+                "recorded_at_ns": "1717200555000000001",
+                "run_id": "halo-demo-run",
+                "event": _event().to_dict(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HaloEvidenceLogError, match="mode"):
+        read_halo_evidence_log(log_path)

--- a/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import aeris_perception.halo_evidence_log as halo_evidence_log
 from aeris_perception.halo_confidence_event import (
     HaloConfidenceEvent,
     parse_halo_confidence_event,
@@ -138,6 +139,53 @@ def test_append_halo_evidence_log_record_increments_sequence_and_replays_in_file
     assert [record.event.timestamp_ns for record in replay_records] == [300, 100]
 
 
+def test_append_halo_evidence_log_record_uses_advisory_lock_for_sequence_allocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    evidence_path = tmp_path / "captures" / "frame-017.png"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"png")
+    log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                "sequence": 0,
+                "recorded_at_ns": "1717200555000000001",
+                "run_id": "halo-demo-run",
+                "mode": "evaluation",
+                "event": _event().to_dict(),
+                "evidence_path": str(evidence_path.resolve()),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    lock_modes: list[int] = []
+
+    def _fake_flock(file_descriptor: int, operation: int) -> None:
+        assert file_descriptor >= 0
+        lock_modes.append(operation)
+
+    monkeypatch.setattr(halo_evidence_log.fcntl, "flock", _fake_flock)
+
+    record = append_halo_evidence_log_record(
+        log_path,
+        _event(event_id="halo-confidence-002"),
+        run_id="halo-demo-run",
+        mode="evaluation",
+        evidence_path=evidence_path,
+        recorded_at_ns=1_717_200_555_000_000_002,
+    )
+
+    assert record.sequence == 1
+    assert lock_modes == [
+        halo_evidence_log.fcntl.LOCK_EX,
+        halo_evidence_log.fcntl.LOCK_UN,
+    ]
+
+
 def test_append_halo_evidence_log_record_rejects_missing_local_evidence_path(
     tmp_path: Path,
 ) -> None:
@@ -193,7 +241,7 @@ def test_read_halo_evidence_log_rejects_unsupported_schema_version(
         read_halo_evidence_log(log_path)
 
 
-def test_read_halo_evidence_log_rejects_missing_evidence_on_replay(
+def test_read_halo_evidence_log_rejects_missing_evidence_but_replay_keeps_record(
     tmp_path: Path,
 ) -> None:
     log_path = tmp_path / "halo_evidence.jsonl"
@@ -209,7 +257,14 @@ def test_read_halo_evidence_log_rejects_missing_evidence_on_replay(
     log_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
     with pytest.raises(HaloEvidenceLogError, match="does not exist"):
-        replay_halo_evidence_log(log_path)
+        read_halo_evidence_log(log_path)
+
+    replay_records = replay_halo_evidence_log(log_path)
+
+    assert len(replay_records) == 1
+    assert replay_records[0].evidence_path == payload["evidence_path"]
+    assert replay_records[0].evidence_ref == "capture-017"
+    assert replay_records[0].evidence_uri == "file:///tmp/halo/capture-017.png"
 
 
 def test_read_halo_evidence_log_requires_first_sequence_to_start_at_zero(

--- a/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
@@ -154,6 +154,20 @@ def test_append_halo_evidence_log_record_rejects_missing_local_evidence_path(
         )
 
 
+def test_append_halo_evidence_log_record_requires_at_least_one_evidence_handle(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+
+    with pytest.raises(HaloEvidenceLogError, match="evidence handle"):
+        append_halo_evidence_log_record(
+            log_path,
+            _event(evidence_ref=None, evidence_uri=None),
+            run_id="halo-demo-run",
+            mode="evaluation",
+        )
+
+
 def test_read_halo_evidence_log_rejects_unsupported_schema_version(
     tmp_path: Path,
 ) -> None:
@@ -196,6 +210,100 @@ def test_read_halo_evidence_log_rejects_missing_evidence_on_replay(
 
     with pytest.raises(HaloEvidenceLogError, match="does not exist"):
         replay_halo_evidence_log(log_path)
+
+
+def test_read_halo_evidence_log_requires_first_sequence_to_start_at_zero(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    evidence_path = tmp_path / "captures" / "frame-017.png"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"png")
+    log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                "sequence": 5,
+                "recorded_at_ns": "1717200555000000001",
+                "run_id": "halo-demo-run",
+                "mode": "evaluation",
+                "event": _event().to_dict(),
+                "evidence_path": str(evidence_path.resolve()),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HaloEvidenceLogError, match="start at sequence 0"):
+        read_halo_evidence_log(log_path)
+
+
+def test_read_halo_evidence_log_wraps_invalid_nested_event_with_line_context(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    evidence_path = tmp_path / "captures" / "frame-017.png"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"png")
+    invalid_event = _event().to_dict()
+    invalid_event.pop("source_id")
+    log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                "sequence": 0,
+                "recorded_at_ns": "1717200555000000001",
+                "run_id": "halo-demo-run",
+                "mode": "evaluation",
+                "event": invalid_event,
+                "evidence_path": str(evidence_path.resolve()),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HaloEvidenceLogError, match="line 1"):
+        read_halo_evidence_log(log_path)
+
+
+def test_append_halo_evidence_log_record_ignores_missing_historical_evidence_for_sequence(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "halo_evidence.jsonl"
+    current_evidence_path = tmp_path / "captures" / "frame-018.png"
+    current_evidence_path.parent.mkdir(parents=True)
+    current_evidence_path.write_bytes(b"png")
+    log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": HALO_EVIDENCE_LOG_SCHEMA_VERSION,
+                "sequence": 0,
+                "recorded_at_ns": "1717200555000000001",
+                "run_id": "halo-demo-run",
+                "mode": "evaluation",
+                "event": _event().to_dict(),
+                "evidence_path": str((tmp_path / "captures" / "deleted.png").resolve()),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    record = append_halo_evidence_log_record(
+        log_path,
+        _event(event_id="halo-confidence-002"),
+        run_id="halo-demo-run",
+        mode="evaluation",
+        evidence_path=current_evidence_path,
+        recorded_at_ns=1_717_200_555_000_000_002,
+    )
+
+    assert record.sequence == 1
+    assert len(log_path.read_text(encoding="utf-8").splitlines()) == 2
+    with pytest.raises(HaloEvidenceLogError, match="does not exist"):
+        read_halo_evidence_log(log_path)
 
 
 def test_read_halo_evidence_log_rejects_partial_record_payload(

--- a/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
+++ b/software/edge/src/aeris_perception/test/test_halo_evidence_log.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import fcntl
 import json
 from pathlib import Path
 
 import pytest
 
-import aeris_perception.halo_evidence_log as halo_evidence_log
 from aeris_perception.halo_confidence_event import (
     HaloConfidenceEvent,
     parse_halo_confidence_event,
@@ -168,7 +168,7 @@ def test_append_halo_evidence_log_record_uses_advisory_lock_for_sequence_allocat
         assert file_descriptor >= 0
         lock_modes.append(operation)
 
-    monkeypatch.setattr(halo_evidence_log.fcntl, "flock", _fake_flock)
+    monkeypatch.setattr(fcntl, "flock", _fake_flock)
 
     record = append_halo_evidence_log_record(
         log_path,
@@ -181,8 +181,8 @@ def test_append_halo_evidence_log_record_uses_advisory_lock_for_sequence_allocat
 
     assert record.sequence == 1
     assert lock_modes == [
-        halo_evidence_log.fcntl.LOCK_EX,
-        halo_evidence_log.fcntl.LOCK_UN,
+        fcntl.LOCK_EX,
+        fcntl.LOCK_UN,
     ]
 
 


### PR DESCRIPTION
## Summary
- add a lightweight Halo evidence log module that persists canonical confidence events as append-only JSONL records
- validate local evidence files before write and on replay, while preserving run metadata and nested event timestamp precision
- add focused tests for append order, schema/version validation, missing evidence, and replay parsing

## Testing
- PYTHONPATH=software/edge/src/aeris_perception:software/edge/src/aeris_msgs python3 -m pytest software/edge/src/aeris_perception/test/test_halo_confidence_event.py software/edge/src/aeris_perception/test/test_halo_evidence_log.py software/edge/src/aeris_msgs/test -q
- python3 -m compileall software/edge/src/aeris_perception/aeris_perception

Closes #125

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new append-only JSONL evidence log module for Halo detection events, plus a focused test suite. The implementation addresses all four issues raised in prior review threads: sequence-0 validation, advisory file locking for concurrent appenders, a distinct `replay_halo_evidence_log` that skips evidence path validation, and skipping evidence-path existence checks on historical records during sequence counting.

- `halo_evidence_log.py` provides `append_halo_evidence_log_record`, `read_halo_evidence_log`, and `replay_halo_evidence_log` backed by a shared internal reader that takes a `validate_evidence_paths` flag, with `fcntl.flock` protecting the read-count-write cycle.
- `test_halo_evidence_log.py` covers append order, sequence continuity, schema/version rejection, missing evidence, advisory lock call sequence, and the read-vs-replay divergence on stale paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — new self-contained module with no regressions to existing code and all previous review concerns addressed.

All four issues from previous review threads are properly resolved: sequence-0 enforcement, fcntl.flock for concurrent writers, distinct replay_halo_evidence_log that skips evidence path validation, and validate_evidence_paths=False when reading historical records for sequence counting. No new correctness issues were found after reading the full implementation and its dependency halo_confidence_event.py.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/edge/src/aeris_perception/aeris_perception/halo_evidence_log.py | New append-only JSONL log module with fcntl advisory locking, sequence-0 validation, and separate read/replay semantics; all previously flagged issues are resolved. |
| software/edge/src/aeris_perception/test/test_halo_evidence_log.py | Focused test suite covering append ordering, schema validation, missing evidence path handling, lock acquisition sequence, and replay vs. read divergence. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant A as append_halo_evidence_log_record
    participant F as JSONL File (fcntl lock)
    participant R as read_halo_evidence_log
    participant P as replay_halo_evidence_log

    C->>A: append(log_path, event, run_id, mode, evidence_path)
    A->>A: "_normalize_evidence_path(validate_exists=True)"
    A->>A: _require_evidence_handle(path/ref/uri)
    A->>F: open(a+) + LOCK_EX
    A->>F: "seek(0) → _read_halo_evidence_log_file(validate_evidence_paths=False)"
    F-->>A: existing_records (no path existence checks)
    A->>A: "build HaloEvidenceLogRecord(sequence=len(existing_records))"
    A->>F: seek(0,2) → write JSON line → flush
    A->>F: LOCK_UN
    A-->>C: HaloEvidenceLogRecord

    C->>R: read_halo_evidence_log(log_path)
    R->>F: "open(r) → _read_halo_evidence_log_file(validate_evidence_paths=True)"
    F-->>R: parse + validate sequence starts at 0, contiguous
    Note over F,R: Raises if evidence_path does not exist on disk
    R-->>C: list[HaloEvidenceLogRecord]

    C->>P: replay_halo_evidence_log(log_path)
    P->>F: "open(r) → _read_halo_evidence_log_file(validate_evidence_paths=False)"
    F-->>P: parse + validate sequence (no path existence checks)
    P-->>C: list[HaloEvidenceLogRecord]
```

<sub>Reviews (2): Last reviewed commit: ["Clean up Halo evidence log test imports"](https://github.com/aeris-drones/aeris/commit/b638ea712d143b83eeeb844e55157f7c631a14ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34744212)</sub>

<!-- /greptile_comment -->