### PR TITLE
Add Halo detection demo surface to GCS

### DIFF
--- a/software/viewer/src/app/icViewModeSurface.test.mjs
+++ b/software/viewer/src/app/icViewModeSurface.test.mjs
@@ -89,6 +89,7 @@ fs.writeFileSync(path.join(RENDER_TEMP_ROOT, "lucide-react.mjs"), `
   export const BatteryMedium = icon("BatteryMedium");
   export const BatteryWarning = icon("BatteryWarning");
   export const Bell = icon("Bell");
+  export const Camera = icon("Camera");
   export const Check = icon("Check");
   export const ChevronRight = icon("ChevronRight");
   export const Crosshair = icon("Crosshair");

--- a/software/viewer/src/app/page.tsx
+++ b/software/viewer/src/app/page.tsx
@@ -27,6 +27,7 @@ import { Switch } from '@/components/ui/switch';
 import { useMissionControl } from '@/hooks/useMissionControl';
 import { useVehicleTelemetry } from '@/hooks/useVehicleTelemetry';
 import { useFusedDetections } from '@/hooks/useFusedDetections';
+import { useHaloDetections } from '@/hooks/useHaloDetections';
 import { applyDetectionStatusOverrides, computeDetectionCounts } from '@/lib/detectionViewState';
 import { normalizeVehicleId } from '@/lib/missionProgressVehicleMeta';
 import { applyVehicleMissionMeta } from '@/lib/fleetVehicleProjection';
@@ -41,6 +42,7 @@ import {
   deriveRouteRecommendations,
 } from '@/lib/routeRecommendations';
 import { ViewerAppProviders } from '@/app/ViewerAppProviders';
+import { normalizeHaloEvidenceReplayPayload } from '@/lib/ros/haloConfidenceEvents';
 
 /**
  * Mock detections for UI demonstration when ROS telemetry is unavailable.
@@ -72,9 +74,41 @@ const mockDetections: Detection[] = [
     vehicleId: 'ranger-1', vehicleName: 'Ranger 1', position: [-150, 0, -80],
     temperature: 36.8, sector: 'Sector A-3', signatureType: 'Possible survivor'
   },
+  ...normalizeHaloEvidenceReplayPayload([
+    {
+      schema_version: 1,
+      sequence: 0,
+      recorded_at_ns: String((Date.now() - 90000) * 1_000_000),
+      run_id: 'halo-demo-run',
+      mode: 'replay',
+      evidence_path: '/tmp/halo/capture-017.png',
+      evidence_ref: 'evidence-017',
+      evidence_uri: 'file:///tmp/halo/capture-017.png',
+      event: {
+        event_id: 'halo-confidence-demo-001',
+        source_id: 'camera:halo_front_camera',
+        source_name: 'Halo Front Camera',
+        source_uri: 'rtsp://halo/front',
+        frame_id: 'halo_rgb_front',
+        frame_index: 21,
+        timestamp_ns: String((Date.now() - 180000) * 1_000_000),
+        label: 'Possible Survivor',
+        detection_type: 'candidate_human_presence',
+        confidence: 0.91,
+        confidence_level: 'HIGH',
+        location_hint: { label: 'Zone E-2', x: 12.5, y: 0, z: -6 },
+        recognition: {
+          baseline_name: 'halo_rgb_region_baseline',
+          baseline_version: '0.1.0',
+          confidence_components: { shape: 0.89, motion: 0.94 },
+        },
+      },
+    },
+  ]),
 ];
 
 const MOCK_ALERT_IDS = ['demo-critical', 'demo-warning'] as const;
+const DETECTION_STALE_TIMEOUT_MS = 2 * 60 * 1000;
 
 /**
  * Root page component for the Aeris GCS.
@@ -163,6 +197,10 @@ function V2PageContent() {
     detections: liveFusedDetections,
     isConnected: fusedFeedConnected,
   } = useFusedDetections(telemetryVehicles);
+  const {
+    detections: liveHaloDetections,
+    isConnected: haloFeedConnected,
+  } = useHaloDetections();
   const allowMockFallback =
     process.env.NODE_ENV !== 'production' && !rosConnected;
 
@@ -202,16 +240,22 @@ function V2PageContent() {
 
   const baseDetections = useMemo<Detection[]>(
     () => {
-      if (fusedFeedConnected) {
-        return liveFusedDetections;
+      if (fusedFeedConnected || haloFeedConnected) {
+        return [...liveFusedDetections, ...liveHaloDetections].sort(
+          (left, right) => right.timestamp - left.timestamp
+        );
       }
       return allowMockFallback ? mockDetections : [];
     },
-    [allowMockFallback, fusedFeedConnected, liveFusedDetections]
+    [allowMockFallback, fusedFeedConnected, haloFeedConnected, liveFusedDetections, liveHaloDetections]
   );
   const detections = useMemo<Detection[]>(
-    () => applyDetectionStatusOverrides(baseDetections, detectionStatusOverrides),
-    [baseDetections, detectionStatusOverrides]
+    () =>
+      applyDetectionStatusOverrides(baseDetections, detectionStatusOverrides).map((detection) => ({
+        ...detection,
+        isStale: routeNowMs - detection.timestamp >= DETECTION_STALE_TIMEOUT_MS,
+      })),
+    [baseDetections, detectionStatusOverrides, routeNowMs]
   );
 
   useEffect(() => {
@@ -774,6 +818,7 @@ function V2PageContent() {
                   thermalCount={detectionCounts.thermal}
                   acousticCount={detectionCounts.acoustic}
                   gasCount={detectionCounts.gas}
+                  rgbCount={detectionCounts.rgb}
                   pendingCount={detectionCounts.pending}
                   confirmedCount={detectionCounts.confirmed}
                   viewMode={icViewModeEnabled ? 'ic' : 'operator'}

--- a/software/viewer/src/components/cards/DetectionsCard.tsx
+++ b/software/viewer/src/components/cards/DetectionsCard.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Flame, AudioLines, Wind, ChevronRight } from 'lucide-react';
+import { Flame, AudioLines, Wind, Camera, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils';
  */
 export interface Detection {
   id: string;
-  sensorType: 'thermal' | 'acoustic' | 'gas';
+  sensorType: 'thermal' | 'acoustic' | 'gas' | 'rgb';
   confidence: number;
   timestamp: number;
   status: 'new' | 'reviewing' | 'confirmed' | 'dismissed';
@@ -21,6 +21,7 @@ export interface DetectionsCardProps {
   thermalCount: number;
   acousticCount: number;
   gasCount: number;
+  rgbCount?: number;
   pendingCount: number;
   confirmedCount: number;
   latestDetection?: Detection;
@@ -53,6 +54,12 @@ const sensorConfig = {
     bg: 'bg-yellow-500/20',
     label: 'Gas'
   },
+  rgb: {
+    Icon: Camera,
+    color: 'text-fuchsia-400',
+    bg: 'bg-fuchsia-500/20',
+    label: 'RGB'
+  },
 };
 
 /**
@@ -74,11 +81,12 @@ export function DetectionsCard({
   thermalCount,
   acousticCount,
   gasCount,
+  rgbCount = 0,
   pendingCount,
   confirmedCount,
   viewMode = 'operator',
 }: DetectionsCardProps) {
-  const totalCount = thermalCount + acousticCount + gasCount;
+  const totalCount = thermalCount + acousticCount + gasCount + rgbCount;
   const hasPending = pendingCount > 0;
   const isIcMode = viewMode === 'ic';
 
@@ -122,6 +130,13 @@ export function DetectionsCard({
           <Wind className={cn('h-4 w-4', sensorConfig.gas.color)} />
           <span className={cn('font-mono font-bold', sensorConfig.gas.color, isIcMode ? 'text-xl' : 'text-sm')}>
             {gasCount}
+          </span>
+        </div>
+
+        <div className={cn('flex items-center gap-1.5 rounded-lg px-2.5 py-0.5', sensorConfig.rgb.bg)}>
+          <Camera className={cn('h-4 w-4', sensorConfig.rgb.color)} />
+          <span className={cn('font-mono font-bold', sensorConfig.rgb.color, isIcMode ? 'text-xl' : 'text-sm')}>
+            {rgbCount}
           </span>
         </div>
       </div>

--- a/software/viewer/src/components/layout/StatusPill.tsx
+++ b/software/viewer/src/components/layout/StatusPill.tsx
@@ -21,6 +21,7 @@ export interface DetectionStatusCounts {
   thermal: number;
   acoustic: number;
   gas: number;
+  rgb?: number;
   pending: number;
   confirmed: number;
 }
@@ -122,9 +123,11 @@ export function StatusPill({
     thermal: 0,
     acoustic: 0,
     gas: 0,
+    rgb: 0,
     pending: 0,
     confirmed: 0,
   };
+  const rgbCount = Number.isFinite(liveDetections.rgb) ? liveDetections.rgb : 0;
   const isIcMode = viewMode === 'ic';
 
   return (
@@ -209,6 +212,7 @@ export function StatusPill({
         <span className={cn('font-mono text-orange-400', isIcMode ? 'text-2xl' : 'text-xs')}>T{liveDetections.thermal}</span>
         <span className={cn('font-mono text-sky-400', isIcMode ? 'text-2xl' : 'text-xs')}>A{liveDetections.acoustic}</span>
         <span className={cn('font-mono text-amber-400', isIcMode ? 'text-2xl' : 'text-xs')}>G{liveDetections.gas}</span>
+        <span className={cn('font-mono text-fuchsia-400', isIcMode ? 'text-2xl' : 'text-xs')}>R{rgbCount}</span>
         <span className="text-white/25">|</span>
         <span className={cn('font-mono text-emerald-400', isIcMode ? 'text-2xl' : 'text-xs')}>P{liveDetections.pending}</span>
         <span className={cn('font-mono', isIcMode ? 'text-2xl text-white' : 'text-xs text-white/70')}>C{liveDetections.confirmed}</span>

--- a/software/viewer/src/components/map/DetectionMarker3D.tsx
+++ b/software/viewer/src/components/map/DetectionMarker3D.tsx
@@ -12,7 +12,7 @@ export interface DetectionMarker3DProps {
   /** World position [x, y, z] - typically y=0 for ground-level detections */
   position: [number, number, number];
   /** Sensor type - determines marker shape and color */
-  sensorType: 'thermal' | 'acoustic' | 'gas';
+  sensorType: 'thermal' | 'acoustic' | 'gas' | 'rgb';
   /** Detection confidence score (0-1) */
   confidence: number;
   /** Review status - drives animation and visual emphasis */
@@ -34,6 +34,7 @@ const SENSOR_COLORS = {
   thermal: '#f97316',
   acoustic: '#3b82f6',
   gas: '#eab308',
+  rgb: '#d946ef',
 };
 
 /** Human-readable labels for sensor types - displayed in the marker UI */
@@ -41,6 +42,7 @@ const SENSOR_LABELS = {
   thermal: 'THERMAL',
   acoustic: 'ACOUSTIC',
   gas: 'GAS',
+  rgb: 'RGB',
 };
 
 /**
@@ -122,6 +124,8 @@ export function DetectionMarker3D({
         return <coneGeometry args={[6, 10, 8]} />;
       case 'gas':
         return <octahedronGeometry args={[7]} />;
+      case 'rgb':
+        return <boxGeometry args={[10, 10, 10]} />;
     }
   }, [sensorType]);
 

--- a/software/viewer/src/components/sheets/DetectionCard.tsx
+++ b/software/viewer/src/components/sheets/DetectionCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { Flame, AudioLines, Wind, Crosshair, Check, X, MapPin, History } from 'lucide-react';
+import { Flame, AudioLines, Wind, Camera, Crosshair, Check, X, MapPin, History, TimerReset } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getConfidenceTextClass } from '@/lib/detectionViewState';
 
@@ -21,7 +21,7 @@ import { getConfidenceTextClass } from '@/lib/detectionViewState';
  */
 export interface Detection {
   id: string;
-  sensorType: 'thermal' | 'acoustic' | 'gas';
+  sensorType: 'thermal' | 'acoustic' | 'gas' | 'rgb';
   confidence: number;
   confidenceLevel?: 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN';
   timestamp: number;
@@ -29,7 +29,7 @@ export interface Detection {
   vehicleId: string;
   vehicleName: string;
   position: [number, number, number];
-  sourceModalities?: Array<'thermal' | 'acoustic' | 'gas'>;
+  sourceModalities?: Array<'thermal' | 'acoustic' | 'gas' | 'rgb'>;
   geometry?: [number, number, number][];
   temperature?: number;
   decibels?: number;
@@ -41,6 +41,10 @@ export interface Detection {
   originalEventTs?: number;
   replayedAtTs?: number;
   isRetroactive?: boolean;
+  isStale?: boolean;
+  evidenceRef?: string;
+  evidencePath?: string;
+  evidenceUri?: string;
 }
 
 export interface DetectionCardProps {
@@ -61,6 +65,7 @@ const sensorConfig = {
   thermal: { Icon: Flame, color: 'text-orange-400', bg: 'bg-orange-500/10', label: 'Thermal' },
   acoustic: { Icon: AudioLines, color: 'text-sky-400', bg: 'bg-sky-500/10', label: 'Acoustic' },
   gas: { Icon: Wind, color: 'text-amber-400', bg: 'bg-amber-500/10', label: 'Gas' },
+  rgb: { Icon: Camera, color: 'text-fuchsia-400', bg: 'bg-fuchsia-500/10', label: 'RGB' },
 };
 
 function formatTime(timestamp: number): string {
@@ -82,6 +87,8 @@ function getReading(detection: Detection): string {
       return hasFiniteValue(detection.decibels) ? `${detection.decibels}dB` : '--';
     case 'gas':
       return hasFiniteValue(detection.concentration) ? `${detection.concentration}ppm` : '--';
+    case 'rgb':
+      return detection.evidenceRef ?? detection.evidencePath ?? detection.evidenceUri ?? '--';
   }
 }
 
@@ -101,6 +108,8 @@ function getDefaultSignature(detection: Detection): string {
       return conf > 0.85 ? 'Voice detected' : conf > 0.6 ? 'Movement sounds' : 'Audio anomaly';
     case 'gas':
       return conf > 0.85 ? 'Hazardous levels' : conf > 0.6 ? 'Elevated concentration' : 'Trace detected';
+    case 'rgb':
+      return conf > 0.85 ? 'RGB survivor candidate' : conf > 0.6 ? 'RGB anomaly' : 'RGB review needed';
   }
 }
 
@@ -133,6 +142,24 @@ export function DetectionCard({
   const reading = getReading(detection);
   const isRetroactive =
     detection.deliveryMode === 'replayed' || detection.isRetroactive === true;
+  const isStale = detection.isStale === true;
+  const evidenceHandles = [
+    detection.evidenceRef
+      ? { label: 'Ref', value: detection.evidenceRef }
+      : null,
+    detection.evidencePath
+      ? { label: 'Path', value: detection.evidencePath }
+      : null,
+    detection.evidenceUri
+      ? { label: 'URI', value: detection.evidenceUri }
+      : null,
+  ].filter((handle): handle is { label: string; value: string } => handle !== null);
+  const sourceLabel = isRetroactive ? 'Replayed' : isStale ? 'Stale' : 'Live';
+  const sourceTextClass = isRetroactive
+    ? 'text-cyan-300'
+    : isStale
+      ? 'text-amber-300'
+      : 'text-emerald-300';
 
   // Derive sector from ENU coordinates when not explicitly provided
   const sector = detection.sector || `Zone ${detection.position[0] > 0 ? 'E' : 'W'}-${Math.abs(Math.round(detection.position[2] / 50))}`;
@@ -173,6 +200,11 @@ export function DetectionCard({
             <History className="h-3 w-3" /> Retroactive
           </span>
         )}
+        {isStale && (
+          <span className="px-2 py-0.5 rounded bg-amber-500/15 text-amber-300 text-base font-medium uppercase flex items-center gap-1">
+            <TimerReset className="h-3 w-3" /> Stale
+          </span>
+        )}
 
         <div className="flex-1" />
 
@@ -188,8 +220,8 @@ export function DetectionCard({
           <span>·</span>
           <span>{detection.vehicleName}</span>
           <span>·</span>
-          <span className={cn(isRetroactive ? 'text-cyan-300' : 'text-emerald-300')}>
-            {isRetroactive ? 'Replayed' : 'Live'}
+          <span className={cn(sourceTextClass)}>
+            {sourceLabel}
           </span>
           <span>·</span>
           <span className="font-mono">{reading}</span>
@@ -201,6 +233,20 @@ export function DetectionCard({
           <span className="text-white/20">|</span>
           <span className="text-white/80">{signature}</span>
         </div>
+
+        {evidenceHandles.length > 0 && (
+          <div className="flex flex-wrap gap-2 text-[11px] text-white/55">
+            {evidenceHandles.map((handle) => (
+              <span
+                key={`${detection.id}-${handle.label}`}
+                className="max-w-full rounded border border-white/10 bg-white/[0.03] px-2 py-1 font-mono"
+              >
+                <span className="mr-1 text-white/35">{handle.label}</span>
+                <span className="break-all">{handle.value}</span>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {isActionable && (

--- a/software/viewer/src/components/sheets/DetectionCardSurface.test.mjs
+++ b/software/viewer/src/components/sheets/DetectionCardSurface.test.mjs
@@ -1,0 +1,116 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-detection-card-render-"));
+const VIEWER_NODE_MODULES = path.resolve(ROOT, "..", "..", "..", "node_modules");
+
+after(() => {
+  fs.rmSync(TEMP_ROOT, { recursive: true, force: true });
+});
+
+fs.symlinkSync(VIEWER_NODE_MODULES, path.join(TEMP_ROOT, "node_modules"), "dir");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "button.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  export function Button({ children, className = "", ...props }) {
+    return _jsx("button", { className, ...props, children });
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "utils.mjs"), `
+  export function cn(...values) {
+    return values.flatMap((value) => Array.isArray(value) ? value : [value]).filter(Boolean).join(" ");
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "detectionViewState.mjs"), `
+  export function getConfidenceTextClass() {
+    return "text-emerald-400";
+  }
+`, "utf8");
+
+fs.writeFileSync(path.join(TEMP_ROOT, "lucide-react.mjs"), `
+  import { jsx as _jsx } from "react/jsx-runtime";
+  function icon(name) {
+    return function Icon({ className = "", ...props }) {
+      return _jsx("svg", { "data-icon": name, className, ...props });
+    };
+  }
+  export const AudioLines = icon("AudioLines");
+  export const Camera = icon("Camera");
+  export const Check = icon("Check");
+  export const Crosshair = icon("Crosshair");
+  export const Flame = icon("Flame");
+  export const History = icon("History");
+  export const MapPin = icon("MapPin");
+  export const TimerReset = icon("TimerReset");
+  export const Wind = icon("Wind");
+  export const X = icon("X");
+`, "utf8");
+
+async function renderCard(props) {
+  const sourcePath = path.join(ROOT, "DetectionCard.tsx");
+  let source = fs.readFileSync(sourcePath, "utf8");
+  source = source
+    .replaceAll("@/components/ui/button", "./button.mjs")
+    .replaceAll("@/lib/utils", "./utils.mjs")
+    .replaceAll("@/lib/detectionViewState", "./detectionViewState.mjs")
+    .replaceAll("lucide-react", "./lucide-react.mjs");
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  }).outputText;
+
+  const modulePath = path.join(TEMP_ROOT, `DetectionCard-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`);
+  fs.writeFileSync(modulePath, compiled, "utf8");
+  const { DetectionCard } = await import(pathToFileURL(modulePath).href);
+  return renderToStaticMarkup(createElement(DetectionCard, props));
+}
+
+test("DetectionCard surfaces Halo evidence handles and replay/stale provenance", async () => {
+  const markup = await renderCard({
+    detection: {
+      id: "halo-confidence-001",
+      sensorType: "rgb",
+      confidence: 0.91,
+      confidenceLevel: "HIGH",
+      timestamp: Date.now() - (3 * 60 * 1000),
+      status: "new",
+      vehicleId: "camera:halo_front_camera",
+      vehicleName: "Halo Front Camera",
+      position: [12.5, 0, -6],
+      sourceModalities: ["rgb"],
+      sector: "Zone E-2",
+      signatureType: "Possible Survivor",
+      deliveryMode: "replayed",
+      isRetroactive: true,
+      isStale: true,
+      evidenceRef: "evidence-017",
+      evidencePath: "/tmp/halo/capture-017.png",
+      evidenceUri: "file:///tmp/halo/capture-017.png",
+    },
+    isNew: true,
+    onConfirm: () => {},
+    onDismiss: () => {},
+    onLocate: () => {},
+  });
+
+  assert.match(markup, /Replayed/);
+  assert.match(markup, /Stale/);
+  assert.match(markup, /evidence-017/);
+  assert.match(markup, /\/tmp\/halo\/capture-017\.png/);
+  assert.match(markup, /file:\/\/\/tmp\/halo\/capture-017\.png/);
+  assert.match(markup, /Possible Survivor/);
+});

--- a/software/viewer/src/components/sheets/DetectionCardSurface.test.mjs
+++ b/software/viewer/src/components/sheets/DetectionCardSurface.test.mjs
@@ -114,3 +114,30 @@ test("DetectionCard surfaces Halo evidence handles and replay/stale provenance",
   assert.match(markup, /file:\/\/\/tmp\/halo\/capture-017\.png/);
   assert.match(markup, /Possible Survivor/);
 });
+
+test("DetectionCard keeps stale-only provenance distinct from replayed detections", async () => {
+  const markup = await renderCard({
+    detection: {
+      id: "halo-confidence-002",
+      sensorType: "rgb",
+      confidence: 0.64,
+      confidenceLevel: "MEDIUM",
+      timestamp: Date.now() - (4 * 60 * 1000),
+      status: "reviewing",
+      vehicleId: "camera:halo_rear_camera",
+      vehicleName: "Halo Rear Camera",
+      position: [4, 0, 8],
+      sourceModalities: ["rgb"],
+      sector: "Zone W-1",
+      signatureType: "Scene Change",
+      isStale: true,
+    },
+    isNew: false,
+    onConfirm: () => {},
+    onDismiss: () => {},
+    onLocate: () => {},
+  });
+
+  assert.match(markup, /Stale/);
+  assert.doesNotMatch(markup, /Replayed/);
+});

--- a/software/viewer/src/hooks/useHaloDetections.test.mjs
+++ b/software/viewer/src/hooks/useHaloDetections.test.mjs
@@ -57,7 +57,7 @@ const compiled = ts.transpileModule(
 const modulePath = path.join(tempDir, "useHaloDetections.mjs");
 fs.writeFileSync(modulePath, compiled, "utf8");
 
-const { normalizeHaloInboundPayload } = await import(pathToFileURL(modulePath).href);
+const { mergeHaloDetectionBatch, normalizeHaloInboundPayload } = await import(pathToFileURL(modulePath).href);
 
 test("normalizeHaloInboundPayload parses pretty-printed JSON before falling back to JSONL", () => {
   const prettyPrintedEnvelope = JSON.stringify({
@@ -111,5 +111,46 @@ test("normalizeHaloInboundPayload guards against runaway doubly-encoded string r
   assert.throws(
     () => normalizeHaloInboundPayload({ data: doublyEncoded }),
     /depth/i
+  );
+});
+
+test("mergeHaloDetectionBatch preserves multiple old replay detections from one inbound batch", () => {
+  const nowMs = 1_800_000_000_000;
+  const previous = [
+    {
+      id: "live-current",
+      timestamp: nowMs - 5_000,
+      deliveryMode: "live",
+    },
+    {
+      id: "stale-live",
+      timestamp: nowMs - (20 * 60 * 1000),
+      deliveryMode: "live",
+    },
+  ];
+  const incomingReplayBatch = [
+    {
+      id: "replay-1",
+      timestamp: nowMs - (30 * 60 * 1000),
+      deliveryMode: "replayed",
+      isRetroactive: true,
+    },
+    {
+      id: "replay-2",
+      timestamp: nowMs - (31 * 60 * 1000),
+      deliveryMode: "replayed",
+      isRetroactive: true,
+    },
+  ];
+
+  const merged = mergeHaloDetectionBatch(previous, incomingReplayBatch, {
+    nowMs,
+    maxAgeMs: 10 * 60 * 1000,
+    maxDetections: 10,
+  });
+
+  assert.deepEqual(
+    merged.map((detection) => detection.id),
+    ["live-current", "replay-1", "replay-2"]
   );
 });

--- a/software/viewer/src/hooks/useHaloDetections.test.mjs
+++ b/software/viewer/src/hooks/useHaloDetections.test.mjs
@@ -1,0 +1,115 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import ts from "typescript";
+import { pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(new URL(".", import.meta.url).pathname);
+const sourcePath = path.join(ROOT, "useHaloDetections.ts");
+const source = fs.readFileSync(sourcePath, "utf8");
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aeris-halo-detections-"));
+
+after(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+fs.writeFileSync(path.join(tempDir, "react.mjs"), `
+  export function useEffect() {}
+  export function useState(initial) { return [initial, () => {}]; }
+`, "utf8");
+
+fs.writeFileSync(path.join(tempDir, "roslib.mjs"), `export default { Topic: class Topic {} };`, "utf8");
+fs.writeFileSync(path.join(tempDir, "context.mjs"), `export function useSharedROSConnection() { return { ros: null, isConnected: false }; }`, "utf8");
+fs.writeFileSync(path.join(tempDir, "haloConfidenceEvents.mjs"), `
+  export function normalizeHaloConfidenceEventMessage(value) {
+    return { kind: "event", value };
+  }
+  export function normalizeHaloEvidenceLogRecord(value) {
+    return { kind: "record", value };
+  }
+  export function normalizeHaloEvidenceReplayPayload(value) {
+    return [{ kind: "jsonl", value }];
+  }
+`, "utf8");
+fs.writeFileSync(path.join(tempDir, "fusedDetectionsFeed.mjs"), `
+  export function mergeLiveDetections(previous, incoming) {
+    return [...previous, incoming];
+  }
+`, "utf8");
+
+const compiled = ts.transpileModule(
+  source
+    .replaceAll("react", "./react.mjs")
+    .replaceAll("roslib", "./roslib.mjs")
+    .replaceAll("@/context/ROSConnectionContext", "./context.mjs")
+    .replaceAll("@/lib/ros/haloConfidenceEvents", "./haloConfidenceEvents.mjs")
+    .replaceAll("@/lib/ros/fusedDetectionsFeed", "./fusedDetectionsFeed.mjs"),
+  {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }
+).outputText;
+
+const modulePath = path.join(tempDir, "useHaloDetections.mjs");
+fs.writeFileSync(modulePath, compiled, "utf8");
+
+const { normalizeHaloInboundPayload } = await import(pathToFileURL(modulePath).href);
+
+test("normalizeHaloInboundPayload parses pretty-printed JSON before falling back to JSONL", () => {
+  const prettyPrintedEnvelope = JSON.stringify({
+    schema_version: 1,
+    sequence: 0,
+    run_id: "halo-demo-run",
+    mode: "replay",
+    event: {
+      event_id: "halo-confidence-001",
+    },
+  }, null, 2);
+
+  const parsed = normalizeHaloInboundPayload({ data: prettyPrintedEnvelope });
+
+  assert.deepEqual(parsed, [
+    {
+      kind: "record",
+      value: {
+        schema_version: 1,
+        sequence: 0,
+        run_id: "halo-demo-run",
+        mode: "replay",
+        event: {
+          event_id: "halo-confidence-001",
+        },
+      },
+    },
+  ]);
+});
+
+test("normalizeHaloInboundPayload falls back to JSONL only when JSON parsing fails", () => {
+  const jsonl = [
+    JSON.stringify({ schema_version: 1, sequence: 0, run_id: "halo-demo-run", mode: "replay", event: { event_id: "one" } }),
+    JSON.stringify({ schema_version: 1, sequence: 1, run_id: "halo-demo-run", mode: "replay", event: { event_id: "two" } }),
+  ].join("\n");
+
+  const parsed = normalizeHaloInboundPayload({ data: jsonl });
+
+  assert.deepEqual(parsed, [{ kind: "jsonl", value: jsonl }]);
+});
+
+test("normalizeHaloInboundPayload guards against runaway doubly-encoded string recursion", () => {
+  const doublyEncoded = JSON.stringify(
+    JSON.stringify(
+      JSON.stringify(
+        JSON.stringify({ event_id: "deep" })
+      )
+    )
+  );
+
+  assert.throws(
+    () => normalizeHaloInboundPayload({ data: doublyEncoded }),
+    /depth/i
+  );
+});

--- a/software/viewer/src/hooks/useHaloDetections.ts
+++ b/software/viewer/src/hooks/useHaloDetections.ts
@@ -29,6 +29,7 @@ const DEFAULT_OPTIONS: Required<UseHaloDetectionsOptions> = {
   maxDetections: 100,
   maxAgeMs: 10 * 60 * 1000,
 };
+const MAX_HALO_PAYLOAD_STRING_DEPTH = 3;
 
 export function useHaloDetections(
   options: UseHaloDetectionsOptions = {}
@@ -97,7 +98,10 @@ export function useHaloDetections(
   };
 }
 
-function normalizeHaloInboundPayload(rawMessage: ROSLIB.Message): Detection[] {
+export function normalizeHaloInboundPayload(
+  rawMessage: ROSLIB.Message,
+  depth = 0
+): Detection[] {
   const payload = (rawMessage as { data?: unknown }).data ?? rawMessage;
 
   if (typeof payload === 'string') {
@@ -105,10 +109,19 @@ function normalizeHaloInboundPayload(rawMessage: ROSLIB.Message): Detection[] {
     if (!trimmed) {
       return [];
     }
-    if (trimmed.includes('\n')) {
-      return normalizeHaloEvidenceReplayPayload(trimmed);
+    if (depth >= MAX_HALO_PAYLOAD_STRING_DEPTH) {
+      throw new Error('Invalid Halo payload: string nesting depth exceeded');
     }
-    return normalizeHaloInboundPayload(JSON.parse(trimmed) as ROSLIB.Message);
+    let parsed: ROSLIB.Message;
+    try {
+      parsed = JSON.parse(trimmed) as ROSLIB.Message;
+    } catch (error) {
+      if (trimmed.includes('\n')) {
+        return normalizeHaloEvidenceReplayPayload(trimmed);
+      }
+      throw error;
+    }
+    return normalizeHaloInboundPayload(parsed, depth + 1);
   }
 
   if (Array.isArray(payload)) {

--- a/software/viewer/src/hooks/useHaloDetections.ts
+++ b/software/viewer/src/hooks/useHaloDetections.ts
@@ -66,14 +66,10 @@ export function useHaloDetections(
 
       setDetectionState((previous) => {
         const currentDetections = previous.connection === ros ? previous.detections : [];
-        const nextDetections = normalizedDetections.reduce(
-          (accumulator, detection) =>
-            mergeLiveDetections(accumulator, detection, {
-              maxAgeMs: merged.maxAgeMs,
-              maxDetections: merged.maxDetections,
-            }),
-          currentDetections
-        );
+        const nextDetections = mergeHaloDetectionBatch(currentDetections, normalizedDetections, {
+          maxAgeMs: merged.maxAgeMs,
+          maxDetections: merged.maxDetections,
+        });
         return {
           connection: ros,
           detections: nextDetections,
@@ -96,6 +92,46 @@ export function useHaloDetections(
         : [],
     isConnected,
   };
+}
+
+export function mergeHaloDetectionBatch(
+  previousDetections: Detection[],
+  incomingDetections: Detection[],
+  options: { nowMs?: number; maxAgeMs?: number; maxDetections?: number } = {}
+): Detection[] {
+  const replayBatch = incomingDetections.length > 1 && incomingDetections.some(
+    (detection) => detection.deliveryMode === 'replayed' || detection.isRetroactive === true
+  );
+
+  if (!replayBatch) {
+    return incomingDetections.reduce(
+      (accumulator, detection) =>
+        mergeLiveDetections(accumulator, detection, options),
+      previousDetections
+    );
+  }
+
+  const nowMs = Number.isFinite(options.nowMs) ? Number(options.nowMs) : Date.now();
+  const maxAgeMs = Number.isFinite(options.maxAgeMs) ? Number(options.maxAgeMs) : 10 * 60 * 1000;
+  const maxDetections = Number.isFinite(options.maxDetections) ? Number(options.maxDetections) : 100;
+  const cutoff = nowMs - maxAgeMs;
+  const byId = new Map<string, Detection>();
+
+  for (const detection of previousDetections) {
+    if (detection?.id && Number(detection.timestamp) >= cutoff) {
+      byId.set(detection.id, detection);
+    }
+  }
+
+  for (const detection of incomingDetections) {
+    if (detection?.id) {
+      byId.set(detection.id, detection);
+    }
+  }
+
+  return Array.from(byId.values())
+    .sort((left, right) => Number(right.timestamp) - Number(left.timestamp))
+    .slice(0, maxDetections);
 }
 
 export function normalizeHaloInboundPayload(

--- a/software/viewer/src/hooks/useHaloDetections.ts
+++ b/software/viewer/src/hooks/useHaloDetections.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ROSLIB from 'roslib';
+import type { Detection } from '@/components/sheets/DetectionCard';
+import {
+  normalizeHaloConfidenceEventMessage,
+  normalizeHaloEvidenceLogRecord,
+  normalizeHaloEvidenceReplayPayload,
+} from '@/lib/ros/haloConfidenceEvents';
+import { mergeLiveDetections } from '@/lib/ros/fusedDetectionsFeed';
+import { useSharedROSConnection } from '@/context/ROSConnectionContext';
+
+interface UseHaloDetectionsOptions {
+  topicName?: string;
+  messageType?: string;
+  maxDetections?: number;
+  maxAgeMs?: number;
+}
+
+interface UseHaloDetectionsResult {
+  detections: Detection[];
+  isConnected: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<UseHaloDetectionsOptions> = {
+  topicName: '/halo/confidence_events',
+  messageType: 'std_msgs/String',
+  maxDetections: 100,
+  maxAgeMs: 10 * 60 * 1000,
+};
+
+export function useHaloDetections(
+  options: UseHaloDetectionsOptions = {}
+): UseHaloDetectionsResult {
+  const merged = { ...DEFAULT_OPTIONS, ...options };
+  const { ros, isConnected } = useSharedROSConnection();
+  const [detectionState, setDetectionState] = useState<{
+    connection: ROSLIB.Ros | null;
+    detections: Detection[];
+  }>({
+    connection: null,
+    detections: [],
+  });
+
+  useEffect(() => {
+    if (!ros || !isConnected) {
+      return;
+    }
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: merged.topicName,
+      messageType: merged.messageType,
+    });
+
+    const handleMessage = (rawMessage: ROSLIB.Message) => {
+      let normalizedDetections: Detection[];
+      try {
+        normalizedDetections = normalizeHaloInboundPayload(rawMessage);
+      } catch (error) {
+        console.warn('[useHaloDetections] Ignoring malformed Halo payload:', error);
+        return;
+      }
+
+      setDetectionState((previous) => {
+        const currentDetections = previous.connection === ros ? previous.detections : [];
+        const nextDetections = normalizedDetections.reduce(
+          (accumulator, detection) =>
+            mergeLiveDetections(accumulator, detection, {
+              maxAgeMs: merged.maxAgeMs,
+              maxDetections: merged.maxDetections,
+            }),
+          currentDetections
+        );
+        return {
+          connection: ros,
+          detections: nextDetections,
+        };
+      });
+    };
+
+    topic.subscribe(handleMessage);
+
+    return () => {
+      topic.unsubscribe();
+      setDetectionState({ connection: null, detections: [] });
+    };
+  }, [isConnected, merged.maxAgeMs, merged.maxDetections, merged.messageType, merged.topicName, ros]);
+
+  return {
+    detections:
+      isConnected && detectionState.connection === ros
+        ? detectionState.detections
+        : [],
+    isConnected,
+  };
+}
+
+function normalizeHaloInboundPayload(rawMessage: ROSLIB.Message): Detection[] {
+  const payload = (rawMessage as { data?: unknown }).data ?? rawMessage;
+
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (!trimmed) {
+      return [];
+    }
+    if (trimmed.includes('\n')) {
+      return normalizeHaloEvidenceReplayPayload(trimmed);
+    }
+    return normalizeHaloInboundPayload(JSON.parse(trimmed) as ROSLIB.Message);
+  }
+
+  if (Array.isArray(payload)) {
+    return normalizeHaloEvidenceReplayPayload(payload);
+  }
+
+  if (payload && typeof payload === 'object' && 'event' in payload) {
+    return [normalizeHaloEvidenceLogRecord(payload)];
+  }
+
+  return [normalizeHaloConfidenceEventMessage(payload)];
+}

--- a/software/viewer/src/lib/detectionViewState.d.ts
+++ b/software/viewer/src/lib/detectionViewState.d.ts
@@ -4,6 +4,7 @@ export interface DetectionCounts {
   thermal: number;
   acoustic: number;
   gas: number;
+  rgb: number;
   pending: number;
   confirmed: number;
 }

--- a/software/viewer/src/lib/detectionViewState.js
+++ b/software/viewer/src/lib/detectionViewState.js
@@ -46,6 +46,7 @@ export function computeDetectionCounts(detections) {
     thermal: 0,
     acoustic: 0,
     gas: 0,
+    rgb: 0,
     pending: 0,
     confirmed: 0,
   };

--- a/software/viewer/src/lib/detectionViewState.test.mjs
+++ b/software/viewer/src/lib/detectionViewState.test.mjs
@@ -29,13 +29,21 @@ test("computeDetectionCounts derives modality counters from fused source modalit
       confidence: 0.5,
       status: "reviewing",
     },
+    {
+      id: "cand-4",
+      sensorType: "rgb",
+      sourceModalities: ["rgb"],
+      confidence: 0.92,
+      status: "new",
+    },
   ]);
 
   assert.deepEqual(counts, {
     thermal: 1,
     acoustic: 2,
     gas: 1,
-    pending: 2,
+    rgb: 1,
+    pending: 3,
     confirmed: 1,
   });
 });

--- a/software/viewer/src/lib/modalities.js
+++ b/software/viewer/src/lib/modalities.js
@@ -1,4 +1,4 @@
-export const KNOWN_MODALITIES = new Set(["thermal", "acoustic", "gas"]);
+export const KNOWN_MODALITIES = new Set(["thermal", "acoustic", "gas", "rgb"]);
 
 export function normalizeModalities(rawModalities) {
   if (!Array.isArray(rawModalities)) {

--- a/software/viewer/src/lib/ros/fusedDetections.js
+++ b/software/viewer/src/lib/ros/fusedDetections.js
@@ -1,5 +1,5 @@
 import { normalizeModalities } from "../modalities.js";
-const MODALITY_PRIORITY = ["gas", "thermal", "acoustic"];
+const MODALITY_PRIORITY = ["gas", "thermal", "acoustic", "rgb"];
 
 function isFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value);

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.d.ts
@@ -45,6 +45,11 @@ export interface NormalizedHaloConfidenceDetection {
   locationHint?: string | HaloEventLocationHint;
   evidenceRef?: string;
   evidenceUri?: string;
+  evidencePath?: string;
+  deliveryMode?: "live" | "replayed";
+  originalEventTs?: number;
+  replayedAtTs?: number;
+  isRetroactive?: boolean;
   recognition: HaloRecognitionMetadata;
 }
 
@@ -52,3 +57,13 @@ export function normalizeHaloConfidenceEventMessage(
   rawMessage: unknown,
   options?: { nowMs?: number }
 ): NormalizedHaloConfidenceDetection;
+
+export function normalizeHaloEvidenceLogRecord(
+  rawRecord: unknown,
+  options?: { nowMs?: number }
+): NormalizedHaloConfidenceDetection;
+
+export function normalizeHaloEvidenceReplayPayload(
+  rawPayload: unknown,
+  options?: { nowMs?: number }
+): NormalizedHaloConfidenceDetection[];

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -329,27 +329,60 @@ function parseReplayPayloadLines(rawPayload) {
   return rawPayload
     .split(/\r?\n/u)
     .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line);
-      } catch (error) {
-        throw new Error("Malformed Halo evidence replay payload: invalid JSONL record", {
-          cause: error,
-        });
-      }
-    });
+    .filter(Boolean);
+}
+
+function warnDroppedReplayRecord(context, index, error, kind = "record") {
+  console.warn(`[haloConfidenceEvents] Dropping malformed ${context} ${kind} at index ${index}:`, error);
+}
+
+function normalizeReplayPayloadBatch(rawRecords, options, { context, initialErrors = [] }) {
+  const detections = [];
+  const errors = [...initialErrors];
+
+  rawRecords.forEach((rawRecord, index) => {
+    try {
+      detections.push(normalizeHaloEvidenceLogRecord(rawRecord, options));
+    } catch (error) {
+      errors.push(error);
+      warnDroppedReplayRecord(context, index, error);
+    }
+  });
+
+  if (detections.length === 0) {
+    if (errors.length > 0) {
+      throw new Error(`Malformed Halo evidence replay payload: no valid ${context} records`, {
+        cause: errors[0],
+      });
+    }
+    throw new Error(`Malformed Halo evidence replay payload: no valid ${context} records`);
+  }
+
+  return detections;
 }
 
 export function normalizeHaloEvidenceReplayPayload(rawPayload, options = {}) {
   if (typeof rawPayload === "string") {
-    return parseReplayPayloadLines(rawPayload).map((record) =>
-      normalizeHaloEvidenceLogRecord(record, options)
-    );
+    const rawRecords = [];
+    const parseErrors = [];
+
+    parseReplayPayloadLines(rawPayload).forEach((line, index) => {
+      try {
+        rawRecords.push(JSON.parse(line));
+      } catch (error) {
+        parseErrors.push(error);
+        warnDroppedReplayRecord("JSONL replay", index, error, "line");
+      }
+    });
+
+    return normalizeReplayPayloadBatch(rawRecords, options, {
+      context: "JSONL replay",
+      initialErrors: parseErrors,
+    });
   }
 
   if (Array.isArray(rawPayload)) {
-    return rawPayload.map((record) => normalizeHaloEvidenceLogRecord(record, options));
+    return normalizeReplayPayloadBatch(rawPayload, options, { context: "replay batch" });
   }
 
   return [normalizeHaloEvidenceLogRecord(rawPayload, options)];

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -41,6 +41,9 @@ function requireReplayPayloadRecord(rawValue) {
   return rawValue;
 }
 
+const HALO_EVIDENCE_LOG_SCHEMA_VERSION = 1;
+const SUPPORTED_HALO_EVIDENCE_LOG_MODES = new Set(["live", "replay", "evaluation"]);
+
 function parseIntegerText(rawValue, fieldName) {
   if (typeof rawValue === "boolean" || rawValue === null || rawValue === undefined) {
     throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer`);
@@ -290,20 +293,35 @@ export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
 
 export function normalizeHaloEvidenceLogRecord(rawRecord, options = {}) {
   const record = requireReplayPayloadRecord(rawRecord);
+  const schemaVersion = requireInt(record.schema_version, "schema_version", 1);
+  if (schemaVersion !== HALO_EVIDENCE_LOG_SCHEMA_VERSION) {
+    throw new Error(
+      `Invalid Halo evidence replay payload: schema_version must be ${HALO_EVIDENCE_LOG_SCHEMA_VERSION}`
+    );
+  }
+  requireInt(record.sequence, "sequence", 0);
+  requireString(record.run_id, "run_id");
+  const mode = requireString(record.mode, "mode").toLowerCase();
+  if (!SUPPORTED_HALO_EVIDENCE_LOG_MODES.has(mode)) {
+    throw new Error("Invalid Halo evidence replay payload: mode must be live, replay, or evaluation");
+  }
   const detection = normalizeHaloConfidenceEventMessage(requireObject(record.event, "event"), options);
   const recordedAtNs = record.recorded_at_ns !== undefined
     ? requireBigInt(record.recorded_at_ns, "recorded_at_ns", 0n).value
     : null;
+  const isReplay = mode === "replay";
 
   return {
     ...detection,
     evidencePath: optionalString(record.evidence_path, "evidence_path"),
     evidenceRef: optionalString(record.evidence_ref, "evidence_ref") ?? detection.evidenceRef,
     evidenceUri: optionalString(record.evidence_uri, "evidence_uri") ?? detection.evidenceUri,
-    deliveryMode: "replayed",
+    deliveryMode: isReplay ? "replayed" : "live",
     originalEventTs: detection.timestamp,
-    replayedAtTs: recordedAtNs === null ? undefined : deriveDisplayTimestampMs(recordedAtNs, options),
-    isRetroactive: true,
+    replayedAtTs: isReplay && recordedAtNs !== null
+      ? deriveDisplayTimestampMs(recordedAtNs, options)
+      : undefined,
+    isRetroactive: isReplay,
   };
 }
 

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.js
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.js
@@ -34,6 +34,13 @@ function optionalString(rawValue, fieldName) {
   return normalized === "" ? undefined : normalized;
 }
 
+function requireReplayPayloadRecord(rawValue) {
+  if (!rawValue || typeof rawValue !== "object" || Array.isArray(rawValue)) {
+    throw new Error("Invalid Halo evidence replay payload: record must be an object");
+  }
+  return rawValue;
+}
+
 function parseIntegerText(rawValue, fieldName) {
   if (typeof rawValue === "boolean" || rawValue === null || rawValue === undefined) {
     throw new Error(`Invalid Halo confidence event: ${fieldName} must be an integer`);
@@ -279,4 +286,53 @@ export function normalizeHaloConfidenceEventMessage(rawMessage, options = {}) {
     evidenceUri: optionalString(message.evidence_uri, "evidence_uri"),
     recognition,
   };
+}
+
+export function normalizeHaloEvidenceLogRecord(rawRecord, options = {}) {
+  const record = requireReplayPayloadRecord(rawRecord);
+  const detection = normalizeHaloConfidenceEventMessage(requireObject(record.event, "event"), options);
+  const recordedAtNs = record.recorded_at_ns !== undefined
+    ? requireBigInt(record.recorded_at_ns, "recorded_at_ns", 0n).value
+    : null;
+
+  return {
+    ...detection,
+    evidencePath: optionalString(record.evidence_path, "evidence_path"),
+    evidenceRef: optionalString(record.evidence_ref, "evidence_ref") ?? detection.evidenceRef,
+    evidenceUri: optionalString(record.evidence_uri, "evidence_uri") ?? detection.evidenceUri,
+    deliveryMode: "replayed",
+    originalEventTs: detection.timestamp,
+    replayedAtTs: recordedAtNs === null ? undefined : deriveDisplayTimestampMs(recordedAtNs, options),
+    isRetroactive: true,
+  };
+}
+
+function parseReplayPayloadLines(rawPayload) {
+  return rawPayload
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error("Malformed Halo evidence replay payload: invalid JSONL record", {
+          cause: error,
+        });
+      }
+    });
+}
+
+export function normalizeHaloEvidenceReplayPayload(rawPayload, options = {}) {
+  if (typeof rawPayload === "string") {
+    return parseReplayPayloadLines(rawPayload).map((record) =>
+      normalizeHaloEvidenceLogRecord(record, options)
+    );
+  }
+
+  if (Array.isArray(rawPayload)) {
+    return rawPayload.map((record) => normalizeHaloEvidenceLogRecord(record, options));
+  }
+
+  return [normalizeHaloEvidenceLogRecord(rawPayload, options)];
 }

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -386,6 +386,79 @@ test("normalizeHaloEvidenceReplayPayload parses JSONL records and record objects
   assert.equal(objectDetections[0].isRetroactive, true);
 });
 
+test("normalizeHaloEvidenceReplayPayload preserves valid detections when a JSONL batch contains malformed records", () => {
+  const mixedJsonl = [
+    JSON.stringify({
+      schema_version: 1,
+      sequence: 0,
+      run_id: "halo-demo-run",
+      mode: "replay",
+      event: {
+        event_id: "halo-confidence-001",
+        source_id: "camera:halo_front_camera",
+        source_name: "halo_front_camera",
+        frame_id: "halo_rgb_front",
+        frame_index: 21,
+        timestamp_ns: "1717200123456789000",
+        label: "Possible Survivor",
+        confidence: 0.72,
+        detection_type: "candidate_human_presence",
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    }),
+    "{not-json}",
+    JSON.stringify({
+      schema_version: 1,
+      sequence: 2,
+      run_id: "halo-demo-run",
+      mode: "replay",
+      event: {
+        event_id: "halo-confidence-003",
+        source_id: "camera:halo_side_camera",
+        source_name: "halo_side_camera",
+        frame_id: "halo_rgb_side",
+        frame_index: 23,
+        timestamp_ns: "1717200125456789000",
+        label: "Possible Survivor",
+        confidence: 0.81,
+        detection_type: "candidate_human_presence",
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    }),
+    JSON.stringify({
+      schema_version: 1,
+      sequence: 3,
+      run_id: "halo-demo-run",
+      mode: "replay",
+      event: {
+        source_id: "camera:halo_broken_camera",
+        source_name: "halo_broken_camera",
+        frame_id: "halo_rgb_broken",
+        frame_index: 24,
+        timestamp_ns: "1717200126456789000",
+        confidence: 0.5,
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    }),
+  ].join("\n");
+
+  const detections = normalizeHaloEvidenceReplayPayload(mixedJsonl);
+
+  assert.deepEqual(detections.map((detection) => detection.id), [
+    "halo-confidence-001",
+    "halo-confidence-003",
+  ]);
+});
+
 test("normalizeHaloEvidenceReplayPayload rejects malformed JSONL and malformed record payloads", () => {
   assert.throws(
     () => normalizeHaloEvidenceReplayPayload("{not-json}"),
@@ -427,7 +500,7 @@ test("normalizeHaloEvidenceReplayPayload rejects malformed JSONL and malformed r
           },
         },
     ]),
-    /detection_type or label/
+    /no valid replay batch records/i
   );
 
   assert.throws(
@@ -559,5 +632,31 @@ test("normalizeHaloEvidenceReplayPayload rejects malformed JSONL and malformed r
         },
       }),
     /recorded_at_ns/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceReplayPayload([
+        "{not-json}",
+        JSON.stringify({
+          schema_version: 1,
+          sequence: 3,
+          run_id: "halo-demo-run",
+          mode: "replay",
+          event: {
+            source_id: "camera:halo_broken_camera",
+            source_name: "halo_broken_camera",
+            frame_id: "halo_rgb_broken",
+            frame_index: 24,
+            timestamp_ns: "1717200126456789000",
+            confidence: 0.5,
+            recognition: {
+              baseline_name: "halo_rgb_region_baseline",
+              baseline_version: "0.1.0",
+            },
+          },
+        }),
+      ]),
+    /no valid/i
   );
 });

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -246,6 +246,59 @@ test("normalizeHaloEvidenceLogRecord reuses the nested event and preserves evide
   assert.equal(detection.evidenceUri, "file:///tmp/halo/capture-017.png");
 });
 
+test("normalizeHaloEvidenceLogRecord keeps live and evaluation wrapper modes distinct from replay", () => {
+  const liveDetection = normalizeHaloEvidenceLogRecord({
+    schema_version: 1,
+    sequence: 0,
+    run_id: "halo-live-run",
+    mode: "live",
+    event: {
+      event_id: "halo-confidence-live-001",
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: 21,
+      timestamp_ns: "1717200123456789000",
+      label: "Possible Survivor",
+      detection_type: "candidate_human_presence",
+      confidence: 0.72,
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    },
+  });
+  const evaluationDetection = normalizeHaloEvidenceLogRecord({
+    schema_version: 1,
+    sequence: 1,
+    run_id: "halo-eval-run",
+    mode: "evaluation",
+    recorded_at_ns: "1717200124456789000",
+    event: {
+      event_id: "halo-confidence-eval-001",
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      frame_id: "halo_rgb_front",
+      frame_index: 22,
+      timestamp_ns: "1717200123456789000",
+      label: "Possible Survivor",
+      detection_type: "candidate_human_presence",
+      confidence: 0.79,
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    },
+  });
+
+  assert.equal(liveDetection.deliveryMode, "live");
+  assert.equal(liveDetection.isRetroactive, false);
+  assert.equal(liveDetection.replayedAtTs, undefined);
+  assert.equal(evaluationDetection.deliveryMode, "live");
+  assert.equal(evaluationDetection.isRetroactive, false);
+  assert.equal(evaluationDetection.replayedAtTs, undefined);
+});
+
 test("normalizeHaloEvidenceReplayPayload parses JSONL records and record objects in order", () => {
   const jsonl = [
     JSON.stringify({
@@ -373,7 +426,138 @@ test("normalizeHaloEvidenceReplayPayload rejects malformed JSONL and malformed r
             },
           },
         },
-      ]),
+    ]),
     /detection_type or label/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 2,
+        sequence: 0,
+        run_id: "halo-demo-run",
+        mode: "replay",
+        event: {
+          event_id: "halo-confidence-001",
+          source_id: "camera:halo_front_camera",
+          source_name: "halo_front_camera",
+          frame_id: "halo_rgb_front",
+          frame_index: 1,
+          timestamp_ns: "10",
+          label: "Possible Survivor",
+          detection_type: "candidate_human_presence",
+          confidence: 0.5,
+          recognition: {
+            baseline_name: "halo_rgb_region_baseline",
+            baseline_version: "0.1.0",
+          },
+        },
+      }),
+    /schema_version/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 1,
+        sequence: -1,
+        run_id: "halo-demo-run",
+        mode: "replay",
+        event: {
+          event_id: "halo-confidence-001",
+          source_id: "camera:halo_front_camera",
+          source_name: "halo_front_camera",
+          frame_id: "halo_rgb_front",
+          frame_index: 1,
+          timestamp_ns: "10",
+          label: "Possible Survivor",
+          detection_type: "candidate_human_presence",
+          confidence: 0.5,
+          recognition: {
+            baseline_name: "halo_rgb_region_baseline",
+            baseline_version: "0.1.0",
+          },
+        },
+      }),
+    /sequence/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 1,
+        sequence: 0,
+        run_id: "",
+        mode: "replay",
+        event: {
+          event_id: "halo-confidence-001",
+          source_id: "camera:halo_front_camera",
+          source_name: "halo_front_camera",
+          frame_id: "halo_rgb_front",
+          frame_index: 1,
+          timestamp_ns: "10",
+          label: "Possible Survivor",
+          detection_type: "candidate_human_presence",
+          confidence: 0.5,
+          recognition: {
+            baseline_name: "halo_rgb_region_baseline",
+            baseline_version: "0.1.0",
+          },
+        },
+      }),
+    /run_id/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 1,
+        sequence: 0,
+        run_id: "halo-demo-run",
+        mode: "archive",
+        event: {
+          event_id: "halo-confidence-001",
+          source_id: "camera:halo_front_camera",
+          source_name: "halo_front_camera",
+          frame_id: "halo_rgb_front",
+          frame_index: 1,
+          timestamp_ns: "10",
+          label: "Possible Survivor",
+          detection_type: "candidate_human_presence",
+          confidence: 0.5,
+          recognition: {
+            baseline_name: "halo_rgb_region_baseline",
+            baseline_version: "0.1.0",
+          },
+        },
+      }),
+    /mode/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 1,
+        sequence: 0,
+        run_id: "halo-demo-run",
+        mode: "replay",
+        recorded_at_ns: "not-an-int",
+        event: {
+          event_id: "halo-confidence-001",
+          source_id: "camera:halo_front_camera",
+          source_name: "halo_front_camera",
+          frame_id: "halo_rgb_front",
+          frame_index: 1,
+          timestamp_ns: "10",
+          label: "Possible Survivor",
+          detection_type: "candidate_human_presence",
+          confidence: 0.5,
+          recognition: {
+            baseline_name: "halo_rgb_region_baseline",
+            baseline_version: "0.1.0",
+          },
+        },
+      }),
+    /recorded_at_ns/
   );
 });

--- a/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
+++ b/software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeHaloConfidenceEventMessage } from "./haloConfidenceEvents.js";
+import {
+  normalizeHaloConfidenceEventMessage,
+  normalizeHaloEvidenceLogRecord,
+  normalizeHaloEvidenceReplayPayload,
+} from "./haloConfidenceEvents.js";
 
 test("normalizeHaloConfidenceEventMessage maps the canonical event into a display-friendly model", () => {
   const event = {
@@ -198,5 +202,178 @@ test("normalizeHaloConfidenceEventMessage rejects invalid payloads", () => {
       },
     }),
     /confidence/
+  );
+});
+
+test("normalizeHaloEvidenceLogRecord reuses the nested event and preserves evidence handles", () => {
+  const detection = normalizeHaloEvidenceLogRecord({
+    schema_version: 1,
+    sequence: 4,
+    recorded_at_ns: "1717200124456789000",
+    run_id: "halo-demo-run",
+    mode: "replay",
+    evidence_path: "/tmp/halo/capture-017.png",
+    evidence_ref: "evidence-017",
+    evidence_uri: "file:///tmp/halo/capture-017.png",
+    event: {
+      event_id: "halo-confidence-001",
+      source_id: "camera:halo_front_camera",
+      source_name: "halo_front_camera",
+      source_uri: "rtsp://halo/front",
+      frame_id: "halo_rgb_front",
+      frame_index: 21,
+      timestamp_ns: "1717200123456789000",
+      label: "Possible Survivor",
+      detection_type: "candidate_human_presence",
+      confidence: 0.72,
+      confidence_level: "MEDIUM",
+      location_hint: { label: "Zone E-2", x: 12.5, y: 0.0, z: -6.0 },
+      recognition: {
+        baseline_name: "halo_rgb_region_baseline",
+        baseline_version: "0.1.0",
+      },
+    },
+  });
+
+  assert.equal(detection.id, "halo-confidence-001");
+  assert.equal(detection.sensorType, "rgb");
+  assert.equal(detection.deliveryMode, "replayed");
+  assert.equal(detection.isRetroactive, true);
+  assert.equal(detection.originalEventTs, 1_717_200_123_456);
+  assert.equal(detection.replayedAtTs, 1_717_200_124_456);
+  assert.equal(detection.evidencePath, "/tmp/halo/capture-017.png");
+  assert.equal(detection.evidenceRef, "evidence-017");
+  assert.equal(detection.evidenceUri, "file:///tmp/halo/capture-017.png");
+});
+
+test("normalizeHaloEvidenceReplayPayload parses JSONL records and record objects in order", () => {
+  const jsonl = [
+    JSON.stringify({
+      schema_version: 1,
+      sequence: 0,
+      recorded_at_ns: "1717200124456789000",
+      run_id: "halo-demo-run",
+      mode: "replay",
+      evidence_path: "/tmp/halo/capture-017.png",
+      event: {
+        event_id: "halo-confidence-001",
+        source_id: "camera:halo_front_camera",
+        source_name: "halo_front_camera",
+        frame_id: "halo_rgb_front",
+        frame_index: 21,
+        timestamp_ns: "1717200123456789000",
+        label: "Possible Survivor",
+        confidence: 0.72,
+        detection_type: "candidate_human_presence",
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    }),
+    JSON.stringify({
+      schema_version: 1,
+      sequence: 1,
+      recorded_at_ns: "1717200125456789000",
+      run_id: "halo-demo-run",
+      mode: "replay",
+      evidence_ref: "evidence-018",
+      event: {
+        event_id: "halo-confidence-002",
+        source_id: "camera:halo_rear_camera",
+        source_name: "halo_rear_camera",
+        frame_id: "halo_rgb_rear",
+        frame_index: 22,
+        timestamp_ns: "1717200124456789000",
+        label: "Debris Movement",
+        confidence: 0.64,
+        detection_type: "scene_change",
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    }),
+  ].join("\n");
+
+  const detections = normalizeHaloEvidenceReplayPayload(jsonl);
+  const objectDetections = normalizeHaloEvidenceReplayPayload([
+    {
+      schema_version: 1,
+      sequence: 2,
+      recorded_at_ns: "1717200126456789000",
+      run_id: "halo-demo-run",
+      mode: "replay",
+      event: {
+        event_id: "halo-confidence-003",
+        source_id: "camera:halo_side_camera",
+        source_name: "halo_side_camera",
+        frame_id: "halo_rgb_side",
+        frame_index: 23,
+        timestamp_ns: "1717200125456789000",
+        label: "Possible Survivor",
+        confidence: 0.81,
+        detection_type: "candidate_human_presence",
+        recognition: {
+          baseline_name: "halo_rgb_region_baseline",
+          baseline_version: "0.1.0",
+        },
+      },
+    },
+  ]);
+
+  assert.deepEqual(detections.map((detection) => detection.id), [
+    "halo-confidence-001",
+    "halo-confidence-002",
+  ]);
+  assert.equal(detections[0].deliveryMode, "replayed");
+  assert.equal(detections[0].evidencePath, "/tmp/halo/capture-017.png");
+  assert.equal(detections[1].evidenceRef, "evidence-018");
+  assert.equal(objectDetections[0].id, "halo-confidence-003");
+  assert.equal(objectDetections[0].isRetroactive, true);
+});
+
+test("normalizeHaloEvidenceReplayPayload rejects malformed JSONL and malformed record payloads", () => {
+  assert.throws(
+    () => normalizeHaloEvidenceReplayPayload("{not-json}"),
+    /Malformed Halo evidence replay payload/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceLogRecord({
+        schema_version: 1,
+        sequence: 0,
+        recorded_at_ns: "1717200124456789000",
+        run_id: "halo-demo-run",
+        mode: "replay",
+      }),
+    /event/
+  );
+
+  assert.throws(
+    () =>
+      normalizeHaloEvidenceReplayPayload([
+        {
+          schema_version: 1,
+          sequence: 0,
+          recorded_at_ns: "1717200124456789000",
+          run_id: "halo-demo-run",
+          mode: "replay",
+          event: {
+            source_id: "camera:halo_front_camera",
+            source_name: "halo_front_camera",
+            frame_id: "halo_rgb_front",
+            frame_index: 1,
+            timestamp_ns: "10",
+            confidence: 0.5,
+            recognition: {
+              baseline_name: "halo_rgb_region_baseline",
+              baseline_version: "0.1.0",
+            },
+          },
+        },
+      ]),
+    /detection_type or label/
   );
 });


### PR DESCRIPTION
## Summary
- normalize Halo confidence events and evidence-log replay records into the existing viewer detection model
- treat RGB as a first-class detection modality across detection counts, markers, and card surfaces
- surface evidence ref, URI, and path with replay and stale status in the existing GCS detection sheet
- subscribe to Halo confidence events in the viewer and keep a replay-backed local demo sample for disconnected runs

## Testing
- cd software/viewer && node --test src/lib/ros/haloConfidenceEvents.test.mjs src/lib/*.test.mjs src/components/sheets/DetectionCardSurface.test.mjs
- cd software/viewer && npm run lint
- cd software/viewer && npx tsc --noEmit

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RGB sensor detection support with dedicated visualization in maps and cards
  * Integrated halo detections feed alongside existing detection sources
  * Evidence tracking for detections with reference and URI information
  * Automatic staleness indicators for outdated detection data
  * Enhanced status display showing RGB detection counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires Halo camera confidence events and evidence-log replay records into the existing GCS detection pipeline, adding RGB as a first-class sensor modality alongside thermal, acoustic, and gas. It also introduces automatic staleness indicators for detections that have not been refreshed within a configurable window.

- **`useHaloDetections` hook** subscribes to `/halo/confidence_events`, normalizing single events, evidence log records, and JSONL replay batches into `Detection[]` via `normalizeHaloInboundPayload`; the `mergeHaloDetectionBatch` helper handles both live and replay-batch merge semantics with separate age-eviction paths.
- **RGB modality** is threaded through `KNOWN_MODALITIES`, `MODALITY_PRIORITY`, `computeDetectionCounts`, `DetectionCard`, `DetectionMarker3D`, `DetectionsCard`, and `StatusPill` with consistent fuchsia styling.
- **Staleness and evidence provenance** are computed in `page.tsx` (2-minute threshold against `routeNowMs`, refreshed every 5 s) and surfaced in `DetectionCard` alongside the existing \"Retroactive\" badge and new evidence-handle chips.

All three issues raised in previous review rounds (newline heuristic misrouting, unbounded string-decode recursion, and all-or-nothing replay batch failure) are verifiably addressed in the current code.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All three issues flagged in earlier rounds are addressed, the new replay and staleness paths are well-tested, and the changes are additive with no regressions to existing fused detection behaviour.

The Halo normalisation pipeline handles the full range of payload shapes (single event, evidence log record, JSONL batch, pretty-printed JSON, doubly-encoded string) with proper depth guards and per-record error accumulation. The merge helper correctly separates live and replay-batch paths. Staleness is computed via the existing 5-second clock tick and applied uniformly. Test coverage is thorough across happy paths and all major rejection scenarios.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| software/viewer/src/hooks/useHaloDetections.ts | New hook subscribing to the Halo ROS topic; correctly guards recursion depth, handles pretty-printed vs JSONL payloads, and provides distinct live/replay merge paths. |
| software/viewer/src/lib/ros/haloConfidenceEvents.js | Adds normalizeHaloEvidenceLogRecord and normalizeHaloEvidenceReplayPayload; per-record error accumulation prevents a single malformed record from discarding a valid batch. |
| software/viewer/src/app/page.tsx | Integrates useHaloDetections alongside fused detections, merges feeds, and computes isStale against a 2-minute threshold refreshed by the existing 5-second routeNowMs interval. |
| software/viewer/src/components/sheets/DetectionCard.tsx | Adds RGB sensor config, evidence-handle chips, stale badge, and three-way source label (Replayed / Stale / Live); both isRetroactive and isStale badges render independently and are verified by the new surface test. |
| software/viewer/src/lib/ros/haloConfidenceEvents.test.mjs | Comprehensive new tests cover record normalization, mode distinction, JSONL ordering, mixed-batch partial-success, and all rejection paths; well-aligned with the implementation. |
| software/viewer/src/components/sheets/DetectionCardSurface.test.mjs | Server-side render tests verify that evidence handles, stale badge, and replayed/stale distinction are correctly surfaced in the card markup. |
| software/viewer/src/lib/detectionViewState.js | Adds rgb: 0 to computeDetectionCounts initial state; RGB modality is now counted via the existing resolveModalities / KNOWN_MODALITIES path. |
| software/viewer/src/components/cards/DetectionsCard.tsx | Adds optional rgbCount prop (defaults to 0) and Camera badge with fuchsia styling; totalCount updated accordingly. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: salvage valid Halo replay records"](https://github.com/aeris-drones/aeris/commit/6de7cb445ac30e73cbaef4ce235e076973f56e24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34755242)</sub>

<!-- /greptile_comment -->